### PR TITLE
Ftr: Overlapping of barplot and highlighted peaks is removed.

### DIFF
--- a/mzroll/barplot.cpp
+++ b/mzroll/barplot.cpp
@@ -57,14 +57,6 @@ void BarPlot::setPeakGroup(PeakGroup* group) {
 
     if (vsamples.size() <=0 ) return;
 
-    if (scene()) {
-        _width =   scene()->width()*0.20;
-        _barwidth = scene()->height()*0.75/vsamples.size();
-        if (_barwidth<3)  _barwidth=3;
-        if (_barwidth>15) _barwidth=15;
-        _height = _yvalues.size()*_barwidth;
-    }
-
     for(int i=0; i < vsamples.size(); i++ ) {
         mzSample* sample = vsamples[i];
         QColor color = QColor::fromRgbF(sample->color[0], sample->color[1],sample->color[2],sample->color[3]);
@@ -77,6 +69,14 @@ void BarPlot::setPeakGroup(PeakGroup* group) {
         _yvalues.push_back(yvalues[i]);
     }
 
+    if (scene()) {
+        _width =   scene()->width()*0.20;
+        _barwidth = scene()->height()*0.75/vsamples.size();
+        if (_barwidth<3)  _barwidth=3;
+        if (_barwidth>15) _barwidth=15;
+        _height = _yvalues.size()*_barwidth;
+    }
+
 }
 
 void BarPlot::wheelEvent ( QGraphicsSceneWheelEvent * event ) {
@@ -86,6 +86,17 @@ void BarPlot::wheelEvent ( QGraphicsSceneWheelEvent * event ) {
     if (scale < 0.1) scale=0.1;
     if (scale > 2 ) scale=2;
     this->setScale(scale);
+}
+
+int BarPlot::intensityTextShift() {
+
+    QFont font("Helvetica");
+    float fontsize = _barwidth*0.8;
+    if  (fontsize < 1 ) fontsize=1;
+    font.setPointSizeF(fontsize);
+    QFontMetrics fm( font );
+    return fm.size(0,"100e+10",0,NULL).width();   
+
 }
 
 void BarPlot::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *)
@@ -111,7 +122,7 @@ void BarPlot::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget
     font.setPointSizeF(fontsize);
     painter->setFont(font);
     QFontMetrics fm( font );
-    int lagendShift = fm.size(0,"100e+10",0,NULL).width();
+    int lagendShift = fm.size(0,"100e+10",0,NULL).width();   
 
     QColor color = QColor::fromRgbF(0.2,0.2,0.2,1.0);
     QBrush brush(color);

--- a/mzroll/barplot.h
+++ b/mzroll/barplot.h
@@ -32,6 +32,7 @@ public:
         void showSampleNames(bool flag) { _showSampleNames=flag; }
         void showIntensityText(bool flag)   { _showIntensityText=flag; }
         void showQValueType(bool flag) { _showQValueType=flag; }
+        int intensityTextShift();
 
 protected:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -1055,6 +1055,45 @@ void EicWidget::addAxes() {
 	return;
 }
 
+void EicWidget::setBarplotPosition(PeakGroup* group) {
+
+	if(!group || !_barplot) return;
+	vector<mzSample*> samples = getMainWindow()->getVisibleSamples();
+	if(samples.size()==0) return;
+
+	int bwidth = _barplot->boundingRect().width();
+	int bheight = _barplot->boundingRect().height();
+	int legendShift = _barplot->intensityTextShift();
+
+	int xpos_right = scene()->width() * 0.95 - bwidth;
+	int xpos_left = scene()->width() * 0.10;
+	int ypos = scene()->height() * 0.10;
+
+	int count_right = 0, count_left = 0;
+
+	for(int i = 0; i < group->peaks.size(); i++) {
+		Peak& peak = group->peaks[i];
+		int x = toX(peak.rt);
+		int y = toY(peak.peakIntensity);
+		if(x >= xpos_right-legendShift-5 && x <= xpos_right+bwidth+5 && y <= ypos+bheight) count_right++;
+		if(x >= xpos_left-legendShift-5 && x <= xpos_left+bwidth+5 && y <= ypos+bheight) count_left++;
+	}
+
+	if(count_right == 0) {
+		_barplot->setPos(xpos_right, ypos);
+		return;
+	}
+
+	if(count_left == 0) {
+		_barplot->setPos(xpos_left, ypos);
+		return;
+	}
+
+	if(count_right <= count_left) _barplot->setPos(xpos_right, ypos);
+	else _barplot->setPos(xpos_left, ypos);
+
+}
+
 void EicWidget::addBarPlot(PeakGroup* group) {
 	//qDebug <<" EicWidget::addBarPlot(PeakGroup* group )";
 	if (group == NULL)
@@ -1067,11 +1106,12 @@ void EicWidget::addBarPlot(PeakGroup* group) {
 	_barplot->setMainWindow(getMainWindow());
 	_barplot->setPeakGroup(group);
 
-	int bwidth = _barplot->boundingRect().width();
-	int bheight = _barplot->boundingRect().height();
-	int xpos = scene()->width() * 0.95 - bwidth;
-	int ypos = scene()->height() * 0.10;
-	_barplot->setPos(xpos, ypos);
+	// int bwidth = _barplot->boundingRect().width();
+	// int bheight = _barplot->boundingRect().height();
+	// int xpos = scene()->width() * 0.95 - bwidth;
+	// int ypos = scene()->height() * 0.10;
+	// _barplot->setPos(xpos, ypos);
+	setBarplotPosition(group);
 	_barplot->setZValue(1000);
 
 	float medianRt = group->medianRt();

--- a/mzroll/eicwidget.h
+++ b/mzroll/eicwidget.h
@@ -36,6 +36,7 @@ public:
 	}
 	QString eicToTextBuffer(); //TODO: Sahil Added while merging eicwidget
 	void addPeakPositions();
+	void setBarplotPosition(PeakGroup* group);
 	
 public Q_SLOTS:
 	void setMzSlice(float mz);


### PR DESCRIPTION
   - If barplot and highlighted peaks overlaps then position of
     barplot will be changed. Suppose, if both ovelaps in right
     side and then barplot will go to left side.

   - If both overlaps in both sides then barplot will remain on
     that side where overlapping peaks will be less.