### PR TITLE
Ftr: Assign MetagroupId for each Isotopic set of groups #266

### DIFF
--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -107,13 +107,16 @@ void PeakDetector::processSlice(mzSlice& slice) {
 }
 
 void PeakDetector::pullAllIsotopes() {
+    int mgId = 0;
     for (unsigned int j = 0; j < mavenParameters->allgroups.size(); j++) {
         if(mavenParameters->stop) break;
         PeakGroup& group = mavenParameters->allgroups[j];
         Compound* compound = group.compound;
 
-        if (mavenParameters->pullIsotopesFlag && !group.isIsotope())
+        if (mavenParameters->pullIsotopesFlag && !group.isIsotope()){
+            group.metaGroupId = ++mgId;
             pullIsotopes(&group);
+        }
 
         if (compound) {
             if (!compound->hasGroup() ||


### PR DESCRIPTION
MetagroupId for all the groups are zero all over the code.
So, we are aassigning them with some values starting from 1 as follows.

For each different parentGroup(for all the isotopic children groups),
get a new MetagroupId by incrementing. Thus, all the children of
that parent will also get the same MetagroupId.