### PR TITLE
Fix: compound charge is used for mass calc unless user enters formula

### DIFF
--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -216,9 +216,9 @@ vector<mzSlice*> PeakDetector::processCompounds(vector<Compound*> set,
                 slice->setSRMId();
 
                 // //Calculating the mzmin and mzmax
+                int charge = mavenParameters->getCharge(c);
                 bool success  = \
-                slice->calculateMzMinMax(mavenParameters->compoundPPMWindow, \
-                                                mavenParameters->ionizationMode*mavenParameters->charge);
+                slice->calculateMzMinMax(mavenParameters->compoundPPMWindow, charge);
                 if (!success) continue;
 
                 //calculating the min and max RT
@@ -242,8 +242,9 @@ void PeakDetector::pullIsotopesBarPlot(PeakGroup* parentgroup) {
         return;
 
     string formula = parentgroup->compound->formula; //parent formula
+    int charge = mavenParameters->getCharge(parentgroup->compound);
     //generate isotope list for parent mass
-    vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, mavenParameters->ionizationMode*mavenParameters->charge, 
+    vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, charge, 
                                                     mavenParameters->isotopeAtom, mavenParameters->noOfIsotopes);
 
     //iterate over samples to find properties for parent's isotopes.
@@ -462,9 +463,9 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
         return;
 
     string formula = parentgroup->compound->formula; //parent formula
-    //generate isotope list for parent mass
+    int charge = mavenParameters->getCharge(parentgroup->compound);//generate isotope list for parent mass
 
-    vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, mavenParameters->ionizationMode*mavenParameters->charge, 
+    vector<Isotope> masslist = MassCalculator::computeIsotopes(formula, charge, 
                                                         mavenParameters->isotopeAtom, mavenParameters->noOfIsotopes);
 
 

--- a/libmaven/csvreports.cpp
+++ b/libmaven/csvreports.cpp
@@ -155,7 +155,8 @@ vector<Isotope> CSVReports::computeIsotopes (PeakGroup* group, int ionizationMod
 
       MassCalculator *masscalc;
       string formula = group->compound->formula;
-      vector<Isotope> masslist = masscalc->computeIsotopes(formula,ionizationMode*mavenparameters->charge,getMavenParameters()->isotopeAtom, 
+      int charge = getMavenParameters()->getCharge(group->compound);
+      vector<Isotope> masslist = masscalc->computeIsotopes(formula,charge,getMavenParameters()->isotopeAtom, 
                                                                     getMavenParameters()->noOfIsotopes);
 
       return masslist;

--- a/libmaven/mavenparameters.cpp
+++ b/libmaven/mavenparameters.cpp
@@ -102,11 +102,14 @@ void MavenParameters::setAverageScanTime() {
 
 int MavenParameters::getCharge(Compound* compound){
 	int charge;
-        if(compound != nullptr && !this->formulaFlag)
-                if(compound->charge)
+        if(compound != nullptr && !this->formulaFlag){
+                if(compound->charge){
                         charge = compound->charge;
-        else
+                }
+        }
+        else{
                 charge = this->ionizationMode*this->charge;
+        }
 	return charge;
 }
 

--- a/libmaven/mavenparameters.cpp
+++ b/libmaven/mavenparameters.cpp
@@ -100,6 +100,16 @@ void MavenParameters::setAverageScanTime() {
                 avgScanTime = samples[0]->getAverageFullScanTime();
 }
 
+int MavenParameters::getCharge(Compound* compound){
+	int charge;
+        if(compound != nullptr && !this->formulaFlag)
+                if(compound->charge)
+                        charge = compound->charge;
+        else
+                charge = this->ionizationMode*this->charge;
+	return charge;
+}
+
 /**
  * MavenParameters::setIonizationMode In this the mode is selected my looking
  * at the first sample polarity

--- a/libmaven/mavenparameters.cpp
+++ b/libmaven/mavenparameters.cpp
@@ -103,8 +103,10 @@ void MavenParameters::setAverageScanTime() {
 int MavenParameters::getCharge(Compound* compound){
 	int charge;
         if(compound != nullptr && !this->formulaFlag){
-                if(compound->charge){
+                if(compound->charge !=0){
                         charge = compound->charge;
+                } else {
+                        charge = this->ionizationMode*this->charge;
                 }
         }
         else{

--- a/libmaven/mavenparameters.h
+++ b/libmaven/mavenparameters.h
@@ -10,7 +10,7 @@
 #include "mzMassCalculator.h"
 #include "mzSample.h"
 #include "mzUtils.h"
-#include "compound.h"
+#include "Compound.h"
 
 class Classifier;
 

--- a/libmaven/mavenparameters.h
+++ b/libmaven/mavenparameters.h
@@ -10,6 +10,7 @@
 #include "mzMassCalculator.h"
 #include "mzSample.h"
 #include "mzUtils.h"
+#include "compound.h"
 
 class Classifier;
 
@@ -35,6 +36,8 @@ public:
 	void setMaxGroupCount(int x) {
 		limitGroupCount = x;
 	}
+	
+	int getCharge(Compound* compound = nullptr);
 
 	/**
 	 * [set Compounds]
@@ -103,6 +106,7 @@ public:
 	 */
 	int ionizationMode;
 	int charge;
+	bool formulaFlag = false;
 
 	// For quantile intensity and qualityWeight
 	double quantileQuality;

--- a/libmaven/mavenparameters.h
+++ b/libmaven/mavenparameters.h
@@ -37,7 +37,7 @@ public:
 		limitGroupCount = x;
 	}
 	
-	int getCharge(Compound* compound = nullptr);
+	int getCharge(Compound* compound = NULL);
 
 	/**
 	 * [set Compounds]

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -1487,7 +1487,7 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
 
 	if (group == NULL)
 		return;
-	int charge = getMainWindow()->mavenParameters->getCharge();
+	int charge = getMainWindow()->mavenParameters->getCharge(group->compound);
 	if (group->getExpectedMz(charge, 
 			getMainWindow()->mavenParameters->isotopeAtom, getMainWindow()->mavenParameters->noOfIsotopes) != -1) {
 		eicParameters->_slice.mz = group->getExpectedMz(charge,
@@ -1519,7 +1519,7 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
 		eicParameters->_slice.rtmin = bounds.rtmin;
 	if (eicParameters->_slice.rtmax > bounds.rtmax)
 		eicParameters->_slice.rtmax = bounds.rtmax;
-	charge = getMainWindow()->mavenParameters->getCharge();
+	charge = getMainWindow()->mavenParameters->getCharge(group->compound);
 
 	if (group->getExpectedMz(charge,
 			getMainWindow()->mavenParameters->isotopeAtom, getMainWindow()->mavenParameters->noOfIsotopes) != -1) {

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -1405,7 +1405,8 @@ void EicWidget::setCompound(Compound* c) {
 	float mz = 0;
 
 	if (!c->formula.empty()) {
-		mz = c->ajustedMass(getMainWindow()->mavenParameters->ionizationMode*getMainWindow()->mavenParameters->charge);
+		int charge = getMainWindow()->mavenParameters->getCharge(c);
+		mz = c->ajustedMass(charge);
 	} else {
 		mz = c->mass;
 	}
@@ -1486,10 +1487,10 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
 
 	if (group == NULL)
 		return;
-
-	if (group->getExpectedMz(getMainWindow()->getIonizationMode()*getMainWindow()->mavenParameters->charge, 
+	int charge = getMainWindow()->mavenParameters->getCharge();
+	if (group->getExpectedMz(charge, 
 			getMainWindow()->mavenParameters->isotopeAtom, getMainWindow()->mavenParameters->noOfIsotopes) != -1) {
-		eicParameters->_slice.mz = group->getExpectedMz(getMainWindow()->getIonizationMode()*getMainWindow()->mavenParameters->charge,
+		eicParameters->_slice.mz = group->getExpectedMz(charge,
 					getMainWindow()->mavenParameters->isotopeAtom, getMainWindow()->mavenParameters->noOfIsotopes);
 	} else {
 		eicParameters->_slice.mz = group->meanMz;
@@ -1518,10 +1519,11 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
 		eicParameters->_slice.rtmin = bounds.rtmin;
 	if (eicParameters->_slice.rtmax > bounds.rtmax)
 		eicParameters->_slice.rtmax = bounds.rtmax;
+	charge = getMainWindow()->mavenParameters->getCharge();
 
-	if (group->getExpectedMz(getMainWindow()->getIonizationMode()*getMainWindow()->mavenParameters->charge,
+	if (group->getExpectedMz(charge,
 			getMainWindow()->mavenParameters->isotopeAtom, getMainWindow()->mavenParameters->noOfIsotopes) != -1) {
-		eicParameters->_slice.mz = group->getExpectedMz(getMainWindow()->getIonizationMode()*getMainWindow()->mavenParameters->charge,
+		eicParameters->_slice.mz = group->getExpectedMz(charge,
 					getMainWindow()->mavenParameters->isotopeAtom, getMainWindow()->mavenParameters->noOfIsotopes);
 	} else {
 		eicParameters->_slice.mz = group->meanMz;

--- a/mzroll/gallerywidget.cpp
+++ b/mzroll/gallerywidget.cpp
@@ -103,8 +103,8 @@ void GalleryWidget::addEicPlots(std::vector<Compound*>&compounds) {
 		if (!c->srmId.empty()) slice.srmId=c->srmId;
 
 		if (!c->formula.empty()) {
-			double mass = mcalc.computeMass(c->formula,mainwindow->mavenParameters->ionizationMode
-												*mainwindow->mavenParameters->charge);
+			int charge = mainwindow->mavenParameters->getCharge(c);
+			double mass = mcalc.computeMass(c->formula,charge);
             double ppmW = mass/1e6*compoundPPMWindow;
             slice.mzmin = mass-ppmW;
             slice.mzmax = mass+ppmW;

--- a/mzroll/ligandwidget.cpp
+++ b/mzroll/ligandwidget.cpp
@@ -672,7 +672,7 @@ void LigandWidget::matchFragmentation() {
 	int mzCount = c->fragment_mzs.size();
 	int intsCount = c->fragment_intensity.size(); 
 
-    int charge = _mw->mavenParameters->getCharge(); //user specified ionization mode
+    int charge = _mw->mavenParameters->getCharge(c); //user specified ionization mode
 	float precursorMz = c->precursorMz;
     if (!c->formula.empty()) precursorMz = c->ajustedMass(charge);
 

--- a/mzroll/ligandwidget.cpp
+++ b/mzroll/ligandwidget.cpp
@@ -335,7 +335,7 @@ void LigandWidget::showTable() {
 
         float mz;
         if (compound->formula.length()) {
-            int charge = _mw->mavenParameters->ionizationMode * _mw->mavenParameters->charge;
+            int charge = _mw->mavenParameters->getCharge(compound);
             mz = compound->ajustedMass(charge);
         } else {
             mz = compound->mass;
@@ -672,7 +672,7 @@ void LigandWidget::matchFragmentation() {
 	int mzCount = c->fragment_mzs.size();
 	int intsCount = c->fragment_intensity.size(); 
 
-    int charge = _mw->mavenParameters->ionizationMode; //user specified ionization mode
+    int charge = _mw->mavenParameters->getCharge(); //user specified ionization mode
 	float precursorMz = c->precursorMz;
     if (!c->formula.empty()) precursorMz = c->ajustedMass(charge);
 

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -1226,10 +1226,10 @@ PeakGroup* MainWindow::bookmarkPeakGroup(PeakGroup* group) {
 
 void MainWindow::setFormulaFocus(QString formula) {
 	int charge = 0;
-	mavenParameters->formulaFlag = TRUE;
+	mavenParameters->formulaFlag = true;
 	//if (getIonizationMode())
 	charge = mavenParameters->getCharge(); //user specified ionization mode
-	mavenParameters->formulaFlag = FALSE;
+	mavenParameters->formulaFlag = false;
 	// MassCalculator mcalc;
 	double parentMass = MassCalculator::computeMass(formula.toStdString(), charge);
 	if (eicWidget->isVisible())

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -1226,9 +1226,10 @@ PeakGroup* MainWindow::bookmarkPeakGroup(PeakGroup* group) {
 
 void MainWindow::setFormulaFocus(QString formula) {
 	int charge = 0;
+	mavenParameters->formulaFlag = TRUE;
 	//if (getIonizationMode())
-		charge = mavenParameters->ionizationMode*mavenParameters->charge; //user specified ionization mode
-
+	charge = mavenParameters->getCharge(); //user specified ionization mode
+	mavenParameters->formulaFlag = FALSE;
 	// MassCalculator mcalc;
 	double parentMass = MassCalculator::computeMass(formula.toStdString(), charge);
 	if (eicWidget->isVisible())
@@ -1264,7 +1265,7 @@ void MainWindow::setCompoundFocus(Compound*c) {
 	// 	charge = 1;
 	// if (getIonizationMode())
 	// 	charge = getIonizationMode(); //user specified ionization mode
-	charge = mavenParameters->ionizationMode*mavenParameters->charge;
+	charge = mavenParameters->getCharge(c);
 	qDebug() << "setCompoundFocus:" << c->name.c_str() << " " << charge << " "
 			<< c->expectedRt;
 
@@ -2849,8 +2850,7 @@ bool MainWindow::checkCompoundExistance(Compound* c) {
 	// 	charge = 1;
 	// if (getIonizationMode())
 	// 	charge = getIonizationMode(); //user specified ionization mode
-	charge = mavenParameters->ionizationMode*mavenParameters->charge;
-
+	charge = mavenParameters->getCharge(c);
 	float mz = c->ajustedMass(charge);
 	float mzmin = mz - mz / 1e6 * 3;
 	float mzmax = mz + mz / 1e6 * 3;
@@ -3292,7 +3292,7 @@ void MainWindow::getLinks(Peak* peak) {
 	//matching compounds
 	for (int i = 0; i < links.size(); i++) {
 		QSet<Compound*> compunds = massCalcWidget->findMathchingCompounds(
-				links[i].mz2, ppm, mavenParameters->ionizationMode*mavenParameters->charge);
+				links[i].mz2, ppm, mavenParameters->getCharge());
 		if (compunds.size() > 0)
 			Q_FOREACH( Compound*c, compunds){ links[i].note += " |" + c->name; break;}
 	}

--- a/mzroll/mainwindow.h
+++ b/mzroll/mainwindow.h
@@ -121,7 +121,7 @@ public:
 	QSettings* getSettings() {
 		return settings;
 	}
-	vector<mzSample*> samples;		//list of loadded samples
+	vector<mzSample*> samples;		//list of loaded samples
 	static mzSample* loadSample(QString filename);
 	int peaksMarked = 0;
 	int noOfPeakTables = 0;
@@ -218,7 +218,7 @@ public:
 	TableDockWidget* getBookmarkedPeaks() {
 		return bookmarkedPeaks;
 	}
-
+	
     QList< QPointer<TableDockWidget> > getPeakTableList() { return groupTables; } //TODO: Sahil - Kiran, Added while merging mainwindow
 	
 	Classifier* getClassifier() {

--- a/mzroll/masscalcgui.cpp
+++ b/mzroll/masscalcgui.cpp
@@ -120,12 +120,12 @@ QSet<Compound*> MassCalcWidget::findMathchingCompounds(float mz, float ppm, floa
 }
 
 void MassCalcWidget::getMatches() {
-    int charge = _mw->mavenParameters->ionizationMode*_mw->mavenParameters->charge;
+    int charge = _mw->mavenParameters->getCharge();
 	QSet<Compound*> compounds = findMathchingCompounds(_mz,_ppm,charge);
 	Q_FOREACH(Compound* c, compounds) {
           MassCalculator::Match* m = new MassCalculator::Match();
           m->name = c->formula;
-          m->mass = MassCalculator::computeMass(c->formula,charge);
+          m->mass = MassCalculator::computeMass(c->formula,_mw->mavenParameters->getCharge(c));
           m->diff = mzUtils::ppmDist((double) m->mass,(double) _mz);
           m->compoundLink = c;
           matches.push_back(m);

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -418,10 +418,11 @@ void TableDockWidget::addRow(PeakGroup* group, QTreeWidgetItem* root) {
     item->setText(0,QString::number(group->groupId));
     item->setText(1,groupTagString(group));
     item->setText(2,QString::number(group->meanMz, 'f', 4));
+    int charge = _mainwindow->mavenParameters->getCharge();
 
-    if (group->getExpectedMz(_mainwindow->getIonizationMode()*_mainwindow->mavenParameters->charge, 
+    if (group->getExpectedMz(charge, 
             _mainwindow->mavenParameters->isotopeAtom, _mainwindow->mavenParameters->noOfIsotopes) != -1) {
-        float mz = group->getExpectedMz(_mainwindow->getIonizationMode()*_mainwindow->mavenParameters->charge, 
+        float mz = group->getExpectedMz(charge, 
                 _mainwindow->mavenParameters->isotopeAtom, _mainwindow->mavenParameters->noOfIsotopes);
 
         item->setText(3,QString::number(mz,'f', 4));
@@ -729,9 +730,11 @@ void TableDockWidget::writeGroupMzEICJson(PeakGroup& grp,ofstream& myfile, vecto
 
             myfile << ",\n" << "\"expectedRt\": " << grp.compound->expectedRt;
 
+            //check!!
             double mass = grp.compound->mass;
-            if (grp.compound->formula.empty()) {
-                float formula_mass =  _mainwindow->mavenParameters->mcalc.computeMass(grp.compound->formula,_mainwindow->mavenParameters->charge);
+            if (!grp.compound->formula.empty()) {
+                int charge = _mainwindow->mavenParameters->getCharge(grp.compound);
+                float formula_mass =  _mainwindow->mavenParameters->mcalc.computeMass(grp.compound->formula,charge);
                 if(formula_mass) mass=formula_mass;
             }
             myfile << ",\n" << "\"expectedMz\": " << mass ;
@@ -1597,9 +1600,10 @@ void TableDockWidget::findMatchingCompounds() {
     float ppm = _mainwindow->getUserPPM();
     float ionizationMode = _mainwindow->mavenParameters->ionizationMode;
     for(int i=0; i < allgroups.size(); i++ ) {
+        int charge = _mainwindow->mavenParameters->getCharge();
         PeakGroup& g = allgroups[i];
         QSet<Compound*>compounds = _mainwindow->massCalcWidget->findMathchingCompounds(g.meanMz, ppm, 
-                    _mainwindow->mavenParameters->ionizationMode*_mainwindow->mavenParameters->charge);
+                    charge);
         if (compounds.size() > 0 ) Q_FOREACH( Compound*c, compounds) { g.tagString += " |" + c->name; break; }
         //cerr << g.meanMz << " " << compounds.size() << endl;
     }

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -418,7 +418,7 @@ void TableDockWidget::addRow(PeakGroup* group, QTreeWidgetItem* root) {
     item->setText(0,QString::number(group->groupId));
     item->setText(1,groupTagString(group));
     item->setText(2,QString::number(group->meanMz, 'f', 4));
-    int charge = _mainwindow->mavenParameters->getCharge();
+    int charge = _mainwindow->mavenParameters->getCharge(group->compound);
 
     if (group->getExpectedMz(charge, 
             _mainwindow->mavenParameters->isotopeAtom, _mainwindow->mavenParameters->noOfIsotopes) != -1) {
@@ -1600,8 +1600,8 @@ void TableDockWidget::findMatchingCompounds() {
     float ppm = _mainwindow->getUserPPM();
     float ionizationMode = _mainwindow->mavenParameters->ionizationMode;
     for(int i=0; i < allgroups.size(); i++ ) {
-        int charge = _mainwindow->mavenParameters->getCharge();
         PeakGroup& g = allgroups[i];
+        int charge = _mainwindow->mavenParameters->getCharge(g.compound);
         QSet<Compound*>compounds = _mainwindow->massCalcWidget->findMathchingCompounds(g.meanMz, ppm, 
                     charge);
         if (compounds.size() > 0 ) Q_FOREACH( Compound*c, compounds) { g.tagString += " |" + c->name; break; }


### PR DESCRIPTION
- getCharge returns the appropriate charge for mass calculation (compound charge used if it exists, user input charge used otherwise)
- formulaFlag to track if user searches by formula