### PR TITLE
Fix: Keep focus line at expectedRt #288

### DIFF
--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -214,7 +214,7 @@ void EicWidget::mouseDoubleClickEvent(QMouseEvent* event) {
 	}
 
 	if (selScan != NULL) { 
-        setFocusLine(selScan->rt);
+        //setFocusLine(selScan->rt);
         Q_EMIT(scanChanged(selScan)); //TODO: Sahil, added while merging eicwidget
 	}
 }


### PR DESCRIPTION
- The red focus line in the EIC widget marks the expectedRt for a group.
- It does not get repositioned to the scan Rt on bookmarking a peak.

Issue: #288