### PR TITLE
delete isotopes from peak groups

### DIFF
--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -1,6 +1,7 @@
 #include "PeakGroup.h"
 #include "Compound.h"
 #include "mzSample.h"
+#include <iterator>
 
 PeakGroup::PeakGroup()  {
     groupId=0;
@@ -216,6 +217,8 @@ bool PeakGroup::deleteChild(PeakGroup* child ) {
     it = find(children.begin(),children.end(),child);
     if ( *it == child ) {
         cerr << "deleteChild: setting child to empty";
+        int index  = std::distance(children.begin(), it);
+        children.erase(children.begin()+index);
         child->clear();
         return true;
         //sort(children.begin(), children.end(),PeakGroup::compIntensity);

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -697,103 +697,23 @@ void TableDockWidget::exportGroupsToSpreadsheet() {
     LOGD;
     //Merged to Maven776 - Kiran
     // CSVReports* csvreport = new CSVReports;
-    vector<mzSample*> samples = _mainwindow->getSamples();
-    CSVReports* csvreports = new CSVReports(samples);
-    csvreports->setMavenParameters(_mainwindow->mavenParameters);
-    if (allgroups.size() == 0 ) {
-        QString msg = "Peaks Table is Empty";
-        QMessageBox::warning(this, tr("Error"), msg);
-        return;
-    }
-
-    QString dir = ".";
-    QSettings* settings = _mainwindow->getSettings();
-
-    if ( settings->contains("lastDir") ) dir = settings->value("lastDir").value<QString>();
-
-    QString groupsTAB = "Groups Summary Matrix Format (*.tab)";
-    QString groupsSTAB = "Groups Summary Matrix Format Without Set Name (*.tab)";    
-    QString peaksTAB =  "Peaks Detailed Format (*.tab)";
-    QString groupsCSV = "Groups Summary Matrix Format Comma Delimited (*.csv)";
-    QString groupsSCSV = "Groups Summary Matrix Format Comma Delimited Without Set Name (*.csv)";
-    QString peaksCSV =  "Peaks Detailed Format Comma Delimited (*.csv)";
-    //Added when Merging to Maven776 - Kiran
-    QString peaksListQE= "Inclusion List QE (*.csv)";
-    QString mascotMGF=   "Mascot Format MS2 Scans (*.mgf)";
-
-    QString sFilterSel;
-    QString fileName = QFileDialog::getSaveFileName(this, 
-            tr("Export Groups"), dir, 
-            groupsTAB + ";;" + groupsSTAB + ";;" + peaksTAB + ";;" + groupsCSV + ";;" + groupsSCSV + ";;" + peaksCSV + ";;" + peaksListQE + ";;" + mascotMGF,
-            &sFilterSel);
-
-    if(fileName.isEmpty()) return;
-
-    if ( sFilterSel == groupsCSV || sFilterSel == peaksCSV) {
-        if(!fileName.endsWith(".csv",Qt::CaseInsensitive)) fileName = fileName + ".csv";
-    }
-    if ( sFilterSel == groupsSCSV) {
-        if(!fileName.endsWith(".csv",Qt::CaseInsensitive)) fileName = fileName + ".csv";
-        cerr <<"csv without:";
-        csvreports->flag = 0;
-        cerr <<"csv without:1";
-    }
-    if ( sFilterSel == groupsTAB || sFilterSel == peaksTAB) {
-        if(!fileName.endsWith(".tab",Qt::CaseInsensitive)) fileName = fileName + ".tab";
-    }
-    if ( sFilterSel == groupsSTAB) {
-        cerr <<"tab without:";
-        if(!fileName.endsWith(".tab",Qt::CaseInsensitive)) fileName = fileName + ".tab";
-        csvreports->flag = 0;
-        cerr <<"tab without:1";
-    }
-    
-    if ( samples.size() == 0) return;
-
-    //Added when Merging to Maven776 - Kiran
-	if (sFilterSel == peaksListQE ) { 
-		writeQEInclusionList(fileName); 
-		return;
-    } else if (sFilterSel == mascotMGF ) {
-        writeMascotGeneric(fileName);
-        return;
-    }
-
-   
-    csvreports->setUserQuantType( _mainwindow->getUserQuantType() );
-
-    //Added to pass into csvreports file when merged with Maven776 - Kiran
-    bool includeSetNamesLines=true;
-
-    if (sFilterSel == groupsCSV) {
-        csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
-    } else if (sFilterSel == groupsTAB )  {
-        csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
-    } else if (sFilterSel == peaksCSV )  {
-        csvreports->openPeakReport(fileName.toStdString());
-    } else if (sFilterSel == peaksTAB )  {
-        csvreports->openPeakReport(fileName.toStdString());
-    } else { 	//default to group summary
-        //Updated when csvreports file was merged with Maven776 - Kiran
-        csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
-    }
-
-    QList<PeakGroup*> selectedGroups = getSelectedGroups();
-    csvreports->setSelectionFlag(static_cast<int>(peakTableSelection));
-
-    for(int i=0; i<allgroups.size(); i++ ) {
-        if (selectedGroups.contains(&allgroups[i])) {
-            PeakGroup& group = allgroups[i];
-            csvreports->addGroup(&group);
+    CSVReports* csvreports = prepareCsvReport();
+    if(csvreports) {
+        QList<PeakGroup*> selectedGroups = getSelectedGroups();
+        for(int i=0; i<allgroups.size(); i++ ) {
+            if (selectedGroups.contains(&allgroups[i])) {
+                PeakGroup& group = allgroups[i];
+                csvreports->addGroup(&group);
+            }
         }
-    }
-    csvreports->closeFiles();
+        csvreports->closeFiles();
 
-    if (csvreports->getErrorReport() != "") {
-        QMessageBox msgBox(_mainwindow);
-        msgBox.setIcon(QMessageBox::Critical);
-        msgBox.setText(csvreports->getErrorReport());
-        msgBox.exec();
+        if (csvreports->getErrorReport() != "") {
+            QMessageBox msgBox(_mainwindow);
+            msgBox.setIcon(QMessageBox::Critical);
+            msgBox.setText(csvreports->getErrorReport());
+            msgBox.exec();
+        }
     }
 }
 

--- a/mzroll/tabledockwidget.h
+++ b/mzroll/tabledockwidget.h
@@ -16,6 +16,7 @@ class AlignmentVizWidget;
 class TrainDialog;
 class ClusterDialog;
 class NumericTreeWidgetItem;
+class CSVReports;
 using namespace std;
 
 class TableDockWidget: public QDockWidget {
@@ -76,6 +77,7 @@ public Q_SLOTS:
       //output to csv file
       //Added when Merging to Maven776 - Kiran
       void exportGroupsToSpreadsheet();
+      void exportAllGroups();
     void showTrainDialog();
     void showClusterDialog();
     inline void selectedPeakSet() {
@@ -167,6 +169,7 @@ private:
 	  void readPeakXML(QXmlStreamReader& xml,PeakGroup* parent);
 	  void setupFiltersDialog();
 	  QString groupTagString(PeakGroup* group);
+      CSVReports* prepareCsvReport();
 
           QList<PeakGroup>allgroups;
 


### PR DESCRIPTION

fix: delete isotopes from peak groups when removing them from table dock widget

This will make sure that deleted isotopes are not exported to csv file

Issue: #261