### PR TITLE
Fix: Inconsistent behaviour during isotopes detection is fixed.

### DIFF
--- a/MavenTests/testMassCalculator.cpp
+++ b/MavenTests/testMassCalculator.cpp
@@ -85,7 +85,7 @@ void TestMassCalculator::testComputeIsotopes() {
     isotopeAtom["N15Labeled_BPE"] = true;
     isotopeAtom["S34Labeled_BPE"] = true;
 
-    vector<Isotope> isotopesXanthosine = MassCalculator::computeIsotopes(XanthosineChe, +1, isotopeAtom);
+    vector<Isotope> isotopesXanthosine = MassCalculator::computeIsotopes(XanthosineChe, +1, isotopeAtom, 2);
 
     //TODO: have to add a test case here
     for(vector<Isotope>::iterator it = isotopesXanthosine.begin(); it != isotopesXanthosine.end(); ++it) {

--- a/MavenTests/testMassCalculator.cpp
+++ b/MavenTests/testMassCalculator.cpp
@@ -79,7 +79,13 @@ void TestMassCalculator::testComputeMass() {
 void TestMassCalculator::testComputeIsotopes() {
     string XanthosineChe = "C10H12N4O6";
 
-    vector<Isotope> isotopesXanthosine = MassCalculator::computeIsotopes(XanthosineChe, +1);
+    map <string, bool> isotopeAtom;
+    isotopeAtom["D2Labeled_BPE"] = true;
+    isotopeAtom["C13Labeled_BPE"] = true;
+    isotopeAtom["N15Labeled_BPE"] = true;
+    isotopeAtom["S34Labeled_BPE"] = true;
+
+    vector<Isotope> isotopesXanthosine = MassCalculator::computeIsotopes(XanthosineChe, +1, isotopeAtom);
 
     //TODO: have to add a test case here
     for(vector<Isotope>::iterator it = isotopesXanthosine.begin(); it != isotopesXanthosine.end(); ++it) {

--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -244,7 +244,7 @@ void PeakDetector::pullIsotopesBarPlot(PeakGroup* parentgroup) {
     string formula = parentgroup->compound->formula; //parent formula
     //generate isotope list for parent mass
     vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, mavenParameters->ionizationMode, 
-                                                                                mavenParameters->isotopeAtom);
+                                                    mavenParameters->isotopeAtom, mavenParameters->noOfIsotopes);
 
     //iterate over samples to find properties for parent's isotopes.
     map<string, PeakGroup> isotopes;
@@ -464,18 +464,11 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
     string formula = parentgroup->compound->formula; //parent formula
     //generate isotope list for parent mass
     vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, mavenParameters->ionizationMode, 
-                                                                            mavenParameters->isotopeAtom);
+                                                        mavenParameters->isotopeAtom, mavenParameters->noOfIsotopes);
 
     //iterate over samples to find properties for parent's isotopes.
     map<string, PeakGroup> isotopes;
     map<string, PeakGroup>::iterator itr2;
-
-    int count_C13Label = 0;
-    int count_N15Label = 0;
-    int count_S34Label = 0;
-    int count_H2Label = 0;
-    int count_C13N15Label = 0;
-    int count_C13S34Label = 0;
 
     //   #pragma omp parallel for ordered
     for (unsigned int s = 0; s < mavenParameters->samples.size(); s++) {
@@ -611,78 +604,15 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
 
             //delete (nearestPeak);
             if (nearestPeak) { //if nearest peak is present
-                if(x.C13 > 0 && x.N15 > 0 && count_C13N15Label < mavenParameters->noOfIsotopes) {
-                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
-                        PeakGroup g;
-                        g.meanMz = isotopeMass;
-                        g.tagString = isotopeName;
-                        g.expectedAbundance = expectedAbundance;
-                        g.isotopeC13count = x.C13;
-                        isotopes[isotopeName] = g;
-                    }
-                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
-                    count_C13N15Label++;
+                if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
+                    PeakGroup g;
+                    g.meanMz = isotopeMass;
+                    g.tagString = isotopeName;
+                    g.expectedAbundance = expectedAbundance;
+                    g.isotopeC13count = x.C13;
+                    isotopes[isotopeName] = g;
                 }
-                else if(x.C13 > 0 && x.S34 > 0 && count_C13S34Label < mavenParameters->noOfIsotopes) {
-                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
-                        PeakGroup g;
-                        g.meanMz = isotopeMass;
-                        g.tagString = isotopeName;
-                        g.expectedAbundance = expectedAbundance;
-                        g.isotopeC13count = x.C13;
-                        isotopes[isotopeName] = g;
-                    }
-                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
-                    count_C13S34Label++;
-                }
-                else if(x.C13 > 0 && x.N15 <=0 && x.S34 <= 0 && count_C13Label < mavenParameters->noOfIsotopes) {
-                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
-                        PeakGroup g;
-                        g.meanMz = isotopeMass;
-                        g.tagString = isotopeName;
-                        g.expectedAbundance = expectedAbundance;
-                        g.isotopeC13count = x.C13;
-                        isotopes[isotopeName] = g;
-                    }
-                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
-                    count_C13Label++;
-                }
-                else if(x.N15 > 0 && x.C13 <=0 && count_N15Label < mavenParameters->noOfIsotopes) {
-                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
-                        PeakGroup g;
-                        g.meanMz = isotopeMass;
-                        g.tagString = isotopeName;
-                        g.expectedAbundance = expectedAbundance;
-                        g.isotopeC13count = x.C13;
-                        isotopes[isotopeName] = g;
-                    }
-                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
-                    count_N15Label++;
-                }
-                else if(x.S34 > 0 && x.C13 <= 0 && count_S34Label < mavenParameters->noOfIsotopes) {
-                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
-                        PeakGroup g;
-                        g.meanMz = isotopeMass;
-                        g.tagString = isotopeName;
-                        g.expectedAbundance = expectedAbundance;
-                        g.isotopeC13count = x.C13;
-                        isotopes[isotopeName] = g;
-                    }
-                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
-                    count_S34Label++;
-                }
-                else if(x.H2 > 0 && count_H2Label < mavenParameters->noOfIsotopes) {
-                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
-                        PeakGroup g;
-                        g.meanMz = isotopeMass;
-                        g.tagString = isotopeName;
-                        g.expectedAbundance = expectedAbundance;
-                        g.isotopeC13count = x.C13;
-                        isotopes[isotopeName] = g;
-                    }
-                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
-                    count_H2Label++;
-                }
+                isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
             }
             vector<Peak>().swap(allPeaks);
         }

--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -243,8 +243,8 @@ void PeakDetector::pullIsotopesBarPlot(PeakGroup* parentgroup) {
 
     string formula = parentgroup->compound->formula; //parent formula
     //generate isotope list for parent mass
-    vector<Isotope> masslist = MassCalculator::computeIsotopes(
-            formula, mavenParameters->ionizationMode);
+    vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, mavenParameters->ionizationMode, 
+                                                                                mavenParameters->isotopeAtom);
 
     //iterate over samples to find properties for parent's isotopes.
     map<string, PeakGroup> isotopes;
@@ -463,12 +463,19 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
 
     string formula = parentgroup->compound->formula; //parent formula
     //generate isotope list for parent mass
-    vector<Isotope> masslist = MassCalculator::computeIsotopes(
-            formula, mavenParameters->ionizationMode);
+    vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, mavenParameters->ionizationMode, 
+                                                                            mavenParameters->isotopeAtom);
 
     //iterate over samples to find properties for parent's isotopes.
     map<string, PeakGroup> isotopes;
     map<string, PeakGroup>::iterator itr2;
+
+    int count_C13Label = 0;
+    int count_N15Label = 0;
+    int count_S34Label = 0;
+    int count_H2Label = 0;
+    int count_C13N15Label = 0;
+    int count_C13S34Label = 0;
 
     //   #pragma omp parallel for ordered
     for (unsigned int s = 0; s < mavenParameters->samples.size(); s++) {
@@ -604,15 +611,78 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
 
             //delete (nearestPeak);
             if (nearestPeak) { //if nearest peak is present
-                if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
-                    PeakGroup g;
-                    g.meanMz = isotopeMass;
-                    g.tagString = isotopeName;
-                    g.expectedAbundance = expectedAbundance;
-                    g.isotopeC13count = x.C13;
-                    isotopes[isotopeName] = g;
+                if(x.C13 > 0 && x.N15 > 0 && count_C13N15Label < mavenParameters->noOfIsotopes) {
+                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
+                        PeakGroup g;
+                        g.meanMz = isotopeMass;
+                        g.tagString = isotopeName;
+                        g.expectedAbundance = expectedAbundance;
+                        g.isotopeC13count = x.C13;
+                        isotopes[isotopeName] = g;
+                    }
+                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
+                    count_C13N15Label++;
                 }
-                isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
+                else if(x.C13 > 0 && x.S34 > 0 && count_C13S34Label < mavenParameters->noOfIsotopes) {
+                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
+                        PeakGroup g;
+                        g.meanMz = isotopeMass;
+                        g.tagString = isotopeName;
+                        g.expectedAbundance = expectedAbundance;
+                        g.isotopeC13count = x.C13;
+                        isotopes[isotopeName] = g;
+                    }
+                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
+                    count_C13S34Label++;
+                }
+                else if(x.C13 > 0 && x.N15 <=0 && x.S34 <= 0 && count_C13Label < mavenParameters->noOfIsotopes) {
+                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
+                        PeakGroup g;
+                        g.meanMz = isotopeMass;
+                        g.tagString = isotopeName;
+                        g.expectedAbundance = expectedAbundance;
+                        g.isotopeC13count = x.C13;
+                        isotopes[isotopeName] = g;
+                    }
+                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
+                    count_C13Label++;
+                }
+                else if(x.N15 > 0 && x.C13 <=0 && count_N15Label < mavenParameters->noOfIsotopes) {
+                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
+                        PeakGroup g;
+                        g.meanMz = isotopeMass;
+                        g.tagString = isotopeName;
+                        g.expectedAbundance = expectedAbundance;
+                        g.isotopeC13count = x.C13;
+                        isotopes[isotopeName] = g;
+                    }
+                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
+                    count_N15Label++;
+                }
+                else if(x.S34 > 0 && x.C13 <= 0 && count_S34Label < mavenParameters->noOfIsotopes) {
+                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
+                        PeakGroup g;
+                        g.meanMz = isotopeMass;
+                        g.tagString = isotopeName;
+                        g.expectedAbundance = expectedAbundance;
+                        g.isotopeC13count = x.C13;
+                        isotopes[isotopeName] = g;
+                    }
+                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
+                    count_S34Label++;
+                }
+                else if(x.H2 > 0 && count_H2Label < mavenParameters->noOfIsotopes) {
+                    if (isotopes.count(isotopeName) == 0) { //label the peak of isotope
+                        PeakGroup g;
+                        g.meanMz = isotopeMass;
+                        g.tagString = isotopeName;
+                        g.expectedAbundance = expectedAbundance;
+                        g.isotopeC13count = x.C13;
+                        isotopes[isotopeName] = g;
+                    }
+                    isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
+                    count_H2Label++;
+                }
             }
             vector<Peak>().swap(allPeaks);
         }

--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -392,12 +392,12 @@ void PeakGroup::updateQuality() {
     }
 }
 
-double PeakGroup::getExpectedMz(int charge, map<string, bool> isotopeAtom) {
+double PeakGroup::getExpectedMz(int charge, map<string, bool> isotopeAtom, int noOfIsotopes) {
 
     if (isIsotope() && childCount() == 0 && compound && !compound->formula.empty()) {
  
         float mz = 0;
-        vector<::Isotope> masslist = MassCalculator::computeIsotopes(compound->formula, charge, isotopeAtom);
+        vector<::Isotope> masslist = MassCalculator::computeIsotopes(compound->formula, charge, isotopeAtom, noOfIsotopes);
 
         for (unsigned int i = 0; i<masslist.size();i++) {
             if (masslist[i].name == tagString) {

--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -392,12 +392,12 @@ void PeakGroup::updateQuality() {
     }
 }
 
-double PeakGroup::getExpectedMz(int charge) {
+double PeakGroup::getExpectedMz(int charge, map<string, bool> isotopeAtom) {
 
     if (isIsotope() && childCount() == 0 && compound && !compound->formula.empty()) {
  
         float mz = 0;
-        vector<::Isotope> masslist = MassCalculator::computeIsotopes(compound->formula, charge);
+        vector<::Isotope> masslist = MassCalculator::computeIsotopes(compound->formula, charge, isotopeAtom);
 
         for (unsigned int i = 0; i<masslist.size();i++) {
             if (masslist[i].name == tagString) {

--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -8,6 +8,11 @@ PeakGroup::PeakGroup()  {
     groupRank=INT_MAX;
 
     maxIntensity=0;
+    maxAreaTopIntensity = 0;
+    maxAreaIntensity = 0;
+    maxHeightIntensity = 0;
+    maxAreaNotCorrectedIntensity = 0;
+    currentIntensity = 0;
     meanRt=0;
     meanMz=0;
 
@@ -62,6 +67,11 @@ void PeakGroup::copyObj(const PeakGroup& o)  {
     groupRank= o.groupRank;
 
     maxIntensity= o.maxIntensity;
+    maxAreaTopIntensity = o.maxAreaTopIntensity;
+    maxAreaIntensity = o.maxAreaIntensity;
+    maxHeightIntensity = o.maxHeightIntensity;
+    maxAreaNotCorrectedIntensity = o.maxAreaNotCorrectedIntensity;
+    currentIntensity = o.currentIntensity;
     meanRt=o.meanRt;
     meanMz=o.meanMz;
 
@@ -416,6 +426,11 @@ void PeakGroup::groupStatistics() {
     float rtSum = 0;
     float mzSum = 0;
     maxIntensity = 0;
+    maxAreaTopIntensity = 0;
+    maxAreaIntensity = 0;
+    maxHeightIntensity = 0;
+    maxAreaNotCorrectedIntensity = 0;
+    currentIntensity = 0;
     totalSampleCount =  0;
 
     blankMax =0;
@@ -450,9 +465,14 @@ void PeakGroup::groupStatistics() {
             default: max = peaks[i].peakIntensity; break;
         }
 
+        if(peaks[i].peakAreaTop > maxAreaTopIntensity) maxAreaTopIntensity = peaks[i].peakAreaTop;
+        if(peaks[i].peakAreaCorrected > maxAreaIntensity) maxAreaIntensity = peaks[i].peakAreaCorrected;
+        if(peaks[i].peakIntensity > maxHeightIntensity) maxHeightIntensity = peaks[i].peakIntensity;
+        if(peaks[i].peakArea > maxAreaNotCorrectedIntensity) maxAreaNotCorrectedIntensity = peaks[i].peakArea;
 
         if(max>maxIntensity) {
             maxIntensity = max;
+            currentIntensity = max;
             meanMz=peaks[i].baseMz;
             meanRt=peaks[i].rt;
         }

--- a/libmaven/PeakGroup.h
+++ b/libmaven/PeakGroup.h
@@ -77,6 +77,11 @@ class PeakGroup{
         bool deletedFlag;
 
         float maxIntensity;
+        float maxAreaTopIntensity;
+        float maxAreaIntensity;
+        float maxHeightIntensity;
+        float maxAreaNotCorrectedIntensity;
+        float currentIntensity;
         float meanRt;
         float meanMz;
         int totalSampleCount;

--- a/libmaven/PeakGroup.h
+++ b/libmaven/PeakGroup.h
@@ -207,7 +207,7 @@ class PeakGroup{
         Scan* getAverageFragmenationScan(float resolution);
 
         
-        double getExpectedMz(int charge, map<string,bool> isotopeAtom);
+        double getExpectedMz(int charge, map<string,bool> isotopeAtom, int noOfIsotopes);
 
         /**
          * [setParent ]

--- a/libmaven/PeakGroup.h
+++ b/libmaven/PeakGroup.h
@@ -206,7 +206,8 @@ class PeakGroup{
 
         Scan* getAverageFragmenationScan(float resolution);
 
-        double getExpectedMz(int charge);
+        
+        double getExpectedMz(int charge, map<string,bool> isotopeAtom);
 
         /**
          * [setParent ]

--- a/libmaven/csvreports.cpp
+++ b/libmaven/csvreports.cpp
@@ -160,8 +160,7 @@ vector<Isotope> CSVReports::computeIsotopes (PeakGroup* group, int ionizationMod
 
       MassCalculator *masscalc;
       string formula = group->compound->formula;
-      vector<Isotope> masslist = masscalc->computeIsotopes(formula,
-              ionizationMode);
+      vector<Isotope> masslist = masscalc->computeIsotopes(formula,ionizationMode,getMavenParameters()->isotopeAtom);
 
       return masslist;
 }

--- a/libmaven/csvreports.cpp
+++ b/libmaven/csvreports.cpp
@@ -160,7 +160,8 @@ vector<Isotope> CSVReports::computeIsotopes (PeakGroup* group, int ionizationMod
 
       MassCalculator *masscalc;
       string formula = group->compound->formula;
-      vector<Isotope> masslist = masscalc->computeIsotopes(formula,ionizationMode,getMavenParameters()->isotopeAtom);
+      vector<Isotope> masslist = masscalc->computeIsotopes(formula,ionizationMode,getMavenParameters()->isotopeAtom, 
+                                                                    getMavenParameters()->noOfIsotopes);
 
       return masslist;
 }

--- a/libmaven/isotopelogic.cpp
+++ b/libmaven/isotopelogic.cpp
@@ -41,12 +41,12 @@ float IsotopeLogic::getIsotopeIntensity(float mz, double ppm) {
 
 void IsotopeLogic::computeIsotopes(string f, double ppm,
 		double maxNaturalAbundanceErr, bool C13Labeled, bool N15Labeled, bool S34Labeled, 
-		bool D2Labeled, map<string, bool> isotopeAtom) {
+		bool D2Labeled, map<string, bool> isotopeAtom, int noOfIsotopes) {
 
 	double parentMass = MassCalculator::computeMass(f, _charge);
 	float parentPeakIntensity = getIsotopeIntensity(parentMass, ppm);
 
-	vector<Isotope> isotopes = MassCalculator::computeIsotopes(f, _charge, isotopeAtom);
+	vector<Isotope> isotopes = MassCalculator::computeIsotopes(f, _charge, isotopeAtom, noOfIsotopes);
 	for (int i = 0; i < isotopes.size(); i++) {
 		Isotope& x = isotopes[i];
 

--- a/libmaven/isotopelogic.cpp
+++ b/libmaven/isotopelogic.cpp
@@ -40,13 +40,13 @@ float IsotopeLogic::getIsotopeIntensity(float mz, double ppm) {
 }
 
 void IsotopeLogic::computeIsotopes(string f, double ppm,
-		double maxNaturalAbundanceErr, bool C13Labeled, bool N15Labeled,
-		bool S34Labeled, bool D2Labeled) {
+		double maxNaturalAbundanceErr, bool C13Labeled, bool N15Labeled, bool S34Labeled, 
+		bool D2Labeled, map<string, bool> isotopeAtom) {
 
 	double parentMass = MassCalculator::computeMass(f, _charge);
 	float parentPeakIntensity = getIsotopeIntensity(parentMass, ppm);
 
-	vector<Isotope> isotopes = MassCalculator::computeIsotopes(f, _charge);
+	vector<Isotope> isotopes = MassCalculator::computeIsotopes(f, _charge, isotopeAtom);
 	for (int i = 0; i < isotopes.size(); i++) {
 		Isotope& x = isotopes[i];
 

--- a/libmaven/isotopelogic.h
+++ b/libmaven/isotopelogic.h
@@ -12,7 +12,7 @@ class IsotopeLogic {
 public:
 	IsotopeLogic();
 	void computeIsotopes(string f, double ppm, double maxNaturalAbundanceErr, bool C13Labeled, bool N15Labeled, 
-		bool S34Labeled, bool D2Labeled, map<string, bool> isotopeAtom);
+		bool S34Labeled, bool D2Labeled, map<string, bool> isotopeAtom, int noOfIsotopes);
 	void userChangedFormula();
 
 	string _formula;

--- a/libmaven/isotopelogic.h
+++ b/libmaven/isotopelogic.h
@@ -7,13 +7,12 @@
 #include "Compound.h"
 #include "mzMassCalculator.h"
 #include "mzSample.h"
-class MainWindow;
 
 class IsotopeLogic {
 public:
 	IsotopeLogic();
-	void computeIsotopes(string f, double ppm, double maxNaturalAbundanceErr,
-			bool C13Labeled, bool N15Labeled, bool S34Labeled, bool D2Labeled);
+	void computeIsotopes(string f, double ppm, double maxNaturalAbundanceErr, bool C13Labeled, bool N15Labeled, 
+		bool S34Labeled, bool D2Labeled, map<string, bool> isotopeAtom);
 	void userChangedFormula();
 
 	string _formula;

--- a/libmaven/mavenparameters.cpp
+++ b/libmaven/mavenparameters.cpp
@@ -54,6 +54,7 @@ MavenParameters::MavenParameters() {
         maxIsotopeScanDiff = 10;
         maxNaturalAbundanceErr = 100;
         minIsotopicCorrelation = 0;
+        noOfIsotopes = 2;
 
 	C13Labeled_BPE = false;
 	N15Labeled_BPE = false;

--- a/libmaven/mavenparameters.h
+++ b/libmaven/mavenparameters.h
@@ -160,6 +160,7 @@ public:
 	double maxIsotopeScanDiff;
 	double maxNaturalAbundanceErr;
 	double minIsotopicCorrelation;
+	int noOfIsotopes;
 	bool C13Labeled_BPE;
 	bool N15Labeled_BPE;
 	bool S34Labeled_BPE;
@@ -196,6 +197,7 @@ public:
 	vector<mzSample*> samples;
 	vector<Compound*> compounds;
 	vector<mzSlice*> _slices;
+	map <string, bool> isotopeAtom;
 	bool stop;
 
 	int alignMaxItterations; //TODO: Sahil - Kiran, Added while merging mainwindow

--- a/libmaven/mzMassCalculator.cpp
+++ b/libmaven/mzMassCalculator.cpp
@@ -87,7 +87,7 @@ double MassCalculator::computeMass(string formula, int charge) {
     return adjustMass(mass, charge);
 }
 
-vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge, map<string, bool> isotopeAtom) {
+vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge, map<string, bool> isotopeAtom, int noOfIsotopes) {
     map<string, int> atoms = getComposition(formula);
     int CatomCount = atoms[C_STRING_ID];
     int NatomCount = atoms[N_STRING_ID];
@@ -100,12 +100,43 @@ vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge, map<
     vector<Isotope> isotopes;
     double parentMass = computeNeutralMass(formula);
 
+    int count1 = 0, count2 = 0;
+
     //Isotope parent(C12_PARENT_LABEL, parentMass);
     //isotopes.push_back(parent);
 
     if(isotopeAtom["ShowIsotopes"]) {
-        if(isotopeAtom["C13Labeled_BPE"]) {
+
+        if(isotopeAtom["C13Labeled_BPE"] && isotopeAtom["N15Labeled_BPE"]) {
             for (int i = 1; i <= CatomCount; i++) {
+                for (int j = 1; j <= NatomCount; j++) {
+                    string name = C13N15_LABEL + integer2string(i) + "-" + integer2string(j);
+                    double mass = parentMass + (j * N_MASS_DELTA) + (i * C_MASS_DELTA);
+                    Isotope x(name, mass, i, j, 0, 0);
+                    isotopes.push_back(x);
+                    count1++;
+                    if(count1 >= noOfIsotopes) break;
+                }
+                if(count1 >= noOfIsotopes) break;
+            }
+        }
+
+        if(isotopeAtom["C13Labeled_BPE"] && isotopeAtom["S34Labeled_BPE"]) {
+            for (int i = 1; i <= CatomCount; i++) {
+                for (int j = 1; j <= SatomCount; j++) {
+                    string name = C13S34_LABEL + integer2string(i) + "-" + integer2string(j);
+                    double mass = parentMass + (j * S_MASS_DELTA) + (i * C_MASS_DELTA);
+                    Isotope x(name, mass, i, 0, j, 0);
+                    isotopes.push_back(x);
+                    count2++;
+                    if(count2 >= noOfIsotopes) break;
+                }
+                if(count2 >= noOfIsotopes) break;
+            }
+        }
+
+        if(isotopeAtom["C13Labeled_BPE"]) {
+            for (int i = 1; i <= CatomCount && i <= noOfIsotopes; i++) {
                 Isotope x(C13_LABEL + integer2string(i),
                         parentMass + (i * C_MASS_DELTA), i, 0, 0, 0);
                 isotopes.push_back(x);
@@ -113,7 +144,7 @@ vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge, map<
         }
 
         if(isotopeAtom["N15Labeled_BPE"]) {
-            for (int i = 1; i <= NatomCount; i++) {
+            for (int i = 1; i <= NatomCount && i <= noOfIsotopes; i++) {
                 Isotope x(N15_LABEL + integer2string(i),
                         parentMass + (i * N_MASS_DELTA), 0, i, 0, 0);
                 isotopes.push_back(x);
@@ -121,7 +152,7 @@ vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge, map<
         }
 
         if(isotopeAtom["S34Labeled_BPE"]) {
-            for (int i = 1; i <= SatomCount; i++) {
+            for (int i = 1; i <= SatomCount && i <= noOfIsotopes; i++) {
                 Isotope x(S34_LABEL + integer2string(i),
                         parentMass + (i * S_MASS_DELTA), 0, 0, i, 0);
                 isotopes.push_back(x);
@@ -129,36 +160,13 @@ vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge, map<
         }
 
         if(isotopeAtom["D2Labeled_BPE"]) {
-            for (int i = 1; i <= HatomCount; i++) {
+            for (int i = 1; i <= HatomCount && i <= noOfIsotopes; i++) {
                 Isotope x(H2_LABEL + integer2string(i), parentMass + (i * D_MASS_DELTA),
                         0, 0, 0, i);
                 isotopes.push_back(x);
             }
         }
 
-        if(isotopeAtom["C13Labeled_BPE"] && isotopeAtom["N15Labeled_BPE"]) {
-            for (int i = 1; i <= CatomCount; i++) {
-                for (int j = 1; j <= NatomCount; j++) {
-                    string name =
-                        C13N15_LABEL + integer2string(i) + "-" + integer2string(j);
-                    double mass = parentMass + (j * N_MASS_DELTA) + (i * C_MASS_DELTA);
-                    Isotope x(name, mass, i, j, 0, 0);
-                    isotopes.push_back(x);
-                }
-            }
-        }
-
-        if(isotopeAtom["C13Labeled_BPE"] && isotopeAtom["S34Labeled_BPE"]) {
-            for (int i = 1; i <= CatomCount; i++) {
-                for (int j = 1; j <= SatomCount; j++) {
-                    string name =
-                        C13S34_LABEL + integer2string(i) + "-" + integer2string(j);
-                    double mass = parentMass + (j * S_MASS_DELTA) + (i * C_MASS_DELTA);
-                    Isotope x(name, mass, i, 0, j, 0);
-                    isotopes.push_back(x);
-                }
-            }
-        }
     }
 
     for (unsigned int i = 0; i < isotopes.size(); i++) {

--- a/libmaven/mzMassCalculator.cpp
+++ b/libmaven/mzMassCalculator.cpp
@@ -87,7 +87,7 @@ double MassCalculator::computeMass(string formula, int charge) {
     return adjustMass(mass, charge);
 }
 
-vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge) {
+vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge, map<string, bool> isotopeAtom) {
     map<string, int> atoms = getComposition(formula);
     int CatomCount = atoms[C_STRING_ID];
     int NatomCount = atoms[N_STRING_ID];
@@ -100,50 +100,64 @@ vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge) {
     vector<Isotope> isotopes;
     double parentMass = computeNeutralMass(formula);
 
-    Isotope parent(C12_PARENT_LABEL, parentMass);
-    isotopes.push_back(parent);
+    //Isotope parent(C12_PARENT_LABEL, parentMass);
+    //isotopes.push_back(parent);
 
-    for (int i = 1; i <= CatomCount; i++) {
-        Isotope x(C13_LABEL + integer2string(i),
-                parentMass + (i * C_MASS_DELTA), i, 0, 0, 0);
-        isotopes.push_back(x);
-    }
-
-    for (int i = 1; i <= NatomCount; i++) {
-        Isotope x(N15_LABEL + integer2string(i),
-                parentMass + (i * N_MASS_DELTA), 0, i, 0, 0);
-        isotopes.push_back(x);
-    }
-
-    for (int i = 1; i <= SatomCount; i++) {
-        Isotope x(S34_LABEL + integer2string(i),
-                parentMass + (i * S_MASS_DELTA), 0, 0, i, 0);
-        isotopes.push_back(x);
-    }
-
-    for (int i = 1; i <= HatomCount; i++) {
-        Isotope x(H2_LABEL + integer2string(i), parentMass + (i * D_MASS_DELTA),
-                0, 0, 0, i);
-        isotopes.push_back(x);
-    }
-
-    for (int i = 1; i <= CatomCount; i++) {
-        for (int j = 1; j <= NatomCount; j++) {
-            string name =
-                C13N15_LABEL + integer2string(i) + "-" + integer2string(j);
-            double mass = parentMass + (j * N_MASS_DELTA) + (i * C_MASS_DELTA);
-            Isotope x(name, mass, i, j, 0, 0);
-            isotopes.push_back(x);
+    if(isotopeAtom["ShowIsotopes"]) {
+        if(isotopeAtom["C13Labeled_BPE"]) {
+            for (int i = 1; i <= CatomCount; i++) {
+                Isotope x(C13_LABEL + integer2string(i),
+                        parentMass + (i * C_MASS_DELTA), i, 0, 0, 0);
+                isotopes.push_back(x);
+            }
         }
-    }
 
-    for (int i = 1; i <= CatomCount; i++) {
-        for (int j = 1; j <= SatomCount; j++) {
-            string name =
-                C13S34_LABEL + integer2string(i) + "-" + integer2string(j);
-            double mass = parentMass + (j * S_MASS_DELTA) + (i * C_MASS_DELTA);
-            Isotope x(name, mass, i, 0, j, 0);
-            isotopes.push_back(x);
+        if(isotopeAtom["N15Labeled_BPE"]) {
+            for (int i = 1; i <= NatomCount; i++) {
+                Isotope x(N15_LABEL + integer2string(i),
+                        parentMass + (i * N_MASS_DELTA), 0, i, 0, 0);
+                isotopes.push_back(x);
+            }
+        }
+
+        if(isotopeAtom["S34Labeled_BPE"]) {
+            for (int i = 1; i <= SatomCount; i++) {
+                Isotope x(S34_LABEL + integer2string(i),
+                        parentMass + (i * S_MASS_DELTA), 0, 0, i, 0);
+                isotopes.push_back(x);
+            }
+        }
+
+        if(isotopeAtom["D2Labeled_BPE"]) {
+            for (int i = 1; i <= HatomCount; i++) {
+                Isotope x(H2_LABEL + integer2string(i), parentMass + (i * D_MASS_DELTA),
+                        0, 0, 0, i);
+                isotopes.push_back(x);
+            }
+        }
+
+        if(isotopeAtom["C13Labeled_BPE"] && isotopeAtom["N15Labeled_BPE"]) {
+            for (int i = 1; i <= CatomCount; i++) {
+                for (int j = 1; j <= NatomCount; j++) {
+                    string name =
+                        C13N15_LABEL + integer2string(i) + "-" + integer2string(j);
+                    double mass = parentMass + (j * N_MASS_DELTA) + (i * C_MASS_DELTA);
+                    Isotope x(name, mass, i, j, 0, 0);
+                    isotopes.push_back(x);
+                }
+            }
+        }
+
+        if(isotopeAtom["C13Labeled_BPE"] && isotopeAtom["S34Labeled_BPE"]) {
+            for (int i = 1; i <= CatomCount; i++) {
+                for (int j = 1; j <= SatomCount; j++) {
+                    string name =
+                        C13S34_LABEL + integer2string(i) + "-" + integer2string(j);
+                    double mass = parentMass + (j * S_MASS_DELTA) + (i * C_MASS_DELTA);
+                    Isotope x(name, mass, i, 0, j, 0);
+                    isotopes.push_back(x);
+                }
+            }
         }
     }
 

--- a/libmaven/mzMassCalculator.h
+++ b/libmaven/mzMassCalculator.h
@@ -96,8 +96,7 @@ class MassCalculator {
         void enumerateMasses(double inputMass, double charge, double maxdiff, vector<Match*>& matches);
 
 
-        static vector<Isotope> computeIsotopes(string formula, int polarity);
-
+        static vector<Isotope> computeIsotopes(string formula, int polarity, map<string, bool> isotopeAtom);
         /**
          * [adjustMass ]
          * @method adjustMass

--- a/libmaven/mzMassCalculator.h
+++ b/libmaven/mzMassCalculator.h
@@ -96,7 +96,7 @@ class MassCalculator {
         void enumerateMasses(double inputMass, double charge, double maxdiff, vector<Match*>& matches);
 
 
-        static vector<Isotope> computeIsotopes(string formula, int polarity, map<string, bool> isotopeAtom);
+        static vector<Isotope> computeIsotopes(string formula, int polarity, map<string, bool> isotopeAtom, int noOfIsotopes);
         /**
          * [adjustMass ]
          * @method adjustMass

--- a/mzroll/background_peaks_update.cpp
+++ b/mzroll/background_peaks_update.cpp
@@ -396,6 +396,8 @@ void BackgroundPeakUpdate::getPullIsotopeSettings() {
                                 "minIsotopicCorrelation").toDouble();
                         mavenParameters->maxNaturalAbundanceErr = settings->value(
                                 "maxNaturalAbundanceErr").toDouble();
+                        mavenParameters->noOfIsotopes = settings->value(
+                                "noOfIsotopes").toInt();
 
                         mavenParameters->C13Labeled_BPE =
                                 settings->value("C13Labeled_BPE").toBool();

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -1436,8 +1436,9 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
 	if (group == NULL)
 		return;
 
-	if (group->getExpectedMz(getMainWindow()->getIonizationMode()) != -1) {
-		eicParameters->_slice.mz = group->getExpectedMz(getMainWindow()->getIonizationMode());
+	if (group->getExpectedMz(getMainWindow()->getIonizationMode(), getMainWindow()->mavenParameters->isotopeAtom) != -1) {
+		eicParameters->_slice.mz = group->getExpectedMz(getMainWindow()->getIonizationMode(),
+																getMainWindow()->mavenParameters->isotopeAtom);
 	} else {
 		eicParameters->_slice.mz = group->meanMz;
 	}
@@ -1466,8 +1467,9 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
 	if (eicParameters->_slice.rtmax > bounds.rtmax)
 		eicParameters->_slice.rtmax = bounds.rtmax;
 
-	if (group->getExpectedMz(getMainWindow()->getIonizationMode()) != -1) {
-		eicParameters->_slice.mz = group->getExpectedMz(getMainWindow()->getIonizationMode());
+	if (group->getExpectedMz(getMainWindow()->getIonizationMode(),getMainWindow()->mavenParameters->isotopeAtom) != -1) {
+		eicParameters->_slice.mz = group->getExpectedMz(getMainWindow()->getIonizationMode(),
+																	getMainWindow()->mavenParameters->isotopeAtom);
 	} else {
 		eicParameters->_slice.mz = group->meanMz;
 	}

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -365,8 +365,8 @@ void EicWidget::findPlotBounds() {
 		if (mzUtils::checkOverlap(eicParameters->peakgroups[i].minRt,
 				eicParameters->peakgroups[i].maxRt, eicParameters->_slice.rtmin,
 				eicParameters->_slice.rtmax) > 0) {
-			if (eicParameters->peakgroups[i].maxIntensity > _maxY) {
-				_maxY = eicParameters->peakgroups[i].maxIntensity;
+			if (eicParameters->peakgroups[i].maxHeightIntensity > _maxY) {
+				_maxY = eicParameters->peakgroups[i].maxHeightIntensity;
 			}
 		}
 	}

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -1436,9 +1436,10 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
 	if (group == NULL)
 		return;
 
-	if (group->getExpectedMz(getMainWindow()->getIonizationMode(), getMainWindow()->mavenParameters->isotopeAtom) != -1) {
+	if (group->getExpectedMz(getMainWindow()->getIonizationMode(), getMainWindow()->mavenParameters->isotopeAtom, 
+					getMainWindow()->mavenParameters->noOfIsotopes) != -1) {
 		eicParameters->_slice.mz = group->getExpectedMz(getMainWindow()->getIonizationMode(),
-																getMainWindow()->mavenParameters->isotopeAtom);
+					getMainWindow()->mavenParameters->isotopeAtom, getMainWindow()->mavenParameters->noOfIsotopes);
 	} else {
 		eicParameters->_slice.mz = group->meanMz;
 	}
@@ -1467,9 +1468,10 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
 	if (eicParameters->_slice.rtmax > bounds.rtmax)
 		eicParameters->_slice.rtmax = bounds.rtmax;
 
-	if (group->getExpectedMz(getMainWindow()->getIonizationMode(),getMainWindow()->mavenParameters->isotopeAtom) != -1) {
+	if (group->getExpectedMz(getMainWindow()->getIonizationMode(),getMainWindow()->mavenParameters->isotopeAtom,
+					getMainWindow()->mavenParameters->noOfIsotopes) != -1) {
 		eicParameters->_slice.mz = group->getExpectedMz(getMainWindow()->getIonizationMode(),
-																	getMainWindow()->mavenParameters->isotopeAtom);
+					getMainWindow()->mavenParameters->isotopeAtom, getMainWindow()->mavenParameters->noOfIsotopes);
 	} else {
 		eicParameters->_slice.mz = group->meanMz;
 	}

--- a/mzroll/forms/peakdetectiondialog.ui
+++ b/mzroll/forms/peakdetectiondialog.ui
@@ -645,6 +645,26 @@
                </property>
               </widget>
              </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="labelMinQuality">
+               <property name="text">
+                <string>Min. Quality</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="doubleSpinBoxMinQuality">
+               <property name="maximum">
+                <double>1.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>0.500000000000000</double>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>

--- a/mzroll/forms/settingsform.ui
+++ b/mzroll/forms/settingsform.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1028</width>
+    <width>1265</width>
     <height>232</height>
    </rect>
   </property>
@@ -23,7 +23,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>3</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="instrumentationOptions">
       <attribute name="title">
@@ -425,6 +425,13 @@
           <string>Baseline Calculation</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_6">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_20">
+            <property name="text">
+             <string>Baseline Smooting </string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="QSpinBox" name="baseline_smoothing">
             <property name="suffix">
@@ -458,33 +465,6 @@
            <widget class="QLabel" name="label_21">
             <property name="text">
              <string>Drop top x%  intensities from chromatogram</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_20">
-            <property name="text">
-             <string>Baseline Smooting </string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="labelMinQuality">
-            <property name="text">
-             <string>Min. Quality</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="doubleSpinBoxMinQuality">
-            <property name="maximum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.500000000000000</double>
             </property>
            </widget>
           </item>

--- a/mzroll/forms/settingsform.ui
+++ b/mzroll/forms/settingsform.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1265</width>
+    <width>1291</width>
     <height>232</height>
    </rect>
   </property>
@@ -615,6 +615,20 @@
            <widget class="QCheckBox" name="S34Labeled_BPE">
             <property name="text">
              <string>S34</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5">
+           <widget class="QSpinBox" name="noOfIsotopes">
+            <property name="value">
+             <number>2</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="6">
+           <widget class="QLabel" name="label_27">
+            <property name="text">
+             <string>Max. Number Of Isotopes</string>
             </property>
            </widget>
           </item>

--- a/mzroll/forms/settingsform.ui
+++ b/mzroll/forms/settingsform.ui
@@ -628,7 +628,7 @@
           <item row="0" column="6">
            <widget class="QLabel" name="label_27">
             <property name="text">
-             <string>Max. Number Of Isotopes</string>
+             <string>Number Of M+1 Isotopes</string>
             </property>
            </widget>
           </item>

--- a/mzroll/isotopeplot.cpp
+++ b/mzroll/isotopeplot.cpp
@@ -84,6 +84,14 @@ QRectF IsotopePlot::boundingRect() const
     return(QRectF(0,0,_width,_height));
 }
 
+void IsotopePlot::setBelowAbThresholdMatrixEntries(MatrixXf &MM, MainWindow* _mw) {
+    for(int i = 0; i < MM.rows(); i++) {
+        for(int j = 0; j < MM.cols(); j++) {
+            if(MM(i,j)*100 <= _mw->getSettings()->value("AbthresholdBarplot").toDouble()) MM(i,j) = 0;
+        }
+    }
+}
+
 void IsotopePlot::showBars() {
     clear();
     if (_isotopes.size() == 0 ) return;
@@ -96,6 +104,7 @@ void IsotopePlot::showBars() {
     if ( _mw ) qtype = _mw->getUserQuantType();
 
     MatrixXf MM = _mw->getIsotopicMatrix(_group);
+    setBelowAbThresholdMatrixEntries(MM,_mw);
 
     if (scene()) {
         _width =   scene()->width()*0.20;
@@ -107,10 +116,10 @@ void IsotopePlot::showBars() {
 
     labels.resize(0);
     for(int i=0; i<MM.rows(); i++ ) {		//samples
-        float sum= MM.row(i).sum();
+        //float sum= MM.row(i).sum();
         labels << QString::fromStdString(_samples[i]->sampleName.c_str());
-        if (sum == 0) continue;
-        MM.row(i) /= sum;
+        //if (sum == 0) continue;
+        //MM.row(i) /= sum;
         //ticks << i ;
     }
 

--- a/mzroll/isotopeplot.h
+++ b/mzroll/isotopeplot.h
@@ -64,6 +64,7 @@ public:
     QRectF boundingRect() const;
     void clear();
     void showBars();
+    void setBelowAbThresholdMatrixEntries(MatrixXf &MM,MainWindow* _mw);
 
 private Q_SLOTS:
     void showPointToolTip(QMouseEvent *event);

--- a/mzroll/isotopeswidget.cpp
+++ b/mzroll/isotopeswidget.cpp
@@ -139,8 +139,8 @@ void IsotopeWidget::computeIsotopes(string f) {
 	bool S34Labeled = settings->value("S34Labeled_BPE").toBool();
 	bool D2Labeled = settings->value("D2Labeled_BPE").toBool();
 
-	isotopeParameters->computeIsotopes(f, ppm, maxNaturalAbundanceErr,
-			C13Labeled, N15Labeled, S34Labeled, D2Labeled);
+	isotopeParameters->computeIsotopes(f, ppm, maxNaturalAbundanceErr, C13Labeled, N15Labeled, S34Labeled, D2Labeled,
+												 							_mw->mavenParameters->isotopeAtom);
 	showTable();
 }
 

--- a/mzroll/isotopeswidget.cpp
+++ b/mzroll/isotopeswidget.cpp
@@ -140,7 +140,7 @@ void IsotopeWidget::computeIsotopes(string f) {
 	bool D2Labeled = settings->value("D2Labeled_BPE").toBool();
 
 	isotopeParameters->computeIsotopes(f, ppm, maxNaturalAbundanceErr, C13Labeled, N15Labeled, S34Labeled, D2Labeled,
-												 							_mw->mavenParameters->isotopeAtom);
+												_mw->mavenParameters->isotopeAtom, _mw->mavenParameters->noOfIsotopes);
 	showTable();
 }
 

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -405,6 +405,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
 	createToolBars();
 	setIonizationMode(0);
+	currentIntensityName = "Max "+quantType->currentText();
 	if (settings->contains("ionizationMode")) {
 		setIonizationMode(settings->value("ionizationMode").toInt());
 	}
@@ -1994,6 +1995,7 @@ void MainWindow::refreshIntensities() {
 	for(int i=0; i<peaksTableList.size(); i++) {
 		peaksTableList[i]->showAllGroups();
 	}
+	bookmarkedPeaks->showAllGroups();
 }
 
 void MainWindow::updateQType(QString qtype) {

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -485,8 +485,8 @@ MainWindow::MainWindow(QWidget *parent) :
 	settings->setValue("closeEvent", 0);
 	setCentralWidget(eicWidgetController());
 	peakDetectionDialog->setMavenParameters(settings);
-
-				
+	
+					
     // if (unloadableFiles.size() > 0) {
 	// 	string filesNames = "Following database file(s) could not be loaded: ";
 	// 	for (std::vector<string>::iterator it = unloadableFiles.begin() ; it != unloadableFiles.end(); ++it)
@@ -1599,6 +1599,9 @@ void MainWindow::readSettings() {
 
 	if (!settings->contains("AbthresholdBarplot"))
 		settings->setValue("AbthresholdBarplot", 1);
+
+	if (!settings->contains("noOfIsotopes"))
+		settings->setValue("noOfIsotopes", 2);
 
 	if (!settings->contains("C13Labeled_BPE"))
 		settings->setValue("C13Labeled_BPE", 2);
@@ -3067,7 +3070,7 @@ void MainWindow::isotopeC13Correct(MatrixXf& MM, int numberofCarbons, map<unsign
 			vector<double> cmv = mzUtils::naturalAbundanceCorrection(
 					numberofCarbons, mv, carbonIsotopeSpecies);
 			for (int j = 0; j < mv.size(); j++) {
-				if (j <= cmv.size()) {
+				if (j < cmv.size()) {
 					MM(i, j) = cmv[j];
 				} else {
 					MM(i, j) = mv[j];

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -1913,6 +1913,7 @@ void MainWindow::createToolBars() {
 	quantType->setToolTip("Peak Quntitation Type");
 	connect(quantType, SIGNAL(activated(int)), eicWidget, SLOT(replot()));
 	connect(quantType, SIGNAL(activated(QString)), peakDetectionDialog, SLOT(updatePeakQType(QString)));
+	connect(quantType, SIGNAL(currentIndexChanged(int)), SLOT(refreshIntensities()));
 	connect(peakDetectionDialog->peakQuantitation, SIGNAL(activated(QString)), this, SLOT(updateQType(QString)));
 
 	settings->beginGroup("searchHistory");
@@ -1986,6 +1987,13 @@ void MainWindow::createToolBars() {
 
 	addToolBar(Qt::TopToolBarArea, toolBar);
 	addToolBar(Qt::RightToolBarArea, sideBar);
+}
+
+void MainWindow::refreshIntensities() {
+	QList<QPointer<TableDockWidget> > peaksTableList = getPeakTableList();
+	for(int i=0; i<peaksTableList.size(); i++) {
+		peaksTableList[i]->showAllGroups();
+	}
 }
 
 void MainWindow::updateQType(QString qtype) {

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -2929,6 +2929,15 @@ int MainWindow::versionCheck() {
 	return 0;
 }
 
+void MainWindow::normalizeIsotopicMatrix(MatrixXf &MM) {
+	for(int i = 0; i < MM.rows(); i++) {
+		float sum = 0;
+		for(int j = 0; j < MM.cols(); j++) sum += MM(i,j);
+		if(sum<=0) continue;
+		for(int j = 0; j < MM.cols(); j++) MM(i,j) /= sum;
+	}
+}
+
 MatrixXf MainWindow::getIsotopicMatrix(PeakGroup* group) {
 
 	PeakGroup::QType qtype = getUserQuantType();
@@ -2986,8 +2995,8 @@ MatrixXf MainWindow::getIsotopicMatrix(PeakGroup* group) {
 				group->compound->formula);
 		numberofCarbons = composition["C"];
 	}
-
 	isotopeC13Correct(MM, numberofCarbons, carbonIsotopeSpecies);
+	normalizeIsotopicMatrix(MM);
 	return MM;
 }
 
@@ -3067,15 +3076,16 @@ void MainWindow::isotopeC13Correct(MatrixXf& MM, int numberofCarbons, map<unsign
 			for (int j = 0; j < mv.size(); j++) {
 				mv[j] /= sum;
 			} //normalize
-			vector<double> cmv = mzUtils::naturalAbundanceCorrection(
-					numberofCarbons, mv, carbonIsotopeSpecies);
+
+			vector<double> cmv = mzUtils::naturalAbundanceCorrection(numberofCarbons, mv, carbonIsotopeSpecies);
+
 			for (int j = 0; j < mv.size(); j++) {
 				if (j < cmv.size()) {
 					MM(i, j) = cmv[j];
 				} else {
 					MM(i, j) = mv[j];
 				}
-				//cerr << mv[j] << " " << cmv[j] << endl;
+				//cerr << " Hello   " << mv[j] << "    " << cmv[j] << "   " << MM(i,j) << endl;
 			}
 		}
 	}

--- a/mzroll/mainwindow.h
+++ b/mzroll/mainwindow.h
@@ -217,6 +217,7 @@ public:
 	MatrixXf getIsotopicMatrixIsoWidget(PeakGroup* group);
 	void isotopeC13Correct(MatrixXf& MM, int numberofCarbons, map<unsigned int, string> carbonIsotopeSpecies);
 	void autoSaveSignal();
+	void normalizeIsotopicMatrix(MatrixXf &MM);
 
     mzSample* getSampleByName(QString sampleName); //TODO: Sahil, Added this while merging mzfile
 	void setIsotopicPlotStyling();

--- a/mzroll/mainwindow.h
+++ b/mzroll/mainwindow.h
@@ -132,6 +132,7 @@ public:
 	QComboBox *quantType;
 	QLabel *statusText;
 	QStringList pathlist;
+	QString currentIntensityName;
 
 	PathwayWidget *pathwayWidget;
 	SpectraWidget *spectraWidget;

--- a/mzroll/mainwindow.h
+++ b/mzroll/mainwindow.h
@@ -264,6 +264,7 @@ public Q_SLOTS:
 	void setMzValue();
 	void setMzValue(float mz);
 	void loadModel();
+	void refreshIntensities();
 	void loadCompoundsFile();
 	bool loadCompoundsFile(QString filename);
 	void loadMethodsFolder(QString& methodsFolder);

--- a/mzroll/peakdetectiondialog.cpp
+++ b/mzroll/peakdetectiondialog.cpp
@@ -219,6 +219,8 @@ void PeakDetectionDialog::inputInitialValuesPeakDetectionDialog() {
                 settings->value("baseline_smoothingWindow").toInt());
             baseline_quantile->setValue(
                 settings->value("baseline_dropTopX").toInt());
+            doubleSpinBoxMinQuality->setValue(
+                settings->value("minQuality").toDouble());
 
             // Peak Scoring and Filtering
             minGoodGroupCount->setValue(
@@ -402,7 +404,7 @@ void PeakDetectionDialog::updateQSettingsWithUserInput(QSettings* settings) {
     // BaseLine Calculation
     settings->setValue("baseline_smoothingWindow", baseline_smoothing->value());
     settings->setValue("baseline_dropTopX", baseline_quantile->value());
-
+    settings->setValue("minQuality",doubleSpinBoxMinQuality->value());
     // Peak Scoring and Filtering
     settings->setValue("minGoodGroupCount", minGoodGroupCount->value());
     settings->setValue("minNoNoiseObs", minNoNoiseObs->value());

--- a/mzroll/peakdetectiondialog.cpp
+++ b/mzroll/peakdetectiondialog.cpp
@@ -329,6 +329,7 @@ void PeakDetectionDialog::findPeaks() {
 
     updateQSettingsWithUserInput(settings);
     setMavenParameters(settings);
+    mainwindow->settingsForm->setIsotopeAtom();
 
     QString title;
     if (_featureDetectionType == FullSpectrum)
@@ -508,6 +509,8 @@ void PeakDetectionDialog::setMavenParameters(QSettings* settings) {
                 "minIsotopicCorrelation").toDouble();
         mavenParameters->maxNaturalAbundanceErr = settings->value(
                 "maxNaturalAbundanceErr").toDouble();
+        mavenParameters->noOfIsotopes = settings->value(
+                "noOfIsotopes").toInt();
 
         mavenParameters->C13Labeled_BPE =
                 settings->value("C13Labeled_BPE").toBool();
@@ -635,6 +638,7 @@ void PeakDetectionDialog::showMethodSummary() {
         methodSummary->clear();
         methodSummary->setPlainText(peakupdater->printSettings());
     }
+    mainwindow->settingsForm->setIsotopeAtom();
 }
 
 

--- a/mzroll/settingsform.cpp
+++ b/mzroll/settingsform.cpp
@@ -55,7 +55,6 @@ SettingsForm::SettingsForm(QSettings* s, MainWindow *w): QDialog(w) {
 
 
     connect(centroid_scan_flag,SIGNAL(toggled(bool)), SLOT(getFormValues()));
-    connect(doubleSpinBoxMinQuality, SIGNAL(valueChanged(double)), SLOT(getFormValues()));
     connect(scan_filter_min_quantile, SIGNAL(valueChanged(int)), SLOT(getFormValues()));
     connect(scan_filter_min_intensity, SIGNAL(valueChanged(int)), SLOT(getFormValues()));
     connect(ionizationType,SIGNAL(currentIndexChanged(int)),SLOT(getFormValues()));
@@ -123,7 +122,6 @@ void SettingsForm::updateSettingFormGUI() {
     baseline_smoothing->setValue(settings->value("baseline_smoothing").toDouble());
     baseline_quantile->setValue(settings->value("baseline_quantile").toDouble());
 
-    doubleSpinBoxMinQuality->setValue(settings->value("minQuality").toDouble());
     //Upload Multiprocessing
     checkBoxMultiprocessing->setCheckState( (Qt::CheckState) settings->value("uploadMultiprocessing").toInt() );
 
@@ -184,7 +182,6 @@ void SettingsForm::getFormValues() {
     settings->setValue("maxNaturalAbundanceErr",maxNaturalAbundanceErr->value());
     settings->setValue("maxIsotopeScanDiff",maxIsotopeScanDiff->value());
     settings->setValue("minIsotopicCorrelation",minIsotopicCorrelation->value());
-    settings->setValue("minQuality",doubleSpinBoxMinQuality->value());
     
     /*Isotopic settings for barplot*/
     settings->setValue("C13Labeled_Barplot", C13Labeled_Barplot->checkState());

--- a/mzroll/settingsform.cpp
+++ b/mzroll/settingsform.cpp
@@ -5,7 +5,7 @@ SettingsForm::SettingsForm(QSettings* s, MainWindow *w): QDialog(w) {
     settings = s;
     mainwindow = w;
     updateSettingFormGUI();
-
+    setIsotopeAtom();
 
     connect(tabWidget, SIGNAL(currentChanged(int)), SLOT(getFormValues()));
 
@@ -33,6 +33,7 @@ SettingsForm::SettingsForm(QSettings* s, MainWindow *w): QDialog(w) {
     connect(S34Labeled_Barplot,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
     connect(D2Labeled_Barplot, SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
     connect(doubleSpinBoxAbThresh, SIGNAL(valueChanged(double)),SLOT(recomputeIsotopes()));
+    connect(noOfIsotopes, SIGNAL(valueChanged(int)),SLOT(recomputeIsotopes()));
         //isotope detection setting
     connect(C13Labeled_IsoWidget,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
     connect(N15Labeled_IsoWidget,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
@@ -71,9 +72,32 @@ void SettingsForm::setSettingsIonizationMode(QString ionMode) {
     else                                    ionizationMode->setCurrentIndex(0);
 }
 
+void SettingsForm::setIsotopeAtom() {
+
+    if(!mainwindow) return;
+    mainwindow->mavenParameters->isotopeAtom.clear();
+
+    if(D2Labeled_BPE->isChecked()) mainwindow->mavenParameters->isotopeAtom["D2Labeled_BPE"] = true;
+    else mainwindow->mavenParameters->isotopeAtom["D2Labeled_BPE"] = false;
+    
+    if(C13Labeled_BPE->isChecked()) mainwindow->mavenParameters->isotopeAtom["C13Labeled_BPE"] = true;
+    else mainwindow->mavenParameters->isotopeAtom["C13Labeled_BPE"] = false;
+
+    if(N15Labeled_BPE->isChecked()) mainwindow->mavenParameters->isotopeAtom["N15Labeled_BPE"] = true;
+    else mainwindow->mavenParameters->isotopeAtom["N15Labeled_BPE"] = false;
+
+    if(S34Labeled_BPE->isChecked()) mainwindow->mavenParameters->isotopeAtom["S34Labeled_BPE"] = true;
+    else mainwindow->mavenParameters->isotopeAtom["S34Labeled_BPE"] = false;
+
+    if(mainwindow->mavenParameters->pullIsotopesFlag) mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"] = true;
+    else mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"] = false;
+    
+}
+
 void SettingsForm::recomputeIsotopes() { 
     getFormValues();
     if (!mainwindow) return;
+    setIsotopeAtom();
 
     //update isotope plot in EICview
     if (mainwindow->getEicWidget()->isVisible()) {
@@ -135,6 +159,7 @@ void SettingsForm::updateSettingFormGUI() {
     S34Labeled_Barplot->setCheckState( (Qt::CheckState) settings->value("S34Labeled_Barplot").toInt() );
     D2Labeled_Barplot->setCheckState(  (Qt::CheckState) settings->value("D2Labeled_Barplot").toInt()  );
     doubleSpinBoxAbThresh->setValue(settings->value("AbthresholdBarplot").toDouble());
+    noOfIsotopes->setValue(settings->value("noOfIsotopes").toInt());
 
     C13Labeled_IsoWidget->setCheckState( (Qt::CheckState) settings->value("C13Labeled_IsoWidget").toInt() );
     N15Labeled_IsoWidget->setCheckState( (Qt::CheckState) settings->value("N15Labeled_IsoWidget").toInt()  );
@@ -189,6 +214,7 @@ void SettingsForm::getFormValues() {
     settings->setValue("S34Labeled_Barplot", S34Labeled_Barplot->checkState());
     settings->setValue("D2Labeled_Barplot", D2Labeled_Barplot->checkState());
     settings->setValue("AbthresholdBarplot",  doubleSpinBoxAbThresh->value());
+    settings->setValue("noOfIsotopes", noOfIsotopes->value());
 
     /*Isotopic settings for bookmark, peak detection and save csv*/
     settings->setValue("C13Labeled_BPE", C13Labeled_BPE->checkState());

--- a/mzroll/settingsform.h
+++ b/mzroll/settingsform.h
@@ -12,6 +12,7 @@ class SettingsForm : public QDialog, public Ui_SettingsForm
                 Q_OBJECT
 		public:
 				 SettingsForm(QSettings* s, MainWindow *w);
+                 void setIsotopeAtom();
                 protected:
                     void closeEvent       (QCloseEvent* e) { getFormValues(); QDialog::closeEvent(e);}
                     void keyPressEvent    (QKeyEvent* e) { QDialog::keyPressEvent(e); getFormValues(); }

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -513,8 +513,10 @@ void TableDockWidget::addRow(PeakGroup* group, QTreeWidgetItem* root) {
     item->setText(1,groupTagString(group));
     item->setText(2,QString::number(group->meanMz, 'f', 4));
 
-    if (group->getExpectedMz(_mainwindow->getIonizationMode(), _mainwindow->mavenParameters->isotopeAtom) != -1) {
-        float mz = group->getExpectedMz(_mainwindow->getIonizationMode(), _mainwindow->mavenParameters->isotopeAtom);
+    if (group->getExpectedMz(_mainwindow->getIonizationMode(), _mainwindow->mavenParameters->isotopeAtom, 
+                    _mainwindow->mavenParameters->noOfIsotopes) != -1) {
+        float mz = group->getExpectedMz(_mainwindow->getIonizationMode(), _mainwindow->mavenParameters->isotopeAtom, 
+                                                            _mainwindow->mavenParameters->noOfIsotopes);
         item->setText(3,QString::number(mz,'f', 4));
     } else {
         item->setText(3, "NA");

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -513,8 +513,8 @@ void TableDockWidget::addRow(PeakGroup* group, QTreeWidgetItem* root) {
     item->setText(1,groupTagString(group));
     item->setText(2,QString::number(group->meanMz, 'f', 4));
 
-    if (group->getExpectedMz(_mainwindow->getIonizationMode()) != -1) {
-        float mz = group->getExpectedMz(_mainwindow->getIonizationMode());
+    if (group->getExpectedMz(_mainwindow->getIonizationMode(), _mainwindow->mavenParameters->isotopeAtom) != -1) {
+        float mz = group->getExpectedMz(_mainwindow->getIonizationMode(), _mainwindow->mavenParameters->isotopeAtom);
         item->setText(3,QString::number(mz,'f', 4));
     } else {
         item->setText(3, "NA");

--- a/mzroll/tabledockwidget.h
+++ b/mzroll/tabledockwidget.h
@@ -47,6 +47,8 @@ public:
     void writeGroupMzEICJson(PeakGroup& grp,ofstream& myfile, vector<string> vsampleNames);
     void saveMzEICJson(string filename);
     void setTableId();
+    void setIntensityColName();
+    float extractMaxIntensity(PeakGroup* group);
     string sanitizeJSONstring(string s);
     float outputRtWindow = 2.0;
 

--- a/peakdetector/PeakDetectorCLI.cpp
+++ b/peakdetector/PeakDetectorCLI.cpp
@@ -52,6 +52,7 @@ bool C13Labeled_BPE =false;
 bool N15Labeled_BPE =false;
 bool S34Labeled_BPE =false;
 bool D2Labeled_BPE =false;
+int noOfIsotopes = 2;
 string csvFileFieldSeparator=",";
 PeakGroup::QType quantitationType = PeakGroup::AreaTop;
 
@@ -784,7 +785,8 @@ void writeCSVReport( string filename) {
             writeGroupInfoCSV( &group->children[0],groupReport); //C12 info
 
             string formula = group->compound->formula;
-            vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, mavenParameters->ionizationMode);
+            vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, mavenParameters->ionizationMode, 
+												             							mavenParameters->isotopeAtom);
             for( int i=0; i<masslist.size(); i++ ) {
             Isotope& x = masslist[i];
             string isotopeName = x.name;

--- a/peakdetector/PeakDetectorCLI.cpp
+++ b/peakdetector/PeakDetectorCLI.cpp
@@ -786,7 +786,7 @@ void writeCSVReport( string filename) {
 
             string formula = group->compound->formula;
             vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, mavenParameters->ionizationMode, 
-												             							mavenParameters->isotopeAtom);
+												            mavenParameters->isotopeAtom, mavenParameters->noOfIsotopes);
             for( int i=0; i<masslist.size(); i++ ) {
             Isotope& x = masslist[i];
             string isotopeName = x.name;


### PR DESCRIPTION
   - During bookmarking peaks groups, isotopes are computed whether
     report isotopic peaks is enabled or not.

   - Isotopes computed in peaktable and bookmark table also takes
     account which isotopic atoms are to be included in isotopes.
     These elements can be set or unset in options dialog.

   - A new quantity is added to limit the maximum number of isotopes
     to be present for a group in options dialog. These value ensures
     maximum number of isotopes for each isotopic atom in a group.