### PR TITLE
Fix: Correct and Document SRM Lists. 

### DIFF
--- a/libmaven/SRMLists.cpp
+++ b/libmaven/SRMLists.cpp
@@ -1,0 +1,108 @@
+#include "SRMLists.h"
+
+SRMLists::SRMLists(vector<mzSample*>samples, deque<Compound*> compoundsDB){
+    this->samples = samples;
+    this->compoundsDB = compoundsDB;
+}
+
+vector<mzSlice*> SRMLists::getSrmSlices(double amuQ1, double amuQ3, int userPolarity, bool rtMatch, bool associateCompoundNames) {
+	//Merged with Maven776 - Kiran
+    QMap<QString, Scan*>seenMRMS;
+    //+118.001@cid34.00 [57.500-58.500]
+    //+ c ESI SRM ms2 102.000@cid19.00 [57.500-58.500]
+    //-87.000 [42.500-43.500]
+    //- c ESI SRM ms2 159.000 [113.500-114.500]
+
+    QRegExp rx1a("[+/-](\\d+\\.\\d+)");
+    QRegExp rx1b("ms2\\s*(\\d+\\.\\d+)");
+    QRegExp rx2("(\\d+\\.\\d+)-(\\d+\\.\\d+)");
+    int countMatches=0;
+
+    vector<mzSlice*>slices;
+    for(int i=0; i < samples.size(); i++ ) {
+        mzSample* sample = samples[i];
+        for( int j=0; j < sample->scans.size(); j++ ) {
+            Scan* scan = sample->getScan(j);
+            if (!scan) continue;
+
+            QString filterLine(scan->filterLine.c_str());
+
+            if (filterLine.isEmpty())   continue;
+
+            if (seenMRMS.contains(filterLine)){
+                if(scan->intensity[0] <= seenMRMS.value(filterLine)->intensity[0])    continue;
+            }
+
+            seenMRMS.insert(filterLine, scan);
+        }
+    }
+
+    for (auto filterLine: seenMRMS.keys()){
+		
+        Scan* scan = seenMRMS.value(filterLine);
+        mzSlice* s = new mzSlice(0,0,0,0);
+		s->srmId = scan->filterLine.c_str();
+        slices.push_back(s);
+
+        if (associateCompoundNames) {
+            //match compounds
+            Compound* compound = NULL;
+            float precursorMz = scan->precursorMz;
+            float productMz   = scan->productMz;
+            float rt = scan->rt;
+            int   polarity= scan->getPolarity();
+            if (polarity==0) filterLine[0] == '+' ? polarity=1 : polarity =-1;
+            if (userPolarity) polarity=userPolarity;  //user specified ionization mode
+
+            if ( precursorMz == 0 ) {
+                if( rx1a.indexIn(filterLine) != -1 ) {
+                    precursorMz = rx1a.capturedTexts()[1].toDouble();
+                } else if ( rx1b.indexIn(filterLine) != -1 ) {
+                    precursorMz = rx1b.capturedTexts()[1].toDouble();
+                }
+            }
+
+            if (productMz == 0) {
+                if ( rx2.indexIn(filterLine) != -1 ) {
+                    float lb = rx2.capturedTexts()[1].toDouble();
+                    float ub = rx2.capturedTexts()[2].toDouble();
+                    productMz = lb+(ub-lb)/2;
+                }
+            }
+
+            if (precursorMz != 0 && productMz != 0 ) {
+                compound = findSpeciesByPrecursor(precursorMz,productMz,rt,rtMatch,polarity,amuQ1,amuQ3);
+            }
+
+            if (compound) {
+                compound->srmId = filterLine.toStdString();
+                s->compound = compound;
+                s->rt = compound->expectedRt;
+                countMatches++;
+            }
+        }                       
+	}
+	return slices;
+}
+
+
+Compound *SRMLists::findSpeciesByPrecursor(float precursorMz, float productMz, float rt, bool rtMatch, int polarity,double amuQ1, double amuQ3) {
+    
+    Compound* x=NULL;
+    float dist=FLT_MAX;
+
+    for(unsigned int i=0; i < compoundsDB.size(); i++ ) {
+            if (compoundsDB[i]->precursorMz == 0 ) continue;
+            //cerr << polarity << " " << compoundsDB[i]->charge << endl;
+            if ((int) compoundsDB[i]->charge != polarity ) continue;
+            float a = abs(compoundsDB[i]->precursorMz - precursorMz);
+            if ( a > amuQ1 ) continue; // q1 tollorance
+            float b = abs(compoundsDB[i]->productMz - productMz);
+            if ( b > amuQ3 ) continue; // q2 tollarance
+            float c = abs( compoundsDB[i]->expectedRt - rt);
+            if ( rtMatch == 0) c = 0.0; 
+            float d = sqrt(a*a+b*b+c*c);
+            if ( d < dist) { x = compoundsDB[i]; dist=d;}
+    }
+    return x;
+}

--- a/libmaven/SRMLists.h
+++ b/libmaven/SRMLists.h
@@ -9,12 +9,40 @@
 
 class SRMLists{
     public:
+
+        /**
+        * [Constructor for the class SRMLists.]
+        * @method SRMLists
+        * @param samples    [vector, with all the samples and repsective scans info]
+        * @param compoundsDB[deque, a database with all the compounds and their databases] 
+        */
         SRMLists(vector<mzSample*>samples, deque<Compound*> compoundsDB);
         vector<mzSample*>samples;
 
+        /**
+        * [Creates and returns slices created after finding best scan assiging the 
+        *  best compound for each SRM with the help of findSpeciesByPrecursor().]
+        * @param amuQ1      [tolerance level in Q1-value]
+        * @param amuQ3      [tolerance level in Q3-value]
+        * @param userPolarity
+        * @param rtMatch    [Boolean - Whether to consider the variation in rt or not]
+        * @param associateCompoundNames [Boolean - Whether to assign names to the compounds]
+        * @return slices
+        */
         vector<mzSlice*> getSrmSlices(double amuQ1, double amuQ3, int userPolarity, bool rtMatch, bool associateCompoundNames);
         deque<Compound*> compoundsDB;
 
+        /**
+        * [Finds the species/compound to which, a particular SRM belongs to(if exists).]
+        * @param precursorMz    [SRM's precursorMz value - Q1]
+        * @param productMz      [SRM's productMz value - Q3]
+        * @param rt             [SRM's rt value]
+        * @param rtMatch        [Boolean - Whether to consider the variation in rt or not]
+        * @param polarity       [SRM's polarity]
+        * @param amuQ1          [tolerance level in Q1-value]
+        * @param amuQ3          [tolerance level in Q3-value]
+        * @return x             [Compound that best fits the scan from database. Null, if none matches.]
+        */
         Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt, bool rtMatch, int polarity,double amuQ1, double amuQ3);
 };
 

--- a/libmaven/SRMLists.h
+++ b/libmaven/SRMLists.h
@@ -1,0 +1,21 @@
+#ifndef SRMLISTS_H
+#define SRMLISTS_H
+
+#include "Compound.h"
+#include "databases.h"
+#include "mzSample.h"
+#include "Scan.h"
+ #include <QMap> 
+
+class SRMLists{
+    public:
+        SRMLists(vector<mzSample*>samples, deque<Compound*> compoundsDB);
+        vector<mzSample*>samples;
+
+        vector<mzSlice*> getSrmSlices(double amuQ1, double amuQ3, int userPolarity, bool rtMatch, bool associateCompoundNames);
+        deque<Compound*> compoundsDB;
+
+        Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt, bool rtMatch, int polarity,double amuQ1, double amuQ3);
+};
+
+#endif

--- a/libmaven/libmaven.pro
+++ b/libmaven/libmaven.pro
@@ -38,6 +38,7 @@ SOURCES = 	base64.cpp \
             Fragment.cpp \
 	        EIC.cpp \
 	        Scan.cpp \
+                SRMLists.cpp \
 	        Peak.cpp  \
 	        Compound.cpp \
 	        savgol.cpp \
@@ -82,6 +83,7 @@ HEADERS += 	constants.h \
                 eiclogic.h \
                 EIC.h \
 	            Scan.h \
+                SRMLists.h \
                 databases.h \
                 Peptide.hpp \
                 PeptideRecord.h \

--- a/mzroll/background_peaks_update.cpp
+++ b/mzroll/background_peaks_update.cpp
@@ -583,8 +583,9 @@ void BackgroundPeakUpdate::findPeaksQQQ() {
 	if(mainwindow == NULL) return;
         double amuQ1 = mainwindow->getSettings()->value("amuQ1").toDouble();
         double amuQ3 = mainwindow->getSettings()->value("amuQ3").toDouble();
+        bool rtMatch = mainwindow->getSettings()->value("rtMatch").toInt();
         bool associateCompoundNames=false;
-        vector<mzSlice*>slices = mainwindow->getSrmSlices(amuQ1,amuQ3,associateCompoundNames);
+        vector<mzSlice*>slices = mainwindow->getSrmSlices(amuQ1,amuQ3,rtMatch,associateCompoundNames);
 	processSlices(slices,"QQQ Peaks");
 	delete_all(slices);
 	slices.clear();

--- a/mzroll/database.cpp
+++ b/mzroll/database.cpp
@@ -201,7 +201,16 @@ vector<Compound*> Database::findSpeciesByName(string name, string dbname) {
 		return set;
 }
 
-Compound* Database::findSpeciesByPrecursor(float precursorMz, float productMz, float rt, int polarity,double amuQ1, double amuQ3) {
+Compound* Database::findSpeciesByPrecursor(float precursorMz, float productMz, float rt, bool rtMatch, int polarity,double amuQ1, double amuQ3) {
+    /*
+        This function takes the attributes(precursorMz, productMz, rt, polarity) of a 
+    scan and compares with the compounds in the compound database to find the best match.
+        It takes the following constraints into account while finding best match:
+            1. Difference in q1 and q2 are within the tolerance range.
+            2. Polarity charge should match exactly.
+            3. The compound with minimum variation interms of precursorMz, productMz and rt values
+               in values is considered best.
+    */
 		Compound* x=NULL;
 		float dist=FLT_MAX;
 
@@ -214,8 +223,9 @@ Compound* Database::findSpeciesByPrecursor(float precursorMz, float productMz, f
 				float b = abs(compoundsDB[i]->productMz - productMz);
 				if ( b > amuQ3 ) continue; // q2 tollarance
                 float c = abs( compoundsDB[i]->expectedRt - rt);
+                if ( rtMatch == 0) c = 0.0; 
                 float d = sqrt(a*a+b*b+c*c);
-				if ( d < dist) { x = compoundsDB[i]; dist=d; }
+				if ( d < dist) { x = compoundsDB[i]; dist=d;}
 		}
 		return x;
 }

--- a/mzroll/database.cpp
+++ b/mzroll/database.cpp
@@ -201,7 +201,7 @@ vector<Compound*> Database::findSpeciesByName(string name, string dbname) {
 		return set;
 }
 
-Compound* Database::findSpeciesByPrecursor(float precursorMz, float productMz, int polarity,double amuQ1, double amuQ3) {
+Compound* Database::findSpeciesByPrecursor(float precursorMz, float productMz, float rt, int polarity,double amuQ1, double amuQ3) {
 		Compound* x=NULL;
 		float dist=FLT_MAX;
 
@@ -213,7 +213,8 @@ Compound* Database::findSpeciesByPrecursor(float precursorMz, float productMz, i
 				if ( a > amuQ1 ) continue; // q1 tollorance
 				float b = abs(compoundsDB[i]->productMz - productMz);
 				if ( b > amuQ3 ) continue; // q2 tollarance
-				float d = sqrt(a*a+b*b);
+                float c = abs( compoundsDB[i]->expectedRt - rt);
+                float d = sqrt(a*a+b*b+c*c);
 				if ( d < dist) { x = compoundsDB[i]; dist=d; }
 		}
 		return x;

--- a/mzroll/database.h
+++ b/mzroll/database.h
@@ -55,7 +55,7 @@ class Database {
 	Molecule2D* getMolecularCoordinates(QString id);
     //Added while merging with Maven776 - Kiran
 	Compound* findSpeciesById(string id, string dbName);
-	Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt,
+	Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt, bool rtMatch,
 					 int polarity, double amuQ1,
 					 double amuQ3);
 	set<Compound*> findSpeciesByMass(float mz, float ppm);

--- a/mzroll/database.h
+++ b/mzroll/database.h
@@ -55,6 +55,7 @@ class Database {
 	Molecule2D* getMolecularCoordinates(QString id);
     //Added while merging with Maven776 - Kiran
 	Compound* findSpeciesById(string id, string dbName);
+	deque<Compound*> getCompoundsDB(){ 	return compoundsDB;}
 	Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt, bool rtMatch,
 					 int polarity, double amuQ1,
 					 double amuQ3);

--- a/mzroll/database.h
+++ b/mzroll/database.h
@@ -55,7 +55,7 @@ class Database {
 	Molecule2D* getMolecularCoordinates(QString id);
     //Added while merging with Maven776 - Kiran
 	Compound* findSpeciesById(string id, string dbName);
-	Compound* findSpeciesByPrecursor(float precursorMz, float productMz,
+	Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt,
 					 int polarity, double amuQ1,
 					 double amuQ3);
 	set<Compound*> findSpeciesByMass(float mz, float ppm);

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -2541,12 +2541,22 @@ void MainWindow::showSRMList() {
 		bool rtMatch = getSettings()->value("rtMatch").toInt();
         double amuQ1 = getSettings()->value("amuQ1").toDouble();
         double amuQ3 = getSettings()->value("amuQ3").toDouble();
-        bool associateCompoundNames=true;
-        vector<mzSlice*>slices = getSrmSlices(amuQ1,amuQ3,rtMatch,associateCompoundNames);
+		bool associateCompoundNames=true;
+		vector<mzSlice*>slices = getSrmSlices(amuQ1,amuQ3,rtMatch,associateCompoundNames);
+		
 		if (slices.size() ==  0 ) return;
         srmDockWidget->setInfo(slices);
         delete_all(slices);
      }
+}
+
+vector<mzSlice*> MainWindow::getSrmSlices(double amuQ1, double amuQ3, bool rtMatch, bool associateCompoundNames){
+	int userPolarity = 0;
+	if (getIonizationMode()) userPolarity=getIonizationMode();
+	deque<Compound*> compoundsDB = DB.getCompoundsDB();
+	SRMLists *srmLists = new SRMLists(samples, compoundsDB);
+	vector<mzSlice*>slices = srmLists->getSrmSlices(amuQ1,amuQ3,userPolarity,rtMatch,associateCompoundNames);
+	return slices;
 }
 
 void MainWindow::setPeakGroup(PeakGroup* group) {
@@ -2690,91 +2700,8 @@ void MainWindow::UndoAlignment() {
 
 	Q_EMIT(undoAlignment(listGroups));
 
+
 }
-
-vector<mzSlice*> MainWindow::getSrmSlices(double amuQ1, double amuQ3, bool rtMatch, bool associateCompoundNames) {
-	//Merged with Maven776 - Kiran
-    qDebug() << "getSrmSlices() Q1=" << amuQ1 << " Q3=" << amuQ3;
-    QMap<QString, Scan*>seenMRMS;
-    //+118.001@cid34.00 [57.500-58.500]
-    //+ c ESI SRM ms2 102.000@cid19.00 [57.500-58.500]
-    //-87.000 [42.500-43.500]
-    //- c ESI SRM ms2 159.000 [113.500-114.500]
-
-    QRegExp rx1a("[+/-](\\d+\\.\\d+)");
-    QRegExp rx1b("ms2\\s*(\\d+\\.\\d+)");
-    QRegExp rx2("(\\d+\\.\\d+)-(\\d+\\.\\d+)");
-    int countMatches=0;
-
-    vector<mzSlice*>slices;
-    for(int i=0; i < samples.size(); i++ ) {
-        mzSample* sample = samples[i];
-        for( int j=0; j < sample->scans.size(); j++ ) {
-            Scan* scan = sample->getScan(j);
-            if (!scan) continue;
-
-            QString filterLine(scan->filterLine.c_str());
-
-            if (filterLine.isEmpty())   continue;
-
-            if (seenMRMS.contains(filterLine)){
-                if(scan->intensity[0] <= seenMRMS.value(filterLine)->intensity[0])    continue;
-            }
-
-            seenMRMS.insert(filterLine, scan);
-        }
-    }
-
-    QMapIterator<QString, Scan*> iter(seenMRMS); 
-
-	int i=0;
-    for (auto filterLine: seenMRMS.keys()){
-		
-        Scan* scan = seenMRMS.value(filterLine);
-        mzSlice* s = new mzSlice(0,0,0,0);
-		s->srmId = scan->filterLine.c_str();
-        slices.push_back(s);
-
-        if (associateCompoundNames) {
-            //match compounds
-            Compound* compound = NULL;
-            float precursorMz = scan->precursorMz;
-            float productMz   = scan->productMz;
-            float rt = scan->rt;
-            int   polarity= scan->getPolarity();
-            if (polarity==0) filterLine[0] == '+' ? polarity=1 : polarity =-1;
-            if (getIonizationMode()) polarity=getIonizationMode();  //user specified ionization mode
-
-            if ( precursorMz == 0 ) {
-                if( rx1a.indexIn(filterLine) != -1 ) {
-                    precursorMz = rx1a.capturedTexts()[1].toDouble();
-                } else if ( rx1b.indexIn(filterLine) != -1 ) {
-                    precursorMz = rx1b.capturedTexts()[1].toDouble();
-                }
-            }
-
-            if (productMz == 0) {
-                if ( rx2.indexIn(filterLine) != -1 ) {
-                    float lb = rx2.capturedTexts()[1].toDouble();
-                    float ub = rx2.capturedTexts()[2].toDouble();
-                    productMz = lb+(ub-lb)/2;
-                }
-            }
-
-            if (precursorMz != 0 && productMz != 0 ) {
-                compound = DB.findSpeciesByPrecursor(precursorMz,productMz,rt,rtMatch,polarity,amuQ1,amuQ3);
-            }
-
-            if (compound) {
-                compound->srmId = filterLine.toStdString();
-                s->compound = compound;
-                s->rt = compound->expectedRt;
-                countMatches++;
-            }
-        }                       
-	}
-	return slices;
-}                                    
 
 void MainWindow::showPeakInfo(Peak* _peak) {
 	if (_peak == NULL)

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -2537,11 +2537,13 @@ void MainWindow::showSRMList() {
 	LOGD;
      //added while merging with Maven776 - Kiran
      if (srmDockWidget->isVisible()) {
+		
+		bool rtMatch = getSettings()->value("rtMatch").toInt();
         double amuQ1 = getSettings()->value("amuQ1").toDouble();
         double amuQ3 = getSettings()->value("amuQ3").toDouble();
         bool associateCompoundNames=true;
-        vector<mzSlice*>slices = getSrmSlices(amuQ1,amuQ3,associateCompoundNames);
-        if (slices.size() ==  0 ) return;
+        vector<mzSlice*>slices = getSrmSlices(amuQ1,amuQ3,rtMatch,associateCompoundNames);
+		if (slices.size() ==  0 ) return;
         srmDockWidget->setInfo(slices);
         delete_all(slices);
      }
@@ -2690,7 +2692,7 @@ void MainWindow::UndoAlignment() {
 
 }
 
-vector<mzSlice*> MainWindow::getSrmSlices(double amuQ1, double amuQ3, bool associateCompoundNames) {
+vector<mzSlice*> MainWindow::getSrmSlices(double amuQ1, double amuQ3, bool rtMatch, bool associateCompoundNames) {
 	//Merged with Maven776 - Kiran
     qDebug() << "getSrmSlices() Q1=" << amuQ1 << " Q3=" << amuQ3;
     QMap<QString, Scan*>seenMRMS;
@@ -2760,7 +2762,7 @@ vector<mzSlice*> MainWindow::getSrmSlices(double amuQ1, double amuQ3, bool assoc
             }
 
             if (precursorMz != 0 && productMz != 0 ) {
-                compound = DB.findSpeciesByPrecursor(precursorMz,productMz,rt,polarity,amuQ1,amuQ3);
+                compound = DB.findSpeciesByPrecursor(precursorMz,productMz,rt,rtMatch,polarity,amuQ1,amuQ3);
             }
 
             if (compound) {

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -2693,7 +2693,7 @@ void MainWindow::UndoAlignment() {
 vector<mzSlice*> MainWindow::getSrmSlices(double amuQ1, double amuQ3, bool associateCompoundNames) {
 	//Merged with Maven776 - Kiran
     qDebug() << "getSrmSlices() Q1=" << amuQ1 << " Q3=" << amuQ3;
-    QSet<QString>seenMRMS;
+    QMap<QString, Scan*>seenMRMS;
     //+118.001@cid34.00 [57.500-58.500]
     //+ c ESI SRM ms2 102.000@cid19.00 [57.500-58.500]
     //-87.000 [42.500-43.500]
@@ -2706,62 +2706,73 @@ vector<mzSlice*> MainWindow::getSrmSlices(double amuQ1, double amuQ3, bool assoc
 
     vector<mzSlice*>slices;
     for(int i=0; i < samples.size(); i++ ) {
-    	mzSample* sample = samples[i];
+        mzSample* sample = samples[i];
         for( int j=0; j < sample->scans.size(); j++ ) {
             Scan* scan = sample->getScan(j);
             if (!scan) continue;
 
-            QString filterLine(scan->filterLine.c_str());            
+            QString filterLine(scan->filterLine.c_str());
 
-            if (filterLine.isEmpty() or seenMRMS.contains(filterLine)) continue;
-            seenMRMS.insert(filterLine);
+            if (filterLine.isEmpty())   continue;
 
+            if (seenMRMS.contains(filterLine)){
+                if(scan->intensity[0] <= seenMRMS.value(filterLine)->intensity[0])    continue;
+            }
 
-            mzSlice* s = new mzSlice(0,0,0,0);
-            s->srmId = scan->filterLine.c_str();
-            slices.push_back(s);
+            seenMRMS.insert(filterLine, scan);
+        }
+    }
 
-            if (associateCompoundNames) {
-                //match compounds
-                Compound* compound = NULL;
-                float precursorMz = scan->precursorMz;
-                float productMz   = scan->productMz;
-                int   polarity= scan->getPolarity();
-                if (polarity==0) filterLine[0] == '+' ? polarity=1 : polarity =-1;
-                if (getIonizationMode()) polarity=getIonizationMode();  //user specified ionization mode
+    QMapIterator<QString, Scan*> iter(seenMRMS); 
 
-                if ( precursorMz == 0 ) {
-                    if( rx1a.indexIn(filterLine) != -1 ) {
-                        precursorMz = rx1a.capturedTexts()[1].toDouble();
-                    } else if ( rx1b.indexIn(filterLine) != -1 ) {
-                        precursorMz = rx1b.capturedTexts()[1].toDouble();
-                    }
-                }
+	int i=0;
+    for (auto filterLine: seenMRMS.keys()){
+		
+        Scan* scan = seenMRMS.value(filterLine);
+        mzSlice* s = new mzSlice(0,0,0,0);
+		s->srmId = scan->filterLine.c_str();
+        slices.push_back(s);
 
-                if (productMz == 0) {
-                    if ( rx2.indexIn(filterLine) != -1 ) {
-                        float lb = rx2.capturedTexts()[1].toDouble();
-                        float ub = rx2.capturedTexts()[2].toDouble();
-                        productMz = lb+(ub-lb)/2;
-                    }
-                }
+        if (associateCompoundNames) {
+            //match compounds
+            Compound* compound = NULL;
+            float precursorMz = scan->precursorMz;
+            float productMz   = scan->productMz;
+            float rt = scan->rt;
+            int   polarity= scan->getPolarity();
+            if (polarity==0) filterLine[0] == '+' ? polarity=1 : polarity =-1;
+            if (getIonizationMode()) polarity=getIonizationMode();  //user specified ionization mode
 
-                if (precursorMz != 0 && productMz != 0 ) {
-                    compound = DB.findSpeciesByPrecursor(precursorMz,productMz,polarity,amuQ1,amuQ3);
-                }
-
-                if (compound) {
-                    compound->srmId = filterLine.toStdString();
-                    s->compound = compound;
-                    s->rt = compound->expectedRt;
-                    countMatches++;
+            if ( precursorMz == 0 ) {
+                if( rx1a.indexIn(filterLine) != -1 ) {
+                    precursorMz = rx1a.capturedTexts()[1].toDouble();
+                } else if ( rx1b.indexIn(filterLine) != -1 ) {
+                    precursorMz = rx1b.capturedTexts()[1].toDouble();
                 }
             }
-        }
-        qDebug() << "SRM mapping: " << countMatches << " compounds mapped out of " << seenMRMS.size();
-    }
-    return slices;
-}
+
+            if (productMz == 0) {
+                if ( rx2.indexIn(filterLine) != -1 ) {
+                    float lb = rx2.capturedTexts()[1].toDouble();
+                    float ub = rx2.capturedTexts()[2].toDouble();
+                    productMz = lb+(ub-lb)/2;
+                }
+            }
+
+            if (precursorMz != 0 && productMz != 0 ) {
+                compound = DB.findSpeciesByPrecursor(precursorMz,productMz,rt,polarity,amuQ1,amuQ3);
+            }
+
+            if (compound) {
+                compound->srmId = filterLine.toStdString();
+                s->compound = compound;
+                s->rt = compound->expectedRt;
+                countMatches++;
+            }
+        }                       
+	}
+	return slices;
+}                                    
 
 void MainWindow::showPeakInfo(Peak* _peak) {
 	if (_peak == NULL)

--- a/mzroll/mainwindow.h
+++ b/mzroll/mainwindow.h
@@ -337,6 +337,16 @@ public Q_SLOTS:
 	void updateEicSmoothingWindow(int value);
     bool setPeptideSequence(QString peptideSeq); //TODO: Sahil, Added while merging point
 	//Added when merging with Maven776 - Kiran
+
+	/**
+	* [	Initialises variables and calls the "SRMLists->getSrmSlices" to compare and assign
+	* 	SRMs to the compounds known through the database. ]
+	* @param q1tol		[tolerance for Q1 value]
+	* @param q3tol		[tolerance for Q1 value]
+	* @param rtMatch	[boolean - Whether to consider rt-value while comparing the compounds]
+	* @param associateCompoundNames [boolean - Whether to assign the compound names or not.]
+	* @result slices 	[Returned by "SRMLists->getSrmSlices"]
+	*/
 	vector<mzSlice*> getSrmSlices(double q1tol, double q3tol, bool rtMatch, bool associateCompoundNames);
 
 	void open();
@@ -350,6 +360,10 @@ public Q_SLOTS:
 	void doSearch(QString needle);
 	//void setupSampleColors();
         // void showMassSlices();
+
+		/**
+		* Update the SRMListWidget whenever the "show SRM Lists" button is clicked.
+		*/
         void showSRMList();
         void addToHistory(const mzSlice& slice);
         void historyNext();

--- a/mzroll/mainwindow.h
+++ b/mzroll/mainwindow.h
@@ -6,6 +6,7 @@
 #include <ctime>
 #include <sstream>
 #include "../libmaven/mavenparameters.h"
+#include "../libmaven/SRMLists.h"
 #include "scatterplot.h"
 #include "eicwidget.h"
 #include "settingsform.h"

--- a/mzroll/mainwindow.h
+++ b/mzroll/mainwindow.h
@@ -336,7 +336,7 @@ public Q_SLOTS:
 	void updateEicSmoothingWindow(int value);
     bool setPeptideSequence(QString peptideSeq); //TODO: Sahil, Added while merging point
 	//Added when merging with Maven776 - Kiran
-	vector<mzSlice*> getSrmSlices(double q1tol, double q3tol, bool associateCompoundNames);
+	vector<mzSlice*> getSrmSlices(double q1tol, double q3tol, bool rtMatch, bool associateCompoundNames);
 
 	void open();
 	void print();

--- a/mzroll/settingsform.cpp
+++ b/mzroll/settingsform.cpp
@@ -332,3 +332,7 @@ void SettingsForm::setStringValue(QString key, QString value) {
      settings->setValue(key,value);
 }
 
+void SettingsForm::setIntValue(QString key, bool value) {
+      if(settings->contains(key)) qDebug() << "Changing " << key << " value to" << value;
+     settings->setValue(key,value);
+}

--- a/mzroll/settingsform.h
+++ b/mzroll/settingsform.h
@@ -28,6 +28,7 @@ class SettingsForm : public QDialog, public Ui_SettingsForm
                  void selectFile(QString key);
                  void  setNumericValue(QString key, double value);
                  void  setStringValue(QString key, QString value);
+                 void  setIntValue(QString key, bool value);
                  void updateMultiprocessing();
 
                  void setSettingsIonizationMode(QString);
@@ -45,6 +46,7 @@ class SettingsForm : public QDialog, public Ui_SettingsForm
                  inline void selectRawExtractor() {      selectFile("RawExtractProgram"); }
                  inline void setQ1Tollrance(double value) { setNumericValue("amuQ1",value); }
                  inline void setQ3Tollrance(double value) { setNumericValue("amuQ3",value); }
+                 inline void setRtMatch(int value)  { setIntValue("rtMatch",value);}
 
 
 

--- a/mzroll/treedockwidget.cpp
+++ b/mzroll/treedockwidget.cpp
@@ -434,12 +434,16 @@ void TreeDockWidget::setQQQToolBar() {
     associateCompounds->setToolTip(tr("Associate Compounds with MRM Transtions"));
     connect(associateCompounds,SIGNAL(clicked()),_mainWindow,SLOT(showSRMList()));
 
+    QCheckBox* rtMatch = new QCheckBox("Consider RT to find Best Match in Compounds", toolBar);
+    connect(rtMatch, SIGNAL(stateChanged(int)),_mainWindow->getSettingsForm(), SLOT(setRtMatch(int)));
+    connect(rtMatch, SIGNAL(stateChanged(int)),_mainWindow,SLOT(showSRMList()));
+
     toolBar->addWidget(new QLabel("Q1"));
     toolBar->addWidget(amuQ1);
     toolBar->addWidget(new QLabel("Q3"));
     toolBar->addWidget(amuQ3);
     toolBar->addWidget(associateCompounds);
-
+    toolBar->addWidget(rtMatch);
     setTitleBarWidget(toolBar);
 
 }


### PR DESCRIPTION
In targeted MS/MS, assigning the species(compound) to the SRMs :

1. Added rt-value as a deciding parameter to find the best match from Compound Database.
2. Made the above criteria optional. There is a checkbox on the "SRM Dock Widget" that user can use to specify whether or not to consider rt while finding the best match.
3. Shifter the logical code from mzroll to libmaven.
4. Added Documentation to the functions in the code.