### PR TITLE
Fix empty isotope EIC from mzroll #255

### DIFF
--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -1813,6 +1813,7 @@ PeakGroup* TableDockWidget::readGroupXML(QXmlStreamReader& xml,PeakGroup* parent
     if (parent) {
         parent->addChild(g);
         if (parent->children.size() > 0 ) {
+            _mainwindow->mavenParameters->isotopeAtom["ShowIsotopes"] = true;
             gp = &(parent->children[ parent->children.size()-1]);
             //cerr << parent << "\t addChild() " << gp << endl;
         }


### PR DESCRIPTION
Isotope EICs were not being populated from mzroll files because the flag for presence of isotope data was not being set before reading group data from mzroll. The appropriate change has been made.