### PR TITLE
Fix: Compute isotopes while bookmarking group if report isotpes is en…

### DIFF
--- a/mzroll/peakdetectiondialog.cpp
+++ b/mzroll/peakdetectiondialog.cpp
@@ -26,6 +26,7 @@ PeakDetectionDialog::PeakDetectionDialog(QWidget *parent) :
         connect(qualityWeight,SIGNAL(valueChanged(int)), this,SLOT(showQualityWeightStatus(int)));
         connect(intensityWeight,SIGNAL(valueChanged(int)), this,SLOT(showIntensityWeightStatus(int)));
         connect(deltaRTWeight,SIGNAL(valueChanged(int)), this,SLOT(showDeltaRTWeightStatus(int)));
+        connect(reportIsotopesOptions, SIGNAL(clicked(bool)), SLOT(setShowIsotopes()));
 
         label_20->setVisible(false);
         chargeMin->setVisible(false);
@@ -39,6 +40,13 @@ PeakDetectionDialog::PeakDetectionDialog(QWidget *parent) :
         reportIsotopesOptions->setEnabled(true); //TODO: Sahil - Kiran, Added while merging mainwindow
         //_featureDetectionType = CompoundDB; //TODO: Sahil - Kiran, removed while merging mainwindow
         connect(changeIsotopeOptions,SIGNAL(clicked()),this, SLOT(showSettingsForm()));
+
+}
+
+void PeakDetectionDialog::setShowIsotopes() {
+
+    if(reportIsotopesOptions->isChecked()) mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"] = true;
+    else mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"] = false;
 
 }
 

--- a/mzroll/peakdetectiondialog.h
+++ b/mzroll/peakdetectiondialog.h
@@ -49,6 +49,7 @@ class PeakDetectionDialog : public QDialog, public Ui_PeakDetectionDialog
 				 void setGroupRank();
 				 void setInitialGroupRank();
 				 void setDeltaRTWeightVisible(bool value);
+				 void setShowIsotopes();
 
 		private:
 				QSettings *settings;

--- a/mzroll/settingsform.cpp
+++ b/mzroll/settingsform.cpp
@@ -75,6 +75,8 @@ void SettingsForm::setSettingsIonizationMode(QString ionMode) {
 void SettingsForm::setIsotopeAtom() {
 
     if(!mainwindow) return;
+
+    bool temp = mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"];
     mainwindow->mavenParameters->isotopeAtom.clear();
 
     if(D2Labeled_BPE->isChecked()) mainwindow->mavenParameters->isotopeAtom["D2Labeled_BPE"] = true;
@@ -89,8 +91,7 @@ void SettingsForm::setIsotopeAtom() {
     if(S34Labeled_BPE->isChecked()) mainwindow->mavenParameters->isotopeAtom["S34Labeled_BPE"] = true;
     else mainwindow->mavenParameters->isotopeAtom["S34Labeled_BPE"] = false;
 
-    if(mainwindow->mavenParameters->pullIsotopesFlag) mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"] = true;
-    else mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"] = false;
+    mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"] = temp;
     
 }
 


### PR DESCRIPTION
…abled.

   - Isotopes will be computed if someone bookmark the group and report
     isotopic peaks option is enabled in peak detecion dialog.

   - Earlier this happened when someone enable that option and then
     click find peaks or swith the tabs and close the dialog and do
     bookmarking.