### PR TITLE
Ftr: Add quantile filter for all peak filter parameters #267

### DIFF
--- a/MavenTests/testPeakDetection.cpp
+++ b/MavenTests/testPeakDetection.cpp
@@ -89,6 +89,52 @@ void TestPeakDetection::testprocessSlices() {
 
 }
 
+void TestPeakDetection::testquantileFilters() {
+    vector<PeakGroup> allgroups = common::getGroupsFromProcessCompounds();
+    PeakGroup group = allgroups[0];
+    vector<Peak> peaks = group.getPeaks();
+    PeakDetector peakDetector;
+    MavenParameters* mavenparameters = new MavenParameters();
+    mavenparameters->minIntensity = group.maxIntensity + 1;
+    peakDetector.setMavenParameters(mavenparameters);
+    QVERIFY(peakDetector.quantileFilters(&group) == true);
+
+    mavenparameters->minIntensity = -1;
+    mavenparameters->minSignalBaseLineRatio = group.maxSignalBaselineRatio + 1;
+    peakDetector.setMavenParameters(mavenparameters);
+    QVERIFY(peakDetector.quantileFilters(&group) == true);
+
+    ClassifierNeuralNet* clsf = new ClassifierNeuralNet();
+    string loadmodel = "bin/default.model";
+    clsf->loadModel(loadmodel);
+    mavenparameters->clsf = clsf;
+    mavenparameters->minIntensity = -1;
+    mavenparameters->minSignalBaseLineRatio = -1;
+    mavenparameters->minQuality = group.maxQuality + 1;
+    peakDetector.setMavenParameters(mavenparameters);
+    QVERIFY(peakDetector.quantileFilters(&group) == true);
+
+    mavenparameters->minIntensity = -1;
+    mavenparameters->minSignalBaseLineRatio = -1;
+    mavenparameters->minQuality = -1;
+    group.blankMax = 1;
+    mavenparameters->minSignalBlankRatio = group.maxIntensity + 1;
+    peakDetector.setMavenParameters(mavenparameters);
+    QVERIFY(peakDetector.quantileFilters(&group) == true);
+
+    mavenparameters->minIntensity = -1;
+    mavenparameters->minSignalBaseLineRatio = -1;
+    mavenparameters->minQuality = -1;
+    group.blankMax = 1;
+    mavenparameters->minSignalBlankRatio = -1;
+    mavenparameters->quantileIntensity = 0;
+    mavenparameters->quantileQuality = 0;
+    mavenparameters->quantileSignalBaselineRatio = 0;
+    mavenparameters->quantileSignalBlankRatio = 0;
+    peakDetector.setMavenParameters(mavenparameters);
+    QVERIFY(peakDetector.quantileFilters(&group) == false);
+}
+
 void TestPeakDetection::testpullIsotopes() {
     DBS.loadCompoundCSVFile(loadCompoundDB);
     vector<Compound*> compounds =

--- a/MavenTests/testPeakDetection.h
+++ b/MavenTests/testPeakDetection.h
@@ -34,6 +34,7 @@ class TestPeakDetection : public QObject {
         void testProcessCompound();
         void testPullEICs();
         void testprocessSlices();
+        void testquantileFilters();
 	void testpullIsotopes();
 };
 

--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -784,7 +784,7 @@ void PeakDetector::alignSamples() {
 }
 
 bool PeakDetector::quantileFilters(PeakGroup *group) {
-    if (group->maxIntensity < mavenParameters->minIntensity){
+    if (group->maxIntensity < mavenParameters->minGroupIntensity){
         return true;
     }
     if (group->maxSignalBaselineRatio < mavenParameters->minSignalBaseLineRatio) {
@@ -803,7 +803,7 @@ bool PeakDetector::quantileFilters(PeakGroup *group) {
     int peaksAboveBlankRatio = 0;
     int peaksAboveMinQuality = 0;
     for (int i = 0; i < peaks.size(); i++) {
-        if (peaks[i].peakIntensity > mavenParameters->minIntensity) {
+        if (peaks[i].peakIntensity > mavenParameters->minGroupIntensity) {
             peaksAboveMinIntensity++;
         }
         if (peaks[i].signalBaselineRatio > mavenParameters->minSignalBaseLineRatio) {

--- a/libmaven/PeakDetector.h
+++ b/libmaven/PeakDetector.h
@@ -122,8 +122,24 @@ public:
 	void processSlices(vector<mzSlice*>&slices, string setName);
 
 	/**
+	 * [apply signal/baseline percentage filter to group; if certain percentage of peaks in the group are above the user input threshold, do not reject the group]
+	 * @method signalBaselineQuantileFilter
+	 * @param  group        [pointer to PeakGroup]
+	 * @return [True if group has to be rejected, else False]
+	 */
+	bool signalBaselineQuantileFilter(PeakGroup *group);
+
+	/**
+	 * [apply signal/blank percentage filter to group; if certain percentage of peaks in the group are above the user input threshold, do not reject the group]
+	 * @method signalBlankQuantileFilter
+	 * @param group        [pointer to PeakGroup]
+	 * @return [True if group has to be rejected, else False]
+	 */
+	bool signalBlankQuantileFilter(PeakGroup *group);
+
+	/**
 	 * [process Compounds]
-	 * @method processSlices
+	 * @method processCompounds
 	 * @param  set        [vector of pointer to Compound]
 	 * @param  setName       [name of set]
 	 * @return [vector of pointer to mzSlice]

--- a/libmaven/PeakDetector.h
+++ b/libmaven/PeakDetector.h
@@ -122,20 +122,12 @@ public:
 	void processSlices(vector<mzSlice*>&slices, string setName);
 
 	/**
-	 * [apply signal/baseline percentage filter to group; if certain percentage of peaks in the group are above the user input threshold, do not reject the group]
-	 * @method signalBaselineQuantileFilter
+	 * [apply peak selection filters to group; if x percentage of peaks in the group are above the user input threshold for a parameter, do not reject the group]
+	 * @method quantileFilters
 	 * @param  group        [pointer to PeakGroup]
 	 * @return [True if group has to be rejected, else False]
 	 */
-	bool signalBaselineQuantileFilter(PeakGroup *group);
-
-	/**
-	 * [apply signal/blank percentage filter to group; if certain percentage of peaks in the group are above the user input threshold, do not reject the group]
-	 * @method signalBlankQuantileFilter
-	 * @param group        [pointer to PeakGroup]
-	 * @return [True if group has to be rejected, else False]
-	 */
-	bool signalBlankQuantileFilter(PeakGroup *group);
+	 bool quantileFilters(PeakGroup *group);
 
 	/**
 	 * [process Compounds]

--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -37,8 +37,8 @@ PeakGroup::PeakGroup()  {
     minQuality = 0.2;
     minIntensity = 0;
 
-    quantileIntensityPeaks = 0;
-    quantileQualityPeaks = 0;
+    //quantileIntensityPeaks = 0;
+    //quantileQualityPeaks = 0;
 
     expectedRtDiff=-1;
     expectedAbundance=0;
@@ -87,8 +87,8 @@ void PeakGroup::copyObj(const PeakGroup& o)  {
     blankSampleCount=o.blankSampleCount;
     blankMean=o.blankMean;
 
-    quantileIntensityPeaks = o.quantileIntensityPeaks;
-    quantileQualityPeaks = o.quantileQualityPeaks;
+    //quantileIntensityPeaks = o.quantileIntensityPeaks;
+    //quantileQualityPeaks = o.quantileQualityPeaks;
 
     sampleMax=o.sampleMax;
     sampleCount=o.sampleCount;
@@ -461,8 +461,8 @@ void PeakGroup::groupStatistics() {
     maxQuality=0;
     goodPeakCount=0;
     maxSignalBaselineRatio=0;
-    quantileIntensityPeaks;
-    quantileQualityPeaks;
+    //quantileIntensityPeaks;
+    //quantileQualityPeaks;
     int nonZeroCount=0;
 
     for(unsigned int i=0; i< peaks.size(); i++) {
@@ -483,8 +483,8 @@ void PeakGroup::groupStatistics() {
         if(peaks[i].peakIntensity > maxHeightIntensity) maxHeightIntensity = peaks[i].peakIntensity;
         if(peaks[i].peakArea > maxAreaNotCorrectedIntensity) maxAreaNotCorrectedIntensity = peaks[i].peakArea;
 
-        if(max > minIntensity) quantileIntensityPeaks++;
-        if(peaks[i].quality > minQuality) quantileQualityPeaks++;  
+        //if(max > minIntensity) quantileIntensityPeaks++;
+        //if(peaks[i].quality > minQuality) quantileQualityPeaks++;  
 
         if(max>maxIntensity) {
             maxIntensity = max;

--- a/libmaven/PeakGroup.h
+++ b/libmaven/PeakGroup.h
@@ -93,8 +93,8 @@ class PeakGroup{
 
         double minIntensity;
 
-        int quantileIntensityPeaks;
-        int quantileQualityPeaks;
+        //int quantileIntensityPeaks;
+        //int quantileQualityPeaks;
 
         float minRt;
         float maxRt;

--- a/libmaven/mavenparameters.cpp
+++ b/libmaven/mavenparameters.cpp
@@ -83,6 +83,8 @@ MavenParameters::MavenParameters() {
         
         quantileQuality = 0.0;
         quantileIntensity = 0.0;
+        quantileSignalBaselineRatio = 0.0;
+        quantileSignalBlankRatio = 0.0;
 
         //options dialog::peak grouping tab-widget
 	distXWeight = 1.0;

--- a/libmaven/mavenparameters.h
+++ b/libmaven/mavenparameters.h
@@ -111,6 +111,8 @@ public:
 	// For quantile intensity and qualityWeight
 	double quantileQuality;
 	double quantileIntensity;
+	double quantileSignalBaselineRatio;
+	double quantileSignalBlankRatio;
 
 	//mass slicing parameters
 	float mzBinStep;

--- a/mzroll/forms/peakdetectiondialog.ui
+++ b/mzroll/forms/peakdetectiondialog.ui
@@ -7,8 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>876</width>
-    <height>726</height>
+    <height>730</height>
    </rect>
+  </property>
+  <property name="sizeIncrement">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Peak Detection</string>
@@ -420,214 +426,6 @@
        <string>EIC Processing and Filtering</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_13">
-       <item row="1" column="0">
-        <widget class="QGroupBox" name="peakScroringOptions">
-         <property name="title">
-          <string>Peak Scoring and Filtering</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="6" column="1">
-           <widget class="QSpinBox" name="minNoNoiseObs">
-            <property name="suffix">
-             <string> scans</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>1000000000</number>
-            </property>
-            <property name="value">
-             <number>3</number>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Min. Signal/BaseLine Ratio</string>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="3">
-           <widget class="QPushButton" name="loadModelButton">
-            <property name="text">
-             <string>Load Model</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="minGroupIntensity">
-            <property name="maximumSize">
-             <size>
-              <width>502</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="suffix">
-             <string/>
-            </property>
-            <property name="maximum">
-             <double>999999999.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>1000000.000000000000000</double>
-            </property>
-            <property name="showGroupSeparator" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="1">
-           <widget class="QLineEdit" name="classificationModelFilename">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Min. Signal/Blank Ratio</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QComboBox" name="peakQuantitation">
-            <item>
-             <property name="text">
-              <string>AreaTop</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Area</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Height</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>AreaNotCorrected</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_27">
-            <property name="text">
-             <string>Atleast x% Peaks above Min. Peak Intensity   </string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0">
-           <widget class="QLabel" name="label_100">
-            <property name="text">
-             <string>Min. Good Peak / Group</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Min. Peak Intensity</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="1">
-           <widget class="QSpinBox" name="minGoodGroupCount">
-            <property name="suffix">
-             <string> peaks</string>
-            </property>
-            <property name="maximum">
-             <number>100000000</number>
-            </property>
-            <property name="value">
-             <number>1</number>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Peak Classifier Model File</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1">
-           <widget class="QSpinBox" name="sigBaselineRatio">
-            <property name="maximum">
-             <number>10000000</number>
-            </property>
-            <property name="value">
-             <number>2</number>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_12">
-            <property name="text">
-             <string>Min. Peak Width</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
-           <widget class="QDoubleSpinBox" name="sigBlankRatio">
-            <property name="maximum">
-             <double>10000000.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>2.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="quantileIntensity">
-            <property name="maximum">
-             <double>100.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_28">
-            <property name="text">
-             <string>Atleast x% Peaks above Min. Peak Quality</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="quantileQuality">
-            <property name="maximum">
-             <double>100.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="labelMinQuality">
-            <property name="text">
-             <string>Min. Quality</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="doubleSpinBoxMinQuality">
-            <property name="maximum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.500000000000000</double>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item row="0" column="0">
         <widget class="QGroupBox" name="eicOptions">
          <property name="enabled">
@@ -765,6 +563,278 @@
               </widget>
              </item>
             </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="peakScoringOptions">
+         <property name="title">
+          <string>Peak Scoring and Filtering</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Min. Peak Intensity</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QSpinBox" name="sigBaselineRatio">
+            <property name="maximum">
+             <number>10000000</number>
+            </property>
+            <property name="value">
+             <number>2</number>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="3">
+           <widget class="QSlider" name="quantileSignalBlankRatio">
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+            <property name="sliderPosition">
+             <number>0</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="tickPosition">
+             <enum>QSlider::TicksBelow</enum>
+            </property>
+            <property name="tickInterval">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QDoubleSpinBox" name="quantileQuality">
+            <property name="maximum">
+             <double>100.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Peak Classifier Model File</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="minGroupIntensity">
+            <property name="maximumSize">
+             <size>
+              <width>502</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="showGroupSeparator" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string/>
+            </property>
+            <property name="maximum">
+             <double>999999999.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>1000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_27">
+            <property name="text">
+             <string>Atleast x% Peaks above Min. Peak Intensity   </string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="2">
+           <widget class="QLabel" name="label_30">
+            <property name="text">
+             <string>S/BL Quantile</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Min. Signal/Blank Ratio</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Min. Signal/BaseLine Ratio</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_28">
+            <property name="text">
+             <string>Atleast x% Peaks above Min. Peak Quality</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="doubleSpinBoxMinQuality">
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.500000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QDoubleSpinBox" name="sigBlankRatio">
+            <property name="maximum">
+             <double>10000000.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>2.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="3">
+           <widget class="QPushButton" name="loadModelButton">
+            <property name="text">
+             <string>Load Model</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1">
+           <widget class="QLineEdit" name="classificationModelFilename">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="label_100">
+            <property name="text">
+             <string>Min. Good Peak / Group</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2">
+           <widget class="QLabel" name="label_29">
+            <property name="text">
+             <string>S/B Quantile</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelMinQuality">
+            <property name="text">
+             <string>Min. Quality</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QSpinBox" name="minGoodGroupCount">
+            <property name="suffix">
+             <string> peaks</string>
+            </property>
+            <property name="maximum">
+             <number>100000000</number>
+            </property>
+            <property name="value">
+             <number>1</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="quantileIntensity">
+            <property name="maximum">
+             <double>100.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Min. Peak Width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QComboBox" name="peakQuantitation">
+            <item>
+             <property name="text">
+              <string>AreaTop</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Area</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Height</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>AreaNotCorrected</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QSpinBox" name="minNoNoiseObs">
+            <property name="suffix">
+             <string> scans</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>1000000000</number>
+            </property>
+            <property name="value">
+             <number>3</number>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="3">
+           <widget class="QSlider" name="quantileSignalBaselineRatio">
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+            <property name="sliderPosition">
+             <number>0</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="invertedAppearance">
+             <bool>false</bool>
+            </property>
+            <property name="invertedControls">
+             <bool>true</bool>
+            </property>
+            <property name="tickPosition">
+             <enum>QSlider::TicksBelow</enum>
+            </property>
+            <property name="tickInterval">
+             <number>5</number>
+            </property>
            </widget>
           </item>
          </layout>

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -1932,9 +1932,15 @@ void MainWindow::readSettings() {
 
     if (!settings->contains("minSignalBaseLineRatio"))
         settings->setValue("minSignalBaseLineRatio", 2);
+	
+	if (!settings->contains("quantileSignalBaselineRatio"))
+		settings->setValue("quantileSignalBaselineRatio", 0.0);
 
     if (!settings->contains("minSignalBlankRatio"))
         settings->setValue("minSignalBlankRatio", 2);
+	
+	if (!settings->contains("quantileSignalBlankRatio"))
+		settings->setValue("quantileSignalBlankRatio", 0.0);
 
     if (!settings->contains("minGroupIntensity"))
         settings->setValue("minGroupIntensity", 5000);

--- a/mzroll/peakdetectiondialog.cpp
+++ b/mzroll/peakdetectiondialog.cpp
@@ -301,8 +301,12 @@ void PeakDetectionDialog::inputInitialValuesPeakDetectionDialog() {
                 settings->value("minNoNoiseObs").toDouble());  // minPeakWidth
             sigBaselineRatio->setValue(
                 settings->value("minSignalBaseLineRatio").toDouble());
+            quantileSignalBaselineRatio->setValue(
+                settings->value("quantileSignalBaselineRatio").toDouble());
             sigBlankRatio->setValue(
                 settings->value("minSignalBlankRatio").toDouble());
+            quantileSignalBlankRatio->setValue(
+                settings->value("quantileSignalBlankRatio").toDouble());
             minGroupIntensity->setValue(
                 settings->value("minGroupIntensity").toDouble());
             peakQuantitation->setCurrentIndex(
@@ -495,7 +499,9 @@ void PeakDetectionDialog::updateQSettingsWithUserInput(QSettings* settings) {
     settings->setValue("minGoodGroupCount", minGoodGroupCount->value());
     settings->setValue("minNoNoiseObs", minNoNoiseObs->value());
     settings->setValue("minSignalBaseLineRatio", sigBaselineRatio->value());
+    settings->setValue("quantileSignalBaselineRatio", quantileSignalBaselineRatio->value());
     settings->setValue("minSignalBlankRatio", sigBlankRatio->value());
+    settings->setValue("quantileSignalBlankRatio", quantileSignalBlankRatio->value());
     settings->setValue("minGroupIntensity", minGroupIntensity->value());
     settings->setValue("peakQuantitation", peakQuantitation->currentIndex());
     settings->setValue("quantileIntensity", quantileIntensity->value());
@@ -567,10 +573,14 @@ void PeakDetectionDialog::setMavenParameters(QSettings* settings) {
         mavenParameters->minGoodGroupCount = settings->value("minGoodGroupCount").toInt();
         mavenParameters->minNoNoiseObs = settings->value("minNoNoiseObs").toDouble();
         mavenParameters->minSignalBaseLineRatio = settings->value("minSignalBaseLineRatio").toDouble();
+        mavenParameters->quantileSignalBaselineRatio = settings->value("quantileSignalBaselineRatio").toDouble();
         mavenParameters->minSignalBlankRatio = settings->value("minSignalBlankRatio").toDouble();
+        mavenParameters->quantileSignalBlankRatio = settings->value("quantileSignalBlankRatio").toDouble();
         mavenParameters->minGroupIntensity = settings->value("minGroupIntensity").toDouble();
         mavenParameters->peakQuantitation = settings->value("peakQuantitation").toInt();
         mavenParameters->quantileIntensity = settings->value("quantileIntensity").toDouble();
+
+        //cerr << "Test: " << mavenParameters->quantileSignalBaselineRatio << endl;
 
         // Peak Group Rank
         mavenParameters->qualityWeight = settings->value("qualityWeight").toInt();


### PR DESCRIPTION
In peak filtering, a group is accepted if the group maximum for every
parameter is above the user input thresholds. This is being modified to
ensure that a group is accepted only if a minimum percentage of its peaks
lie above the thresholds; else the group is filtered out.

Quantile filters for Peak Intensity and Peak Quality already exist. They
have now been added for two more parameters:
- Signal/Baseline ratio
- Signal/Blank ratio
The remaining parameters do not require this addition

Issue: #267