### PR TITLE
Ftr: Peak table is added for visualizing groups present in scatterplot.

### DIFF
--- a/src/gui/mzroll/comparesamplesdialog.cpp
+++ b/src/gui/mzroll/comparesamplesdialog.cpp
@@ -147,6 +147,7 @@ void CompareSamplesDialog::compareSamples() {
 	if (sset1.size() == 0 || sset2.size() == 0)
 		return;
 	compareSets(sset1, sset2);
+	if (parentWidget()) ((ScatterPlot*) parentWidget())->showPeakTable();
 }
 
 void CompareSamplesDialog::compareSets(vector<mzSample*> sset1,

--- a/src/gui/mzroll/scatterplot.h
+++ b/src/gui/mzroll/scatterplot.h
@@ -17,6 +17,9 @@ class ScatterPlot: public PlotDockWidget  {
                 ~ScatterPlot();
 				void showSimilar(PeakGroup* g);
 				void setTable(TableDockWidget* t);
+                void setPeakTable(QWidget* w);
+                vector<PeakGroup*> presentGroups;
+                QToolButton *btnPeakTable;
 
 		public Q_SLOTS:
 				void contrastGroups();
@@ -28,7 +31,7 @@ class ScatterPlot: public PlotDockWidget  {
                 void setPlotTypeFlower() { plotType=FLOWRPLOT;    draw(); }
                 void setPlotTypePLS() { plotType=PLSPLOT;    draw(); }
                 void showSimilarOnClick(bool t) { showSimilarFlag=t; }
-
+                void showPeakTable();
 
 
 
@@ -48,6 +51,7 @@ class ScatterPlot: public PlotDockWidget  {
 				QAction* showSimilarOptions;
 				bool showSimilarFlag;
 				TableDockWidget* _table;
+                TableDockWidget* _peakTable;
 				CompareSamplesDialog* compareSamplesDialog;
 
                 plotTypeEnum plotType;


### PR DESCRIPTION
   - A peak table button is added in toolbar of scatterplot to hide
     and show the peak table in UI.

   - This peak table will contain all the groups that are present in
     scatterplot graph.

   - This peak table is directly attached and get refreshed whenever
     two or more sample sets are compared with some log2 fold change
     cutoff, p-value cutoff etc.

   - This peak table works same as other peak tables.