### PR TITLE
Fix: Export selected groups into CSV or Tab

### DIFF
--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -1219,9 +1219,9 @@ void EicWidget::addPeakPositions(PeakGroup* group) {
 
 	bool setZValue = false;
 	if (eicParameters->selectedGroup && group == eicParameters->selectedGroup) {
-		sort(group->peaks.begin(), group->peaks.end(), Peak::compIntensity);
 		setZValue = true;
 	}
+	sort(group->peaks.begin(), group->peaks.end(), Peak::compIntensity);
 
 	for (unsigned int i = 0; i < group->peaks.size(); i++) {
 		Peak& peak = group->peaks[i];

--- a/mzroll/isotopeplot.cpp
+++ b/mzroll/isotopeplot.cpp
@@ -30,13 +30,17 @@ void IsotopePlot::clear() {
             delete(child);
         }
     }
-    if(mpMouseText) {
-        _mw->customPlot->removeItem(mpMouseText);
+    if (_mw) {
+        if (_mw->customPlot) {
+            if(mpMouseText) {
+                _mw->customPlot->removeItem(mpMouseText);
+            }
+            disconnect(_mw->customPlot, SIGNAL(mouseMove(QMouseEvent*)));
+            _mw->customPlot->plotLayout()->clear();
+            _mw->customPlot->clearPlottables();
+            _mw->customPlot->replot();
+        }
     }
-    disconnect(_mw->customPlot, SIGNAL(mouseMove(QMouseEvent*)));
-    _mw->customPlot->plotLayout()->clear();
-    _mw->customPlot->clearPlottables();
-    _mw->customPlot->replot();
 }
 
 void IsotopePlot::setPeakGroup(PeakGroup* group) {

--- a/mzroll/isotopeswidget.cpp
+++ b/mzroll/isotopeswidget.cpp
@@ -164,7 +164,6 @@ void IsotopeWidget::pullIsotopes(PeakGroup* group) {
 		_mw->setStatusText(
 				tr("Unknown compound. Clipboard set to %1").arg(
 						group->tagString.c_str()));
-		return;
 	}
 
 	vector<mzSample*> vsamples = _mw->getVisibleSamples();

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -454,6 +454,9 @@ bool MainWindow::askAutosave() {
 
 
 AutoSave::AutoSave(QWidget*){
+
+	doAutosave = false;
+	askAutosave = 0;
 }
 
 
@@ -466,7 +469,8 @@ void AutoSave::saveMzRoll(){
 
     QSettings* settings = _mainwindow->getSettings();
 
-	if (_mainwindow->peaksMarked == 1){
+	if (_mainwindow->peaksMarked == 1 && askAutosave == 0){
+		askAutosave++;
 		doAutosave = _mainwindow->askAutosave();
 		if (doAutosave) saveMzRollAllTables();
 	}

--- a/mzroll/mainwindow.h
+++ b/mzroll/mainwindow.h
@@ -96,6 +96,7 @@ public:
 	AutoSave(QWidget*);
 	void setMainWindow(MainWindow*);
 	bool doAutosave;
+	int askAutosave;
 	QString fileName;
 	QString newFileName;
 	MainWindow* _mainwindow;

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -613,10 +613,14 @@ void TableDockWidget::exportGroupsToSpreadsheet() {
         //Updated when csvreports file was merged with Maven776 - Kiran
         csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
     }
-    
+
+    QList<PeakGroup*> selectedGroups = getSelectedGroups();
+
     for(int i=0; i<allgroups.size(); i++ ) {
-        PeakGroup& group = allgroups[i];
-        csvreports->addGroup(&group);
+        if (selectedGroups.contains(&allgroups[i])) {
+            PeakGroup& group = allgroups[i];
+            csvreports->addGroup(&group);
+        }
     }
     csvreports->closeFiles();
 }


### PR DESCRIPTION
Problem Statement: All the groups were exported when we click
on 'export selected groups'

Solution: get selected items from treewidget and compare the value
of each item with allgroups. If the group exist in the selected items
then that group is being exported