### PR TITLE
Fix: Change of data type of weightage of group rank parameters.

### DIFF
--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -908,8 +908,6 @@ void PeakDetector::processSlices(vector<mzSlice*>&slices, string setName) {
                         double B = (double) mavenParameters->intensityWeight/10;
                         double C = (double) mavenParameters->deltaRTWeight/10;
 
-                        cerr << "  A: " << A << "     B: " << B << "     C: " << C << endl;
-
                         if (mavenParameters->matchRtFlag && compound != NULL && compound->expectedRt > 0) {
                             group.groupRank = pow(rtDiff, 2*C) * pow((1.1 - group.maxQuality), A)
                                                   * (1 /( pow(log(group.maxIntensity + 1), B))); //TODO Formula to rank groups

--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -647,13 +647,20 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
             child.expectedRtDiff = rtDiff;
         }
 
+        double A = (double) mavenParameters->qualityWeight/10;
+        double B = (double) mavenParameters->intensityWeight/10;
+        double C = (double) mavenParameters->deltaRTWeight/10;
+
         if (mavenParameters->matchRtFlag && child.compound != NULL && child.compound->expectedRt > 0)
         {
-            child.groupRank = rtDiff * rtDiff * (1.1 - child.maxQuality) * (1 / log(child.maxIntensity + 1));
+            child.groupRank = pow(rtDiff, 2*C) * pow((1.1 - child.maxQuality), A)
+                                                  * (1 /( pow(log(child.maxIntensity + 1), B)));
         }
         else
         {
-            child.groupRank = (1.1 - child.maxQuality) * (1 / log(child.maxIntensity + 1));
+            child.groupRank = pow((1.1 - child.maxQuality), A)
+                                                  * (1 /(pow(log(child.maxIntensity + 1), B)));
+
         }
 
 
@@ -897,9 +904,11 @@ void PeakDetector::processSlices(vector<mzSlice*>&slices, string setName) {
                         }
 
                         // Peak Group Rank accoording to given weightage
-                        double A = mavenParameters->qualityWeight/10;
-                        double B = mavenParameters->intensityWeight/10;
-                        double C = mavenParameters->deltaRTWeight/10;
+                        double A = (double) mavenParameters->qualityWeight/10;
+                        double B = (double) mavenParameters->intensityWeight/10;
+                        double C = (double) mavenParameters->deltaRTWeight/10;
+
+                        cerr << "  A: " << A << "     B: " << B << "     C: " << C << endl;
 
                         if (mavenParameters->matchRtFlag && compound != NULL && compound->expectedRt > 0) {
                             group.groupRank = pow(rtDiff, 2*C) * pow((1.1 - group.maxQuality), A)

--- a/mzroll/forms/peakdetectiondialog.ui
+++ b/mzroll/forms/peakdetectiondialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabwidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="featureSelectionTab">
       <attribute name="title">
@@ -901,12 +901,6 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
          </layout>
-         <zorder>label_26</zorder>
-         <zorder>deltaRTWeight</zorder>
-         <zorder>qualityWeight</zorder>
-         <zorder>intensityWeight</zorder>
-         <zorder>label_24</zorder>
-         <zorder>label_25</zorder>
          <zorder>deltaRTWeight</zorder>
          <zorder>label_26</zorder>
          <zorder>qualityWeightStatus</zorder>

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -1176,13 +1176,19 @@ PeakGroup* MainWindow::bookmarkPeakGroup(PeakGroup* group) {
 			group->expectedRtDiff = rtDiff;
 		}
 
+		double A = (double) mavenParameters->qualityWeight/10;
+        double B = (double) mavenParameters->intensityWeight/10;
+        double C = (double) mavenParameters->deltaRTWeight/10;
+
         if (mavenParameters->matchRtFlag && group->compound != NULL && group->compound->expectedRt > 0)
         {
-            group->groupRank = rtDiff * rtDiff * (1.1 - group->maxQuality) * (1 / log(group->maxIntensity + 1));
+            group->groupRank = pow(rtDiff, 2*C) * pow((1.1 - group->maxQuality), A)
+                                                  * (1 /( pow(log(group->maxIntensity + 1), B)));
         }
         else
         {
-            group->groupRank = (1.1 - group->maxQuality) * (1 / log(group->maxIntensity + 1));
+            group->groupRank = pow((1.1 - group->maxQuality), A)
+                                                  * (1 /(pow(log(group->maxIntensity + 1), B)));
         }
 
         bookmarkedGroup = bookmarkedPeaks->addPeakGroup(group);


### PR DESCRIPTION
   - All the weightage values are changed into decimal value
     instead of integer value.

   - Change of group rank for isotopes and groups present in
     bookmark table.