### PR TITLE
Fix: Crash when same group is referenced in two tables

### DIFF
--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -621,7 +621,7 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
     //fill peak group list with the compound and it's isotopes.
     // peak group list would be filled with the parent group, with its isotopes as children
     // click on + to see children == isotopes
-    parentgroup->children.clear();
+    // parentgroup->children.clear();
     for (itr2 = isotopes.begin(); itr2 != isotopes.end(); ++itr2) {
         string isotopeName = (*itr2).first;
         PeakGroup& child = (*itr2).second;
@@ -691,10 +691,18 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
             if (isotopeName.find(H2_LABEL) != string::npos)
                 continue;
         }
-        parentgroup->addChild(child);
+
+        bool childExist = false;
+        for (unsigned int ii = 0; ii < parentgroup->children.size(); ii++) {
+            if (parentgroup->children[ii].tagString == isotopeName) {
+                childExist = true;
+            }
+        }
+
+        if (!childExist) parentgroup->addChild(child);
     }
 
-    parentgroup->childrenIsoWidget.clear();
+    // parentgroup->childrenIsoWidget.clear();
     for (itr2 = isotopes.begin(); itr2 != isotopes.end(); ++itr2) {
         string isotopeName = (*itr2).first;
         PeakGroup& child = (*itr2).second;
@@ -739,7 +747,16 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
             if (isotopeName.find(H2_LABEL) != string::npos)
                 continue;
         }
-        parentgroup->addChildIsoWidget(child);
+
+        bool childExist = false;
+        for (unsigned int ii = 0; ii < parentgroup->childrenIsoWidget.size(); ii++) {
+            if (parentgroup->childrenIsoWidget[ii].tagString == isotopeName) {
+                childExist = true;
+            }
+        }
+
+        if (!childExist) parentgroup->addChildIsoWidget(child);
+
     }
 }
 

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -891,7 +891,7 @@ void TableDockWidget::writeGroupMzEICJson(PeakGroup& grp,ofstream& myfile, vecto
                 myfile << ",\n" << "\"groupOverlapFrac\": " << peak.groupOverlapFrac ;
                 myfile << ",\n" << "\"gaussFitR2\": " << peak.gaussFitR2 ;
                 myfile << ",\n" << "\"peakRank\": " << peak.peakRank ;
-
+                myfile << ",\n" << "\"peakWidth\": " << peak.width ;
                 //EIC* eic = peak.getEIC(); //need to see if this is sufficient or if we need to change rt window
                 //this doesn't work -- peak.getEIC need not return a valid pointer neessarily, the EICs get cleared
 


### PR DESCRIPTION
Problem Statement: Bookmarking group from Automatic peak
detection table and then going back to isotope of the same
group (in automatic peaks table) leads to crash.

Solution: Not to clear group's children when pulling isotopes.
- Remove duplicates from isotopes vector