### PR TITLE
Fix: Add axes in all sample comparison plots #297

### DIFF
--- a/mzroll/plotdock.cpp
+++ b/mzroll/plotdock.cpp
@@ -338,13 +338,16 @@ void PlotDockWidget::drawAxes() {
 	 //QPen pen3(Qt::red);
 	 //scene()->addRect(scene()->getPlotRect(),pen3,Qt::NoBrush);
 
-     PlotAxes* x= new PlotAxes(0,10,scene());
-	 x->setZValue(0);
-	 x->setOffset(0);
+     PlotAxes* xAxis= new PlotAxes(0,10,scene());
+	 xAxis->setZValue(0);
+	 xAxis->setOffset(0);
 
-     PlotAxes* y= new PlotAxes(1,10,scene());
-	 y->setZValue(0);
-	 y->setOffset(0);
+     PlotAxes* yAxis= new PlotAxes(1,10,scene());
+	 yAxis->setZValue(0);
+	 yAxis->setOffset(0);
+
+	 scene()->addItem(xAxis);
+	 scene()->addItem(yAxis);
 }
 
 

--- a/mzroll/scatterplot.cpp
+++ b/mzroll/scatterplot.cpp
@@ -178,7 +178,7 @@ void ScatterPlot::drawScatter(StatisticsVector<float>vecA,StatisticsVector<float
     scene()->setLogTransformed(true,true);
 
 	//draw x and y axes
-	drawAxes();
+    drawAxes();
 	scene()->showVLine(true);
 	scene()->showHLine(true);
     scene()->showXLabel("Sample Set 1");


### PR DESCRIPTION
X and Y axes scales have been made visible in scatter plot and flower plot widgets.

Issue: 297