### PR TITLE
Ftr: Option of quantile % filtering for intensity and quality is added.

### DIFF
--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -881,6 +881,7 @@ void PeakDetector::processSlices(vector<mzSlice*>&slices, string setName) {
                         PeakGroup& group = peakgroups[j];
                         group.setQuantitationType((PeakGroup::QType) mavenParameters->peakQuantitation);
                         group.minQuality = mavenParameters->minQuality;
+                        group.minIntensity = mavenParameters->minGroupIntensity;
                         group.computeAvgBlankArea(eics);
                         group.groupStatistics();
                         groupCount++;
@@ -906,6 +907,13 @@ void PeakDetector::processSlices(vector<mzSlice*>&slices, string setName) {
                             < mavenParameters->minSignalBaseLineRatio)
                                 continue;
                         if (group.maxIntensity < mavenParameters->minGroupIntensity)
+                                continue;
+                    
+                        int noVisibleSamples = mavenParameters->getVisibleSamples().size();
+
+                        if ((group.quantileIntensityPeaks/noVisibleSamples)*100 < mavenParameters->quantileIntensity) 
+                                continue;
+                        if ((group.quantileQualityPeaks/noVisibleSamples)*100 < mavenParameters->quantileQuality) 
                                 continue;
 
                         if (compound)

--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -34,6 +34,10 @@ PeakGroup::PeakGroup()  {
     maxPeakOverlap=0;
     maxQuality=0;
     minQuality = 0.2;
+    minIntensity = 0;
+
+    quantileIntensityPeaks = 0;
+    quantileQualityPeaks = 0;
 
     expectedRtDiff=-1;
     expectedAbundance=0;
@@ -66,6 +70,8 @@ void PeakGroup::copyObj(const PeakGroup& o)  {
     metaGroupId= o.metaGroupId;
     groupRank= o.groupRank;
 
+    minQuality = o.minQuality;
+    minIntensity = o.minIntensity;
     maxIntensity= o.maxIntensity;
     maxAreaTopIntensity = o.maxAreaTopIntensity;
     maxAreaIntensity = o.maxAreaIntensity;
@@ -78,6 +84,9 @@ void PeakGroup::copyObj(const PeakGroup& o)  {
     blankMax=o.blankMax;
     blankSampleCount=o.blankSampleCount;
     blankMean=o.blankMean;
+
+    quantileIntensityPeaks = o.quantileIntensityPeaks;
+    quantileQualityPeaks = o.quantileQualityPeaks;
 
     sampleMax=o.sampleMax;
     sampleCount=o.sampleCount;
@@ -450,6 +459,8 @@ void PeakGroup::groupStatistics() {
     maxQuality=0;
     goodPeakCount=0;
     maxSignalBaselineRatio=0;
+    quantileIntensityPeaks;
+    quantileQualityPeaks;
     int nonZeroCount=0;
 
     for(unsigned int i=0; i< peaks.size(); i++) {
@@ -469,6 +480,9 @@ void PeakGroup::groupStatistics() {
         if(peaks[i].peakAreaCorrected > maxAreaIntensity) maxAreaIntensity = peaks[i].peakAreaCorrected;
         if(peaks[i].peakIntensity > maxHeightIntensity) maxHeightIntensity = peaks[i].peakIntensity;
         if(peaks[i].peakArea > maxAreaNotCorrectedIntensity) maxAreaNotCorrectedIntensity = peaks[i].peakArea;
+
+        if(max > minIntensity) quantileIntensityPeaks++;
+        if(peaks[i].quality > minQuality) quantileQualityPeaks++;  
 
         if(max>maxIntensity) {
             maxIntensity = max;

--- a/libmaven/PeakGroup.h
+++ b/libmaven/PeakGroup.h
@@ -90,6 +90,11 @@ class PeakGroup{
         float expectedAbundance;
         int   isotopeC13count;
 
+        double minIntensity;
+
+        int quantileIntensityPeaks;
+        int quantileQualityPeaks;
+
         float minRt;
         float maxRt;
         float minMz;

--- a/libmaven/mavenparameters.cpp
+++ b/libmaven/mavenparameters.cpp
@@ -79,7 +79,20 @@ MavenParameters::MavenParameters() {
         alignMaxItterations = 10;  //TODO: Sahil - Kiran, Added while merging mainwindow
         alignPolynomialDegree = 5; //TODO: Sahil - Kiran, Added while merging mainwindow
         
+        quantileQuality = 0.0;
+        quantileIntensity = 0.0;
 
+}
+
+vector<mzSample*> MavenParameters::getVisibleSamples() {
+
+	vector<mzSample*> vsamples;
+	for (int i = 0; i < samples.size(); i++) {
+		if (samples[i] && samples[i]->isSelected) {
+			vsamples.push_back(samples[i]);
+		}
+	}
+	return vsamples;
 }
 
 void MavenParameters::setAverageScanTime() {

--- a/libmaven/mavenparameters.h
+++ b/libmaven/mavenparameters.h
@@ -87,6 +87,7 @@ public:
 	 * @method cleanup
 	 */
 	void cleanup();
+	vector<mzSample*> getVisibleSamples();
 
 	bool writeCSVFlag;
 	bool alignSamplesFlag;
@@ -102,6 +103,10 @@ public:
 	 */
 	int ionizationMode;
 	int charge;
+
+	// For quantile intensity and qualityWeight
+	double quantileQuality;
+	double quantileIntensity;
 
 	//mass slicing parameters
 	float mzBinStep;

--- a/mzroll/forms/peakdetectiondialog.ui
+++ b/mzroll/forms/peakdetectiondialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>876</width>
-    <height>660</height>
+    <height>726</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -426,35 +426,52 @@
           <string>Peak Scoring and Filtering</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Peak Classifier Model File</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Min. Peak Intensity</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Min. Signal/BaseLine Ratio</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="label_12">
             <property name="text">
              <string>Min. Peak Width</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_100">
+            <property name="text">
+             <string>Min. Good Peak / Group</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="3">
+           <widget class="QPushButton" name="loadModelButton">
+            <property name="text">
+             <string>Load Model</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QComboBox" name="peakQuantitation">
+            <item>
+             <property name="text">
+              <string>AreaTop</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Area</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Height</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>AreaNotCorrected</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="4" column="1">
            <widget class="QSpinBox" name="minNoNoiseObs">
             <property name="suffix">
              <string> scans</string>
@@ -470,7 +487,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
+          <item row="7" column="1">
            <widget class="QSpinBox" name="minGoodGroupCount">
             <property name="suffix">
              <string> peaks</string>
@@ -483,21 +500,28 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="3">
-           <widget class="QPushButton" name="loadModelButton">
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_5">
             <property name="text">
-             <string>Load Model</string>
+             <string>Peak Classifier Model File</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Min. Peak Intensity</string>
             </property>
            </widget>
           </item>
           <item row="6" column="0">
-           <widget class="QLabel" name="label_100">
+           <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Min. Good Peak / Group</string>
+             <string>Min. Signal/BaseLine Ratio</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QDoubleSpinBox" name="sigBlankRatio">
             <property name="maximum">
              <double>10000000.000000000000000</double>
@@ -507,7 +531,24 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="8" column="1">
+           <widget class="QLineEdit" name="classificationModelFilename">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QSpinBox" name="sigBaselineRatio">
+            <property name="maximum">
+             <number>10000000</number>
+            </property>
+            <property name="value">
+             <number>2</number>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
            <widget class="QLabel" name="label_9">
             <property name="text">
              <string>Min. Signal/Blank Ratio</string>
@@ -536,45 +577,18 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
-           <widget class="QSpinBox" name="sigBaselineRatio">
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="quantileIntensity">
             <property name="maximum">
-             <number>10000000</number>
-            </property>
-            <property name="value">
-             <number>2</number>
+             <double>100.000000000000000</double>
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
-           <widget class="QLineEdit" name="classificationModelFilename">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_27">
             <property name="text">
-             <string/>
+             <string>% Peaks Atleast Above Threshold Intensity   </string>
             </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QComboBox" name="peakQuantitation">
-            <item>
-             <property name="text">
-              <string>AreaTop</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Area</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Height</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>AreaNotCorrected</string>
-             </property>
-            </item>
            </widget>
           </item>
          </layout>
@@ -593,85 +607,6 @@
            <widget class="QLabel" name="label_36">
             <property name="text">
              <string>EIC Smoothing Algorithm</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QGroupBox" name="groupBox">
-            <property name="title">
-             <string>Baseline Calculation</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_6">
-             <item row="0" column="1">
-              <widget class="QSpinBox" name="baseline_quantile">
-               <property name="suffix">
-                <string> %</string>
-               </property>
-               <property name="prefix">
-                <string/>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-               <property name="value">
-                <number>80</number>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_15">
-               <property name="text">
-                <string>Drop top x%  intensities from chromatogram</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_8">
-               <property name="text">
-                <string>Baseline Smoothing </string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QSpinBox" name="baseline_smoothing">
-               <property name="suffix">
-                <string> scans</string>
-               </property>
-               <property name="maximum">
-                <number>1000000</number>
-               </property>
-               <property name="value">
-                <number>5</number>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="labelMinQuality">
-               <property name="text">
-                <string>Min. Quality</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QDoubleSpinBox" name="doubleSpinBoxMinQuality">
-               <property name="maximum">
-                <double>1.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>0.500000000000000</double>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_14">
-            <property name="text">
-             <string>Peak Grouping (Max Group Rt Difference)</string>
             </property>
            </widget>
           </item>
@@ -698,6 +633,32 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="text">
+             <string>Peak Grouping (Max Group Rt Difference)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="eic_smoothingAlgorithm">
+            <item>
+             <property name="text">
+              <string>Savitzky-Golay</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Gaussian</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Moving Average</string>
+             </property>
+            </item>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="QSpinBox" name="eic_smoothingWindow">
             <property name="suffix">
@@ -720,23 +681,90 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="eic_smoothingAlgorithm">
-            <item>
-             <property name="text">
-              <string>Savitzky-Golay</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Gaussian</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Moving Average</string>
-             </property>
-            </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QGroupBox" name="groupBox">
+            <property name="title">
+             <string>Baseline Calculation</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_6">
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_8">
+               <property name="text">
+                <string>Baseline Smoothing </string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QSpinBox" name="baseline_quantile">
+               <property name="suffix">
+                <string> %</string>
+               </property>
+               <property name="prefix">
+                <string/>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+               <property name="value">
+                <number>80</number>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="labelMinQuality">
+               <property name="text">
+                <string>Min. Quality</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="doubleSpinBoxMinQuality">
+               <property name="maximum">
+                <double>1.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>0.500000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_15">
+               <property name="text">
+                <string>Drop top x%  intensities from chromatogram</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="baseline_smoothing">
+               <property name="suffix">
+                <string> scans</string>
+               </property>
+               <property name="maximum">
+                <number>1000000</number>
+               </property>
+               <property name="value">
+                <number>5</number>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_28">
+               <property name="text">
+                <string>% Peaks Atleast Above Threshold Quality</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QDoubleSpinBox" name="quantileQuality">
+               <property name="maximum">
+                <double>100.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/mzroll/forms/peakdetectiondialog.ui
+++ b/mzroll/forms/peakdetectiondialog.ui
@@ -426,24 +426,69 @@
           <string>Peak Scoring and Filtering</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_12">
+          <item row="6" column="1">
+           <widget class="QSpinBox" name="minNoNoiseObs">
+            <property name="suffix">
+             <string> scans</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>1000000000</number>
+            </property>
+            <property name="value">
+             <number>3</number>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Min. Peak Width</string>
+             <string>Min. Signal/BaseLine Ratio</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="3">
+           <widget class="QPushButton" name="loadModelButton">
+            <property name="text">
+             <string>Load Model</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="minGroupIntensity">
+            <property name="maximumSize">
+             <size>
+              <width>502</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="suffix">
+             <string/>
+            </property>
+            <property name="maximum">
+             <double>999999999.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>1000000.000000000000000</double>
+            </property>
+            <property name="showGroupSeparator" stdset="0">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1">
+           <widget class="QLineEdit" name="classificationModelFilename">
+            <property name="text">
+             <string/>
             </property>
            </widget>
           </item>
           <item row="7" column="0">
-           <widget class="QLabel" name="label_100">
+           <widget class="QLabel" name="label_9">
             <property name="text">
-             <string>Min. Good Peak / Group</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="3">
-           <widget class="QPushButton" name="loadModelButton">
-            <property name="text">
-             <string>Load Model</string>
+             <string>Min. Signal/Blank Ratio</string>
             </property>
            </widget>
           </item>
@@ -471,23 +516,28 @@
             </item>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QSpinBox" name="minNoNoiseObs">
-            <property name="suffix">
-             <string> scans</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>1000000000</number>
-            </property>
-            <property name="value">
-             <number>3</number>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_27">
+            <property name="text">
+             <string>Atleast x% Peaks above Min. Peak Intensity   </string>
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
+          <item row="9" column="0">
+           <widget class="QLabel" name="label_100">
+            <property name="text">
+             <string>Min. Good Peak / Group</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Min. Peak Intensity</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
            <widget class="QSpinBox" name="minGoodGroupCount">
             <property name="suffix">
              <string> peaks</string>
@@ -500,45 +550,14 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
+          <item row="10" column="0">
            <widget class="QLabel" name="label_5">
             <property name="text">
              <string>Peak Classifier Model File</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Min. Peak Intensity</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Min. Signal/BaseLine Ratio</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="sigBlankRatio">
-            <property name="maximum">
-             <double>10000000.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>2.000000000000000</double>
-            </property>
-           </widget>
-          </item>
           <item row="8" column="1">
-           <widget class="QLineEdit" name="classificationModelFilename">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
            <widget class="QSpinBox" name="sigBaselineRatio">
             <property name="maximum">
              <number>10000000</number>
@@ -548,32 +567,20 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_9">
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_12">
             <property name="text">
-             <string>Min. Signal/Blank Ratio</string>
+             <string>Min. Peak Width</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="minGroupIntensity">
-            <property name="maximumSize">
-             <size>
-              <width>502</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="suffix">
-             <string/>
-            </property>
+          <item row="7" column="1">
+           <widget class="QDoubleSpinBox" name="sigBlankRatio">
             <property name="maximum">
-             <double>999999999.000000000000000</double>
+             <double>10000000.000000000000000</double>
             </property>
             <property name="value">
-             <double>1000000.000000000000000</double>
-            </property>
-            <property name="showGroupSeparator" stdset="0">
-             <bool>true</bool>
+             <double>2.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -584,10 +591,37 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_27">
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_28">
             <property name="text">
-             <string>% Peaks Atleast Above Threshold Intensity   </string>
+             <string>Atleast x% Peaks above Min. Peak Quality</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QDoubleSpinBox" name="quantileQuality">
+            <property name="maximum">
+             <double>100.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelMinQuality">
+            <property name="text">
+             <string>Min. Quality</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="doubleSpinBoxMinQuality">
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.500000000000000</double>
             </property>
            </widget>
           </item>
@@ -710,26 +744,6 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="labelMinQuality">
-               <property name="text">
-                <string>Min. Quality</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QDoubleSpinBox" name="doubleSpinBoxMinQuality">
-               <property name="maximum">
-                <double>1.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>0.500000000000000</double>
-               </property>
-              </widget>
-             </item>
              <item row="0" column="0">
               <widget class="QLabel" name="label_15">
                <property name="text">
@@ -747,20 +761,6 @@
                </property>
                <property name="value">
                 <number>5</number>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="label_28">
-               <property name="text">
-                <string>% Peaks Atleast Above Threshold Quality</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1">
-              <widget class="QDoubleSpinBox" name="quantileQuality">
-               <property name="maximum">
-                <double>100.000000000000000</double>
                </property>
               </widget>
              </item>

--- a/mzroll/isotopeswidget.cpp
+++ b/mzroll/isotopeswidget.cpp
@@ -179,7 +179,6 @@ void IsotopeWidget::pullIsotopes(PeakGroup* group) {
 		// } else {
 		// 	mavenParameters->setIonizationMode();
 		// }
-		cerr << "<<<<hello<<<<" << mavenParameters->ionizationMode << "<<<<bye<<<<" << endl;
 		workerThread->start();
 		_mw->setStatusText("IsotopeWidget:: pullIsotopes(() started");
 	}
@@ -209,7 +208,6 @@ void IsotopeWidget::pullIsotopesForBarplot(PeakGroup* group) {
 		// } else {
 		// 	mavenParameters->setIonizationMode();
 		// }
-		cerr << "<<<<hello1<<<<" << mavenParameters->ionizationMode << "<<<<bye1<<<<" << endl;
 		workerThreadBarplot->start();
 		_mw->setStatusText("IsotopeWidget:: pullIsotopes(() started");
 	}

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -1812,6 +1812,12 @@ void MainWindow::readSettings() {
     if (!settings->contains("baseline_dropTopX"))
         settings->setValue("baseline_dropTopX", 80);
 
+	if (!settings->contains("minQuality"))
+        settings->setValue("minQuality", 0.50);
+
+	if (!settings->contains("quantileQuality"))
+        settings->setValue("quantileQuality", 0.0);
+
     // Peak Scoring and Fitering
     if (!settings->contains("minGoodGroupCount"))
         settings->setValue("minGoodGroupCount", 1);
@@ -1828,8 +1834,8 @@ void MainWindow::readSettings() {
     if (!settings->contains("minGroupIntensity"))
         settings->setValue("minGroupIntensity", 5000);
 	
-	if (!settings->contains("minQuality"))
-        settings->setValue("minQuality", 0.50);
+	if (!settings->contains("quantileIntensity"))
+        settings->setValue("quantileIntensity", 0.0);
 
 	// Peak Group Rank
 	if (!settings->contains("qualityWeight"))

--- a/mzroll/peakdetectiondialog.cpp
+++ b/mzroll/peakdetectiondialog.cpp
@@ -282,6 +282,8 @@ void PeakDetectionDialog::inputInitialValuesPeakDetectionDialog() {
                 settings->value("baseline_dropTopX").toInt());
             doubleSpinBoxMinQuality->setValue(
                 settings->value("minQuality").toDouble());
+            quantileQuality->setValue(
+                settings->value("quantileQuality").toDouble());
 
             // Peak Scoring and Filtering
             minGoodGroupCount->setValue(
@@ -295,7 +297,9 @@ void PeakDetectionDialog::inputInitialValuesPeakDetectionDialog() {
             minGroupIntensity->setValue(
                 settings->value("minGroupIntensity").toDouble());
             peakQuantitation->setCurrentIndex(
-            settings->value("peakQuantitation").toInt());
+                settings->value("peakQuantitation").toInt());
+            quantileIntensity->setValue(
+                settings->value("quantileIntensity").toDouble());
 
             // Peak Group Rank
             qualityWeight->setValue(
@@ -478,6 +482,7 @@ void PeakDetectionDialog::updateQSettingsWithUserInput(QSettings* settings) {
     settings->setValue("baseline_smoothingWindow", baseline_smoothing->value());
     settings->setValue("baseline_dropTopX", baseline_quantile->value());
     settings->setValue("minQuality",doubleSpinBoxMinQuality->value());
+    settings->setValue("quantileQuality", quantileQuality->value());
     // Peak Scoring and Filtering
     settings->setValue("minGoodGroupCount", minGoodGroupCount->value());
     settings->setValue("minNoNoiseObs", minNoNoiseObs->value());
@@ -485,6 +490,7 @@ void PeakDetectionDialog::updateQSettingsWithUserInput(QSettings* settings) {
     settings->setValue("minSignalBlankRatio", sigBlankRatio->value());
     settings->setValue("minGroupIntensity", minGroupIntensity->value());
     settings->setValue("peakQuantitation", peakQuantitation->currentIndex());
+    settings->setValue("quantileIntensity", quantileIntensity->value());
     // Peak Group Rank
     settings->setValue("qualityWeight", qualityWeight->value());
     settings->setValue("intensityWeight", intensityWeight->value());
@@ -547,6 +553,7 @@ void PeakDetectionDialog::setMavenParameters(QSettings* settings) {
         mavenParameters->baseline_smoothingWindow = settings->value("baseline_smoothingWindow").toInt();
         mavenParameters->baseline_dropTopX = settings->value("baseline_dropTopX").toInt();
         mavenParameters->minQuality = settings->value("minQuality").toDouble();
+        mavenParameters->quantileQuality = settings->value("quantileQuality").toDouble();
 
         // Peak Scoring and Filtering
         mavenParameters->minGoodGroupCount = settings->value("minGoodGroupCount").toInt();
@@ -555,6 +562,7 @@ void PeakDetectionDialog::setMavenParameters(QSettings* settings) {
         mavenParameters->minSignalBlankRatio = settings->value("minSignalBlankRatio").toDouble();
         mavenParameters->minGroupIntensity = settings->value("minGroupIntensity").toDouble();
         mavenParameters->peakQuantitation = settings->value("peakQuantitation").toInt();
+        mavenParameters->quantileIntensity = settings->value("quantileIntensity").toDouble();
 
         // Peak Group Rank
         mavenParameters->qualityWeight = settings->value("qualityWeight").toInt();


### PR DESCRIPTION
   - An extra option for filtering in intensity nad quality in peak
     detection is added.

   - This option states that there should be atleast x% of peaks
     whose intensity is greater than threshold intensity for every
     group, otherwise that group will not be addded in peak table.

   - Same feature is available for quality also.