### PR TITLE
fix: Fast interaction crash on multithread crash

### DIFF
--- a/mzroll/isotopeswidget.cpp
+++ b/mzroll/isotopeswidget.cpp
@@ -229,6 +229,11 @@ void IsotopeWidget::setClipboard() {
 		}
 	}
 	workerThread->stop();
+
+	if (_mw->threadCompound != NULL) {
+		_mw->setCompoundFocus(_mw->threadCompound);
+		_mw->threadCompound = NULL;
+	}
 }
 
 void IsotopeWidget::updateIsotopicBarplot() {
@@ -236,6 +241,11 @@ void IsotopeWidget::updateIsotopicBarplot() {
 		_mw->getEicWidget()->updateIsotopicBarplot(isotopeParametersBarPlot->_group);
 	}
 	workerThreadBarplot->stop();
+
+	if (_mw->threadCompound != NULL) {
+		_mw->setCompoundFocus(_mw->threadCompound);
+		_mw->threadCompound = NULL;
+	}
 }
 
 void IsotopeWidget::setClipboard(QList<PeakGroup*>& groups) {

--- a/mzroll/isotopeswidget.h
+++ b/mzroll/isotopeswidget.h
@@ -22,6 +22,8 @@ Q_OBJECT
 public:
 	IsotopeWidget(MainWindow*);
 	~IsotopeWidget();
+	BackgroundPeakUpdate* workerThread;
+	BackgroundPeakUpdate* workerThreadBarplot;
 
 public Q_SLOTS:
 	void setCharge(double charge);
@@ -50,8 +52,6 @@ private:
 	  IsotopeLogic* isotopeParameters;
 	  IsotopeLogic* isotopeParametersBarPlot;
       MainWindow* _mw;
-	  BackgroundPeakUpdate* workerThread;
-	  BackgroundPeakUpdate* workerThreadBarplot;
 	  bool bookmarkflag;
 
      QString groupIsotopeMatrixExport(PeakGroup* group, bool includeSampleHeader); //TODO: Changed the structure of the function while merging isotopewidget

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -94,7 +94,7 @@ MainWindow::MainWindow(QWidget *parent) :
 	QStringList list = QApplication::libraryPaths();
 	qDebug() << "Library Path=" << list;
 #endif
-
+	threadCompound = NULL;
 	readSettings();
 
 	QString dataDir = ".";
@@ -900,6 +900,11 @@ void MainWindow::setPathwayFocus(Pathway* p) {
 void MainWindow::setCompoundFocus(Compound*c) {
 	if (c == NULL)
 		return;
+		
+	if (!(isotopeWidget->workerThread->stopped() && isotopeWidget->workerThreadBarplot->stopped())) {
+		threadCompound = c;
+		return;
+	}
 
 	int charge = 0;
 	if (samples.size() > 0 && samples[0]->getPolarity() > 0)

--- a/mzroll/mainwindow.h
+++ b/mzroll/mainwindow.h
@@ -178,6 +178,8 @@ public:
     Pillow::HttpServer*	  embededhttpserver;
 	QProgressBar *progressBar;
 
+	Compound * threadCompound;
+
 	int sampleCount() {
 		return samples.size();
 	}


### PR DESCRIPTION
- When the user interact between EIC plot and compounddb crash is
  removed by checking is the thread had finished or not
- If the thread is not finished then the action to be taken is
  stored and performed after the thread is over.