### PR TITLE
Fix: A option for adding isotopes in bookmark & barplot in options.

### DIFF
--- a/libmaven/mzMassCalculator.cpp
+++ b/libmaven/mzMassCalculator.cpp
@@ -105,7 +105,15 @@ vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge, map<
     Isotope parent(C12_PARENT_LABEL, parentMass);
     isotopes.push_back(parent);
 
-    if(isotopeAtom["ShowIsotopes"]) {
+    bool b;
+
+    if(isotopeAtom["IsotopeWidget"]) {
+        b = isotopeAtom["showBookmarkIsotopes"];
+        isotopeAtom["showBookmarkIsotopes"] = false;
+    }
+    else b = isotopeAtom["showIsotopes"];
+
+    if(b) {
 
         if(isotopeAtom["C13Labeled_BPE"] && isotopeAtom["N15Labeled_BPE"]) {
             for (int i = 1; i <= CatomCount; i++) {

--- a/libmaven/mzMassCalculator.cpp
+++ b/libmaven/mzMassCalculator.cpp
@@ -102,16 +102,21 @@ vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge, map<
 
     int count1 = 0, count2 = 0;
 
-    Isotope parent(C12_PARENT_LABEL, parentMass);
-    isotopes.push_back(parent);
-
     bool b;
 
     if(isotopeAtom["IsotopeWidget"]) {
         b = isotopeAtom["showBookmarkIsotopes"];
-        isotopeAtom["showBookmarkIsotopes"] = false;
+        if(b) {
+            Isotope parent(C12_PARENT_LABEL, parentMass);
+            isotopes.push_back(parent);
+        }
+        isotopeAtom["IsotopeWidget"] = false;
     }
-    else b = isotopeAtom["showIsotopes"];
+    else {
+        b = isotopeAtom["ShowIsotopes"];
+        Isotope parent(C12_PARENT_LABEL, parentMass);
+        isotopes.push_back(parent);
+    }
 
     if(b) {
 

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -186,6 +186,7 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
 	eicParameters->_integratedGroup.groupStatistics();
 	//setSelectedGroup (&eicParameters->_integratedGroup);
 	//getMainWindow()->isotopeWidget->integrationFlag = true;
+	getMainWindow()->mavenParameters->isotopeAtom["IsotopeWidget"] = true;
 	getMainWindow()->isotopeWidget->updateIsotopicBarplot(&eicParameters->_integratedGroup);
 	getMainWindow()->isotopeWidget->setPeakGroupAndMore(&eicParameters->_integratedGroup, true);
 }

--- a/mzroll/forms/settingsform.ui
+++ b/mzroll/forms/settingsform.ui
@@ -487,14 +487,14 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QCheckBox" name="D2Labeled_IsoWidget">
             <property name="text">
              <string>D2</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="5">
+          <item row="2" column="5">
            <widget class="QDoubleSpinBox" name="doubleSpinBoxAbThresh">
             <property name="decimals">
              <number>1</number>
@@ -510,77 +510,77 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="3">
+          <item row="1" column="3">
            <widget class="QCheckBox" name="N15Labeled_BPE">
             <property name="text">
              <string>N15</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="4">
+          <item row="2" column="4">
            <widget class="QCheckBox" name="S34Labeled_Barplot">
             <property name="text">
              <string>S34</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="label_Barplot">
             <property name="text">
              <string>Isotopic barplot </string>
             </property>
            </widget>
           </item>
-          <item row="2" column="4">
+          <item row="3" column="4">
            <widget class="QCheckBox" name="S34Labeled_IsoWidget">
             <property name="text">
              <string>S34</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
+          <item row="2" column="2">
            <widget class="QCheckBox" name="C13Labeled_Barplot">
             <property name="text">
              <string>C13</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QCheckBox" name="D2Labeled_Barplot">
             <property name="text">
              <string>D2</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="label_IsoWidget">
             <property name="text">
              <string>Isotopic widget</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="3">
+          <item row="2" column="3">
            <widget class="QCheckBox" name="N15Labeled_Barplot">
             <property name="text">
              <string>N15</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
+          <item row="3" column="2">
            <widget class="QCheckBox" name="C13Labeled_IsoWidget">
             <property name="text">
              <string>C13</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
+          <item row="1" column="0">
            <widget class="QLabel" name="label_BPE">
             <property name="text">
              <string>Bookmark, peakdetection &amp; file export</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="1" column="1">
            <widget class="QCheckBox" name="D2Labeled_BPE">
             <property name="enabled">
              <bool>true</bool>
@@ -590,35 +590,21 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="6">
+          <item row="2" column="6">
            <widget class="QLabel" name="label_26">
             <property name="text">
              <string>Abundance Threshold</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
+          <item row="1" column="2">
            <widget class="QCheckBox" name="C13Labeled_BPE">
             <property name="text">
              <string>C13</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="3">
-           <widget class="QCheckBox" name="N15Labeled_IsoWidget">
-            <property name="text">
-             <string>N15</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <widget class="QCheckBox" name="S34Labeled_BPE">
-            <property name="text">
-             <string>S34</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="5">
+          <item row="1" column="5">
            <widget class="QSpinBox" name="noOfIsotopes">
             <property name="maximum">
              <number>100</number>
@@ -628,10 +614,31 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="6">
+          <item row="3" column="3">
+           <widget class="QCheckBox" name="N15Labeled_IsoWidget">
+            <property name="text">
+             <string>N15</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <widget class="QCheckBox" name="S34Labeled_BPE">
+            <property name="text">
+             <string>S34</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="6">
            <widget class="QLabel" name="label_27">
             <property name="text">
              <string>Number Of M+n Isotopes</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="3">
+           <widget class="QCheckBox" name="showBookmarkIsotopes">
+            <property name="text">
+             <string>Show Isotopes in BookMark Table &amp;&amp; Barplot</string>
             </property>
            </widget>
           </item>

--- a/mzroll/isotopeswidget.cpp
+++ b/mzroll/isotopeswidget.cpp
@@ -50,8 +50,10 @@ void IsotopeWidget::setPeakGroupAndMore(PeakGroup* grp, bool bookmarkflg) {
 		return;
 	bookmarkflag = bookmarkflg;
 	isotopeParameters->_group = grp;
-	if (grp && grp->type() != PeakGroup::Isotope)
+	if (grp && grp->type() != PeakGroup::Isotope) {
+		_mw->mavenParameters->isotopeAtom["IsotopeWidget"] = true;
 		pullIsotopes(grp);
+	}
 }
 
 void IsotopeWidget::updateIsotopicBarplot(PeakGroup* grp) {

--- a/mzroll/isotopeswidget.cpp
+++ b/mzroll/isotopeswidget.cpp
@@ -50,10 +50,8 @@ void IsotopeWidget::setPeakGroupAndMore(PeakGroup* grp, bool bookmarkflg) {
 		return;
 	bookmarkflag = bookmarkflg;
 	isotopeParameters->_group = grp;
-	if (grp && grp->type() != PeakGroup::Isotope) {
-		_mw->mavenParameters->isotopeAtom["IsotopeWidget"] = true;
+	if (grp && grp->type() != PeakGroup::Isotope) 
 		pullIsotopes(grp);
-	}
 }
 
 void IsotopeWidget::updateIsotopicBarplot(PeakGroup* grp) {

--- a/mzroll/point.cpp
+++ b/mzroll/point.cpp
@@ -62,7 +62,6 @@ void EicPoint::hoverEnterEvent (QGraphicsSceneHoverEvent*) {
                             "<br> <b>area: </b>" + 		  QString::number(_peak->peakAreaCorrected) +
                             "<br> <b>rt: </b>" +   QString::number(_peak->rt, 'f', 2 ) +
                             "<br> <b>scan#: </b>" +   QString::number(_peak->scan ) + 
-                            "<br> <b>sample number: </b>" +   QString::number(_peak->getScan()->sampleNumber) + 
                             "<br> <b>m/z: </b>" + QString::number(_peak->peakMz, 'f', 6 )
 							);
 
@@ -88,7 +87,6 @@ void EicPoint::hoverEnterEvent (QGraphicsSceneHoverEvent*) {
 		setToolTip( "<b>  Sample: </b>"   + QString( _scan->sample->sampleName.c_str() ) +
 					"<br> <b>FilterLine: </b>" + 		  QString(_scan->filterLine.c_str() ) + 
 					"<br> <b>Scan#: </b>" +   QString::number(_scan->scannum) +
-                    "<br> <b>sample number: </b>" +   QString::number(_scan->sampleNumber) + 
 					"<br> <b>PrecursorMz: </b>" +   QString::number(_scan->precursorMz, 'f', 2 )
 		);
 	}
@@ -123,6 +121,7 @@ void EicPoint::mouseDoubleClickEvent(QGraphicsSceneMouseEvent*) {
 
     if ( _group && _group->isIsotope() == false ) {
         //_mw->isotopeWidget->updateIsotopicBarplot(_group);
+        _mw->mavenParameters->isotopeAtom["IsotopeWidget"] = true;
         _mw->isotopeWidget->setPeakGroupAndMore(_group, true);
     }
 

--- a/mzroll/settingsform.cpp
+++ b/mzroll/settingsform.cpp
@@ -40,6 +40,8 @@ SettingsForm::SettingsForm(QSettings* s, MainWindow *w): QDialog(w) {
     connect(S34Labeled_IsoWidget,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
     connect(D2Labeled_IsoWidget, SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
 
+    connect(showBookmarkIsotopes, SIGNAL(toggled(bool)),SLOT(showSetIsotopeAtom()));
+
     connect(isotopeC13Correction, SIGNAL(toggled(bool)), SLOT(recomputeIsotopes()));
 
     connect(maxNaturalAbundanceErr, SIGNAL(valueChanged(double)), SLOT(recomputeIsotopes()));
@@ -72,9 +74,15 @@ void SettingsForm::setSettingsIonizationMode(QString ionMode) {
     else                                    ionizationMode->setCurrentIndex(0);
 }
 
+void SettingsForm::showSetIsotopeAtom() {
+    setIsotopeAtom();
+    cerr << mainwindow->mavenParameters->isotopeAtom["IsotopeWidget"] << " hello \n\n";
+}
+
 void SettingsForm::setIsotopeAtom() {
 
     if(!mainwindow) return;
+    bool b = mainwindow->mavenParameters->isotopeAtom["IsotopeWidget"];
     mainwindow->mavenParameters->isotopeAtom.clear();
 
     if(D2Labeled_BPE->isChecked()) mainwindow->mavenParameters->isotopeAtom["D2Labeled_BPE"] = true;
@@ -89,8 +97,13 @@ void SettingsForm::setIsotopeAtom() {
     if(S34Labeled_BPE->isChecked()) mainwindow->mavenParameters->isotopeAtom["S34Labeled_BPE"] = true;
     else mainwindow->mavenParameters->isotopeAtom["S34Labeled_BPE"] = false;
 
+    if(showBookmarkIsotopes->isChecked()) mainwindow->mavenParameters->isotopeAtom["showBookmarkIsotopes"] = true;
+    else mainwindow->mavenParameters->isotopeAtom["showBookmarkIsotopes"] = false;
+
     if(mainwindow->mavenParameters->pullIsotopesFlag) mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"] = true;
     else mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"] = false;
+
+    mainwindow->mavenParameters->isotopeAtom["IsotopeWidget"] = b;
     
 }
 

--- a/mzroll/settingsform.cpp
+++ b/mzroll/settingsform.cpp
@@ -76,7 +76,6 @@ void SettingsForm::setSettingsIonizationMode(QString ionMode) {
 
 void SettingsForm::showSetIsotopeAtom() {
     setIsotopeAtom();
-    cerr << mainwindow->mavenParameters->isotopeAtom["IsotopeWidget"] << " hello \n\n";
 }
 
 void SettingsForm::setIsotopeAtom() {

--- a/mzroll/settingsform.h
+++ b/mzroll/settingsform.h
@@ -28,6 +28,7 @@ class SettingsForm : public QDialog, public Ui_SettingsForm
                  void  setNumericValue(QString key, double value);
                  void  setStringValue(QString key, QString value);
                  void updateMultiprocessing();
+                 void showSetIsotopeAtom();
 
                  void setSettingsIonizationMode(QString);
 


### PR DESCRIPTION
   - A different checkbox option is added in isotope detection tab
     of options dialog.

   - This option when checked enables the addition of isotopes in
     bookmark table and isotopic barplot.