### PR TITLE
keep track of the samples used while peak detection

### DIFF
--- a/libmaven/EIC.cpp
+++ b/libmaven/EIC.cpp
@@ -823,14 +823,14 @@ bool EIC::makeEICSlice(mzSample* sample, float mzmin,float mzmax, float rtmin, f
             }
             
             case EIC::SUM: {
-                int n = 0;
+                float n = 0;
                 for(unsigned int scanIdx = lb; scanIdx < scan->nobs(); scanIdx++ ) {
                     if (scan->mz[scanIdx] < mzmin) continue;
                     if (scan->mz[scanIdx] > mzmax) break;
 
                     eicIntensity += scan->intensity[scanIdx];
-                    eicMz += scan->mz[scanIdx];
-                    n++;
+                    eicMz += scan->mz[scanIdx] * scan->intensity[scanIdx];
+                    n += scan->intensity[scanIdx];
                 }
                 eicMz /= n;
                 break;

--- a/libmaven/EIC.cpp
+++ b/libmaven/EIC.cpp
@@ -822,6 +822,8 @@ bool EIC::makeEICSlice(mzSample* sample, float mzmin,float mzmax, float rtmin, f
                 break;
             }
             
+            //calculate the weighted average(with intensities as weights) 
+            //while finding the eicMz for the whole EIC.
             case EIC::SUM: {
                 float n = 0;
                 for(unsigned int scanIdx = lb; scanIdx < scan->nobs(); scanIdx++ ) {

--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -355,7 +355,7 @@ void PeakDetector::pullIsotopesBarPlot(PeakGroup* parentgroup) {
                     mavenParameters->eic_smoothingAlgorithm);
             eic->setBaselineSmoothingWindow(mavenParameters->baseline_smoothingWindow);
             eic->setBaselineDropTopX(mavenParameters->baseline_dropTopX);
-            eic->setFilterSignalBaselineDiff(mavenParameters->minSignalBaselineDifference);
+            eic->setFilterSignalBaselineDiff(mavenParameters->isotopicMinSignalBaselineDifference);
             eic->getPeakPositions(mavenParameters->eic_smoothingWindow);
             //TODO: this could be optimized to not bother finding peaks outside of
             //maxIsotopeScanDiff window

--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -573,7 +573,7 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
                     mavenParameters->eic_smoothingAlgorithm);
             eic->setBaselineSmoothingWindow(mavenParameters->baseline_smoothingWindow);
             eic->setBaselineDropTopX(mavenParameters->baseline_dropTopX);
-            eic->setFilterSignalBaselineDiff(mavenParameters->minSignalBaselineDifference);
+            eic->setFilterSignalBaselineDiff(mavenParameters->isotopicMinSignalBaselineDifference);
             eic->getPeakPositions(mavenParameters->eic_smoothingWindow);
             //TODO: this needs be optimized to not bother finding peaks outside of
             //maxIsotopeScanDiff window

--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -237,7 +237,13 @@ vector<float> PeakGroup::getOrderedIntensityVector(vector<mzSample*>& samples, Q
 
     for( unsigned int j=0; j < samples.size(); j++) {
         sampleOrder[samples[j]]=j;
-        maxIntensity[j]=0;
+        // check if the the sample was used while peak detection or not
+        // samplesUsed is populate during peakDetection
+        auto it = std::find(std::begin(samplesUsed), std::end(samplesUsed), samples[j]);
+        if(it != std::end(samplesUsed))
+            maxIntensity[j]=0;
+        else
+            maxIntensity[j] = -1;
     }
 
     for( unsigned int j=0; j < peaks.size(); j++) {
@@ -261,7 +267,15 @@ vector<float> PeakGroup::getOrderedIntensityVector(vector<mzSample*>& samples, Q
 
             //normalize
             if(sample) y *= sample->getNormalizationConstant();
-            if(maxIntensity[s] < y) { maxIntensity[s] = y; }
+            if(maxIntensity[s] < y) {
+                // check if the the sample was used while peak detection or not
+                // samplesUsed is populate during peakDetection
+                auto it = std::find(std::begin(samplesUsed), std::end(samplesUsed), sample);
+                if(it != std::end(samplesUsed))
+                    maxIntensity[s]=y;
+                else
+                    maxIntensity[s] = -1;
+            }
         }
     }
     return maxIntensity;

--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -1,6 +1,7 @@
 #include "PeakGroup.h"
 #include "Compound.h"
 #include "mzSample.h"
+#include <iterator>
 
 PeakGroup::PeakGroup()  {
     groupId=0;
@@ -215,6 +216,8 @@ bool PeakGroup::deleteChild(PeakGroup* child ) {
     it = find(children.begin(),children.end(),child);
     if ( *it == child ) {
         cerr << "deleteChild: setting child to empty";
+        int index  = std::distance(children.begin(), it);
+        children.erase(children.begin()+index);
         child->clear();
         return true;
         //sort(children.begin(), children.end(),PeakGroup::compIntensity);

--- a/libmaven/PeakGroup.h
+++ b/libmaven/PeakGroup.h
@@ -62,6 +62,7 @@ class PeakGroup{
         deque<PeakGroup> children;
         deque<PeakGroup> childrenBarPlot;
         deque<PeakGroup> childrenIsoWidget;
+        vector<mzSample*> samplesUsed;
 
         string srmId;
         string tagString;

--- a/libmaven/csvreports.cpp
+++ b/libmaven/csvreports.cpp
@@ -62,7 +62,7 @@ void CSVReports::insertGroupReportColumnNamesintoCSVFile(string outputfile,bool 
         QStringList groupReportcolnames;
         groupReportcolnames << "label" << "metaGroupId" << "groupId" << "goodPeakCount"
                 << "medMz" << "medRt" << "maxQuality" << "note" << "compound"
-                << "compoundId" << "expectedRtDiff" << "ppmDiff" << "parent";
+                << "compoundId" << "formula" << "expectedRtDiff" << "ppmDiff" << "parent";
         QString header = groupReportcolnames.join(SEP.c_str());
         groupReport << header.toStdString();
         for (unsigned int i = 0; i < samples.size(); i++) {
@@ -87,7 +87,7 @@ void CSVReports::insertPeakReportColumnNamesintoCSVFile(){
 
     if (peakReport.is_open()) {
         QStringList peakReportcolnames;
-        peakReportcolnames << "groupId" << "compound" << "compoundId" << "sample" << "peakMz"
+        peakReportcolnames << "groupId" << "compound" << "compoundId" << "formula" << "sample" << "peakMz"
                 << "medianMz" << "baseMz" << "rt" << "rtmin" << "rtmax" << "quality"
                 << "peakIntensity" << "peakArea" << "peakAreaTop"
                 << "peakAreaCorrected" << "peakAreaTopCorrected"
@@ -275,6 +275,7 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
 
     string compoundName;
     string compoundID;
+    string formula;
     // TODO: Added this while merging this file
     string categoryString;
     float expectedRtDiff = 0;
@@ -285,6 +286,7 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         compoundName = sanitizeString(group->compound->name.c_str()).toStdString();
         // TODO: Added this while merging this file
         compoundID   = sanitizeString(group->compound->id.c_str()).toStdString();
+        formula = sanitizeString(group->compound->formula.c_str()).toStdString();
         ppmDist = mzUtils::ppmDist((double) group->compound->mass,
                 (double) group->meanMz);
         expectedRtDiff = group->expectedRtDiff;
@@ -299,6 +301,7 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
 
     groupReport << SEP << compoundName;
     groupReport << SEP << compoundID;
+    groupReport << SEP << formula;
     //groupReport << SEP << categoryString;
     groupReport << SEP << expectedRtDiff;
     groupReport << SEP << ppmDist;
@@ -320,11 +323,13 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
         return;
     string compoundName = "";
     string compoundID = "";
+    string formula = "";
 
     if (group->compound != NULL) {
         // TODO: Added this while merging this file
         compoundName = sanitizeString(group->compound->name.c_str()).toStdString();
         compoundID   = sanitizeString(group->compound->id.c_str()).toStdString();
+        formula = sanitizeString(group->compound->formula.c_str()).toStdString();
     }
 
     if (selectionFlag == 2) {
@@ -352,6 +357,7 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
                 << groupId << SEP
                 << compoundName << SEP
                 << compoundID << SEP
+                << formula << SEP
                 << sampleName << SEP
                 << peak.peakMz <<  SEP
                 << peak.medianMz <<  SEP

--- a/libmaven/csvreports.cpp
+++ b/libmaven/csvreports.cpp
@@ -240,7 +240,6 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         return;
     groupId++;
 
-
     char lab;
     lab = group->label;
 
@@ -312,8 +311,14 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         groupReport << SEP << group->meanMz;
     }
 
-    for (unsigned int j = 0; j < samples.size(); j++)
-        groupReport << SEP << yvalues[j];
+
+    for (unsigned int j = 0; j < samples.size(); j++){
+        // -1 value means a particular sample was not used in peak detection
+        if(yvalues[j] == -1)
+            groupReport << SEP << "NA";
+        else
+            groupReport << SEP << yvalues[j];
+    }
     groupReport << endl;
 
 }

--- a/libmaven/mavenparameters.cpp
+++ b/libmaven/mavenparameters.cpp
@@ -33,6 +33,7 @@ MavenParameters::MavenParameters() {
         baseline_smoothingWindow = 5;
         baseline_dropTopX = 80;
         minSignalBaselineDifference = 0;
+        isotopicMinSignalBaselineDifference=0;
 
         eicType = 0;
 

--- a/libmaven/mavenparameters.h
+++ b/libmaven/mavenparameters.h
@@ -131,6 +131,7 @@ public:
 	int baseline_dropTopX;
 
 	double minSignalBaselineDifference;
+	double isotopicMinSignalBaselineDifference;
 
 	int eicType;
 

--- a/libmaven/mzSample.cpp
+++ b/libmaven/mzSample.cpp
@@ -988,6 +988,8 @@ EIC* mzSample::getEIC(float precursorMz, float collisionEnergy, float productMz,
 						break;
 					}
 					
+                                        //calculate the weighted average(with intensities as weights) 
+                                        //while finding the eicMz for the whole EIC.
 					case EIC::SUM: {
 						float n = 0;
 						for(unsigned int k=0; k < scan->nobs(); k++) {
@@ -1074,6 +1076,8 @@ EIC* mzSample::getEIC(string srm, int eicType) {
 								break;
 							}
 							
+                                                        //calculate the weighted average(with intensities as weights) 
+                                                        //while finding the eicMz for the whole EIC.
 							case EIC::SUM: {
 								float n = 0;
 								for(unsigned int k=0; k < scan->nobs(); k++) {

--- a/libmaven/mzSample.cpp
+++ b/libmaven/mzSample.cpp
@@ -989,11 +989,11 @@ EIC* mzSample::getEIC(float precursorMz, float collisionEnergy, float productMz,
 					}
 					
 					case EIC::SUM: {
-						int n = 0;
+						float n = 0;
 						for(unsigned int k=0; k < scan->nobs(); k++) {
 							eicIntensity += scan->intensity[k];
-							eicMz += scan->mz[k];
-							n++;
+							eicMz += (scan->mz[k]) * (scan->intensity[k]);
+							n+=scan->intensity[k];
 						}
 
 						eicMz /= n;
@@ -1075,10 +1075,11 @@ EIC* mzSample::getEIC(string srm, int eicType) {
 							}
 							
 							case EIC::SUM: {
-								int n = 0;
+								float n = 0;
 								for(unsigned int k=0; k < scan->nobs(); k++) {
 									eicIntensity += scan->intensity[k];
-									eicMz += scan->mz[k];
+									eicMz += (scan->mz[k]) * (scan->intensity[k]);
+                                                                        n += scan->intensity[k];
 								}
 
 								eicMz /= n;

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -214,7 +214,7 @@ void EicWidget::mouseDoubleClickEvent(QMouseEvent* event) {
 	}
 
 	if (selScan != NULL) { 
-        setFocusLine(selScan->rt);
+        //setFocusLine(selScan->rt);
         Q_EMIT(scanChanged(selScan)); //TODO: Sahil, added while merging eicwidget
 	}
 }

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -375,7 +375,10 @@ void EicWidget::findPlotBounds() {
 			}
 		}
 	}
-
+	float mx=0;
+	for(int i=0;i<eicParameters->eics.size();++i)
+			mx=max(mx,eicParameters->eics[i]->maxIntensity);
+	if(_maxY==0) _maxY=mx;
 	//if(_minY <= 0) _minY = 0;
 	_maxY = (_maxY * 1.3) + 1;
 	if (_minX > _maxX)

--- a/mzroll/forms/settingsform.ui
+++ b/mzroll/forms/settingsform.ui
@@ -834,7 +834,7 @@
            <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Droid Sans Mono,Courier New,monospace,Droid Sans Fallback'; font-size:11pt; color:#000000;&quot;&gt;score = 1.0/((distX*A)+0.01)/((distY*B)+0.01)*(C*overlap)&lt;/span&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;where&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	distX = Rt difference of peaks being compared&lt;/span&gt;&lt;/p&gt;
@@ -852,7 +852,7 @@ p, li { white-space: pre-wrap; }
            <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Droid Sans Mono,Courier New,monospace,Droid Sans Fallback'; font-size:11pt; color:#000000;&quot;&gt;score = 1.0/((distX*A)+0.01)/((distY*B)+0.01)&lt;/span&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;where&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	distX = Rt difference of peaks being compared&lt;/span&gt;&lt;/p&gt;
@@ -1015,7 +1015,7 @@ p, li { white-space: pre-wrap; }
          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;Group Rank = ((1.1 - Q)^A) * (1 /( log(I + 1))^B) * (dRT)^(2*C)&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
@@ -1046,7 +1046,7 @@ p, li { white-space: pre-wrap; }
          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;Group Rank = ((1.1 - Q)^A) * (1 /( log(I + 1))^B) &lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;

--- a/mzroll/forms/settingsform.ui
+++ b/mzroll/forms/settingsform.ui
@@ -741,6 +741,12 @@
           </item>
           <item row="4" column="1">
            <widget class="QDoubleSpinBox" name="isotopicMinSignalBaselineDifference">
+            <property name="font">
+             <font>
+              <family>Ubuntu</family>
+              <pointsize>11</pointsize>
+             </font>
+            </property>
             <property name="maximum">
              <double>100000000000000000000.000000000000000</double>
             </property>

--- a/mzroll/forms/settingsform.ui
+++ b/mzroll/forms/settingsform.ui
@@ -23,7 +23,7 @@
    <item row="1" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="instrumentationOptions">
       <attribute name="title">
@@ -732,10 +732,24 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="2">
+          <item row="5" column="0" colspan="2">
            <widget class="QCheckBox" name="isotopeC13Correction">
             <property name="text">
              <string>Correct for Natural C13 Isotope Abundance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="isotopicMinSignalBaselineDifference">
+            <property name="maximum">
+             <double>100000000000000000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_35">
+            <property name="text">
+             <string>Min. Signal Baseline Difference</string>
             </property>
            </widget>
           </item>
@@ -814,15 +828,15 @@
            <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Droid Sans Mono,Courier New,monospace,Droid Sans Fallback'; font-size:14px; color:#000000;&quot;&gt;score = 1.0/((distX*A)+0.01)/((distY*B)+0.01)*(C*overlap)&lt;/span&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;where&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	distX = Rt difference of peaks being compared&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	A = Weight of distX&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	distY = Difference between peak Intensities&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	B = Weight of distY&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	overlap = Overlap of peaks (between 0 to 1)&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	C = Overlap weight&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Droid Sans Mono,Courier New,monospace,Droid Sans Fallback'; font-size:11pt; color:#000000;&quot;&gt;score = 1.0/((distX*A)+0.01)/((distY*B)+0.01)*(C*overlap)&lt;/span&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;where&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	distX = Rt difference of peaks being compared&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	A = Weight of distX&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	distY = Difference between peak Intensities&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	B = Weight of distY&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	overlap = Overlap of peaks (between 0 to 1)&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	C = Overlap weight&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
@@ -832,13 +846,13 @@ p, li { white-space: pre-wrap; }
            <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Droid Sans Mono,Courier New,monospace,Droid Sans Fallback'; color:#000000;&quot;&gt;score = 1.0/((distX*A)+0.01)/((distY*B)+0.01)&lt;/span&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;where&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	distX = Rt difference of peaks being compared&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	A = Weight of distX&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	distY = Difference between peak Intensities&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	B = Weight of distY&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Droid Sans Mono,Courier New,monospace,Droid Sans Fallback'; font-size:11pt; color:#000000;&quot;&gt;score = 1.0/((distX*A)+0.01)/((distY*B)+0.01)&lt;/span&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;where&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	distX = Rt difference of peaks being compared&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	A = Weight of distX&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	distY = Difference between peak Intensities&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	B = Weight of distY&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
@@ -995,22 +1009,22 @@ p, li { white-space: pre-wrap; }
          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Group Rank = ((1.1 - Q)^A) * (1 /( log(I + 1))^B) * (dRT)^(2*C)&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Where   &lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                Q =  Quality of a group &lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                A =  Quality Weightage&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                I  =  Intensity of a group   &lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;               B =  Intensity Weightage&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;               dRT = Difference between compound retention time and group mean retention time&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;               C =  dRT Weightage&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;Group Rank = ((1.1 - Q)^A) * (1 /( log(I + 1))^B) * (dRT)^(2*C)&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;Where   &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                Q =  Quality of a group &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                A =  Quality Weightage&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                I  =  Intensity of a group   &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;               B =  Intensity Weightage&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;               dRT = Difference between compound retention time and group mean retention time&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;               C =  dRT Weightage&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
        <widget class="QTextBrowser" name="formulaWithoutRt">
@@ -1026,18 +1040,18 @@ p, li { white-space: pre-wrap; }
          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Group Rank = ((1.1 - Q)^A) * (1 /( log(I + 1))^B) &lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Where   &lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                Q =  Quality of a group &lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                A =  Quality Weightage&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                I  =  Intensity of a group   &lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;               B =  Intensity Weightage&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;Group Rank = ((1.1 - Q)^A) * (1 /( log(I + 1))^B) &lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;Where   &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                Q =  Quality of a group &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                A =  Quality Weightage&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                I  =  Intensity of a group   &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;               B =  Intensity Weightage&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </widget>

--- a/mzroll/mainwindow.cpp
+++ b/mzroll/mainwindow.cpp
@@ -1925,6 +1925,8 @@ void MainWindow::readSettings() {
 
     if (!settings->contains("minSignalBaselineDifference"))
         settings->setValue("minSignalBaselineDifference", 0);
+    if(!settings->contains("isotopicMinSignalBaselineDifference"))
+	   	settings->setValue("isotopicMinSignalBaselineDifference",0);
 
 	if (!settings->contains("minQuality"))
         settings->setValue("minQuality", 0.50);

--- a/mzroll/plotdock.cpp
+++ b/mzroll/plotdock.cpp
@@ -338,13 +338,16 @@ void PlotDockWidget::drawAxes() {
 	 //QPen pen3(Qt::red);
 	 //scene()->addRect(scene()->getPlotRect(),pen3,Qt::NoBrush);
 
-     PlotAxes* x= new PlotAxes(0,10,scene());
-	 x->setZValue(0);
-	 x->setOffset(0);
+     PlotAxes* xAxis= new PlotAxes(0,10,scene());
+	 xAxis->setZValue(0);
+	 xAxis->setOffset(0);
 
-     PlotAxes* y= new PlotAxes(1,10,scene());
-	 y->setZValue(0);
-	 y->setOffset(0);
+     PlotAxes* yAxis= new PlotAxes(1,10,scene());
+	 yAxis->setZValue(0);
+	 yAxis->setOffset(0);
+
+	 scene()->addItem(xAxis);
+	 scene()->addItem(yAxis);
 }
 
 

--- a/mzroll/projectdockwidget.cpp
+++ b/mzroll/projectdockwidget.cpp
@@ -926,6 +926,19 @@ void ProjectDockWidget::unloadSample(mzSample* sample) {
     Q_FOREACH(peaksTable, peaksTableList) {
         PeakGroup* grp;
         Q_FOREACH(grp, peaksTable->getGroups()) {
+
+            auto it = std::find(std::begin(grp->samplesUsed), std::end(grp->samplesUsed), sample);
+            if(it != std::end(grp->samplesUsed)){
+                grp->samplesUsed.erase(it);
+            }
+
+            for(PeakGroup& childGrp: grp->children) {
+                auto it = std::find(std::begin(childGrp.samplesUsed), std::end(childGrp.samplesUsed), sample);
+                if(it != std::end(childGrp.samplesUsed)){
+                    childGrp.samplesUsed.erase(it);
+                }
+            }
+
             vector<Peak>& peaks = grp->getPeaks();
             for(unsigned int j=0; j< peaks.size(); j++) {
                 Peak p = peaks.at(j);

--- a/mzroll/scatterplot.cpp
+++ b/mzroll/scatterplot.cpp
@@ -178,7 +178,7 @@ void ScatterPlot::drawScatter(StatisticsVector<float>vecA,StatisticsVector<float
     scene()->setLogTransformed(true,true);
 
 	//draw x and y axes
-	drawAxes();
+    drawAxes();
 	scene()->showVLine(true);
 	scene()->showHLine(true);
     scene()->showXLabel("Sample Set 1");

--- a/mzroll/settingsform.cpp
+++ b/mzroll/settingsform.cpp
@@ -17,6 +17,7 @@ SettingsForm::SettingsForm(QSettings* s, MainWindow *w): QDialog(w) {
     connect(baseline_smoothing, SIGNAL(valueChanged(int)), SLOT(recomputeEIC()));
     connect(baseline_quantile, SIGNAL(valueChanged(int)), SLOT(recomputeEIC()));
     connect(minSignalBaselineDifference, SIGNAL(valueChanged(double)), SLOT(recomputeEIC()));
+    connect(isotopicMinSignalBaselineDifference, SIGNAL(valueChanged(double)), SLOT(recomputeEIC()));
 
     connect(ionizationMode, SIGNAL(currentIndexChanged(int)), SLOT(getFormValues()));
     connect(ionizationMode, SIGNAL(currentIndexChanged(QString)), mainwindow, SLOT(setQComboBox()));

--- a/mzroll/settingsform.cpp
+++ b/mzroll/settingsform.cpp
@@ -227,7 +227,7 @@ void SettingsForm::updateSettingFormGUI() {
     baseline_smoothing->setValue(settings->value("baseline_smoothing").toInt());
     baseline_quantile->setValue(settings->value("baseline_quantile").toInt());
     minSignalBaselineDifference->setValue(settings->value("minSignalBaselineDifference").toInt());
-
+    isotopicMinSignalBaselineDifference->setValue(settings->value("isotopicMinSignalBaselineDifference").toInt());
     //Upload Multiprocessing
     checkBoxMultiprocessing->setCheckState( (Qt::CheckState) settings->value("uploadMultiprocessing").toInt() );
 
@@ -318,7 +318,8 @@ void SettingsForm::getFormValues() {
     settings->setValue("maxIsotopeScanDiff",maxIsotopeScanDiff->value());
     settings->setValue("minIsotopicCorrelation",minIsotopicCorrelation->value());
     settings->setValue("minSignalBaselineDifference", minSignalBaselineDifference->value());
-    
+    settings->setValue("isotopicMinSignalBaselineDifference",isotopicMinSignalBaselineDifference->value());
+
     /*Isotopic settings for barplot*/
     settings->setValue("C13Labeled_Barplot", C13Labeled_Barplot->checkState());
     settings->setValue("N15Labeled_Barplot", N15Labeled_Barplot->checkState());
@@ -471,6 +472,8 @@ void SettingsForm::setMavenParameters() {
         mavenParameters->baseline_smoothingWindow = settings->value("baseline_smoothing").toDouble();
         mavenParameters->baseline_dropTopX = settings->value("baseline_quantile").toDouble();
         mavenParameters->minSignalBaselineDifference = settings->value("minSignalBaselineDifference").toDouble();
+        mavenParameters->isotopicMinSignalBaselineDifference=settings->value("isotopicMinSignalBaselineDifference").toDouble();
+
     }
 }
 

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -695,103 +695,23 @@ void TableDockWidget::exportGroupsToSpreadsheet() {
     LOGD;
     //Merged to Maven776 - Kiran
     // CSVReports* csvreport = new CSVReports;
-    vector<mzSample*> samples = _mainwindow->getSamples();
-    CSVReports* csvreports = new CSVReports(samples);
-    csvreports->setMavenParameters(_mainwindow->mavenParameters);
-    if (allgroups.size() == 0 ) {
-        QString msg = "Peaks Table is Empty";
-        QMessageBox::warning(this, tr("Error"), msg);
-        return;
-    }
-
-    QString dir = ".";
-    QSettings* settings = _mainwindow->getSettings();
-
-    if ( settings->contains("lastDir") ) dir = settings->value("lastDir").value<QString>();
-
-    QString groupsTAB = "Groups Summary Matrix Format (*.tab)";
-    QString groupsSTAB = "Groups Summary Matrix Format Without Set Name (*.tab)";    
-    QString peaksTAB =  "Peaks Detailed Format (*.tab)";
-    QString groupsCSV = "Groups Summary Matrix Format Comma Delimited (*.csv)";
-    QString groupsSCSV = "Groups Summary Matrix Format Comma Delimited Without Set Name (*.csv)";
-    QString peaksCSV =  "Peaks Detailed Format Comma Delimited (*.csv)";
-    //Added when Merging to Maven776 - Kiran
-    QString peaksListQE= "Inclusion List QE (*.csv)";
-    QString mascotMGF=   "Mascot Format MS2 Scans (*.mgf)";
-
-    QString sFilterSel;
-    QString fileName = QFileDialog::getSaveFileName(this, 
-            tr("Export Groups"), dir, 
-            groupsTAB + ";;" + groupsSTAB + ";;" + peaksTAB + ";;" + groupsCSV + ";;" + groupsSCSV + ";;" + peaksCSV + ";;" + peaksListQE + ";;" + mascotMGF,
-            &sFilterSel);
-
-    if(fileName.isEmpty()) return;
-
-    if ( sFilterSel == groupsCSV || sFilterSel == peaksCSV) {
-        if(!fileName.endsWith(".csv",Qt::CaseInsensitive)) fileName = fileName + ".csv";
-    }
-    if ( sFilterSel == groupsSCSV) {
-        if(!fileName.endsWith(".csv",Qt::CaseInsensitive)) fileName = fileName + ".csv";
-        cerr <<"csv without:";
-        csvreports->flag = 0;
-        cerr <<"csv without:1";
-    }
-    if ( sFilterSel == groupsTAB || sFilterSel == peaksTAB) {
-        if(!fileName.endsWith(".tab",Qt::CaseInsensitive)) fileName = fileName + ".tab";
-    }
-    if ( sFilterSel == groupsSTAB) {
-        cerr <<"tab without:";
-        if(!fileName.endsWith(".tab",Qt::CaseInsensitive)) fileName = fileName + ".tab";
-        csvreports->flag = 0;
-        cerr <<"tab without:1";
-    }
-    
-    if ( samples.size() == 0) return;
-
-    //Added when Merging to Maven776 - Kiran
-	if (sFilterSel == peaksListQE ) { 
-		writeQEInclusionList(fileName); 
-		return;
-    } else if (sFilterSel == mascotMGF ) {
-        writeMascotGeneric(fileName);
-        return;
-    }
-
-   
-    csvreports->setUserQuantType( _mainwindow->getUserQuantType() );
-
-    //Added to pass into csvreports file when merged with Maven776 - Kiran
-    bool includeSetNamesLines=true;
-
-    if (sFilterSel == groupsCSV) {
-        csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
-    } else if (sFilterSel == groupsTAB )  {
-        csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
-    } else if (sFilterSel == peaksCSV )  {
-        csvreports->openPeakReport(fileName.toStdString());
-    } else if (sFilterSel == peaksTAB )  {
-        csvreports->openPeakReport(fileName.toStdString());
-    } else { 	//default to group summary
-        //Updated when csvreports file was merged with Maven776 - Kiran
-        csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
-    }
-
-    QList<PeakGroup*> selectedGroups = getSelectedGroups();
-    csvreports->setSelectionFlag(static_cast<int>(peakTableSelection));
-
-    for(int i=0; i<allgroups.size(); i++ ) {
-        if (selectedGroups.contains(&allgroups[i])) {
-            PeakGroup& group = allgroups[i];
-            csvreports->addGroup(&group);
+    CSVReports* csvreports = prepareCsvReport();
+    if(csvreports) {
+        QList<PeakGroup*> selectedGroups = getSelectedGroups();
+        for(int i=0; i<allgroups.size(); i++ ) {
+            if (selectedGroups.contains(&allgroups[i])) {
+                PeakGroup& group = allgroups[i];
+                csvreports->addGroup(&group);
+            }
         }
-    }
-    csvreports->closeFiles();
+        csvreports->closeFiles();
 
-    if (csvreports->getErrorReport() != "") {
-        QMessageBox msgBox(_mainwindow);
-        msgBox.setIcon(QMessageBox::Critical);
-        msgBox.setText(csvreports->getErrorReport());
-        msgBox.exec();
+        if (csvreports->getErrorReport() != "") {
+            QMessageBox msgBox(_mainwindow);
+            msgBox.setIcon(QMessageBox::Critical);
+            msgBox.setText(csvreports->getErrorReport());
+            msgBox.exec();
+        }
     }
 }
 

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -584,6 +584,113 @@ float TableDockWidget::extractMaxIntensity(PeakGroup* group) {
     return temp;
 }
 
+CSVReports* TableDockWidget::prepareCsvReport()
+{
+    vector<mzSample*> samples = _mainwindow->getSamples();
+    CSVReports* csvreports = new CSVReports(samples);
+    csvreports->setMavenParameters(_mainwindow->mavenParameters);
+    if (allgroups.size() == 0 ) {
+        QString msg = "Peaks Table is Empty";
+        QMessageBox::warning(this, tr("Error"), msg);
+        return NULL;
+    }
+
+    QString dir = ".";
+    QSettings* settings = _mainwindow->getSettings();
+
+    if ( settings->contains("lastDir") ) dir = settings->value("lastDir").value<QString>();
+
+    QString groupsTAB = "Groups Summary Matrix Format (*.tab)";
+    QString groupsSTAB = "Groups Summary Matrix Format Without Set Name (*.tab)";
+    QString peaksTAB =  "Peaks Detailed Format (*.tab)";
+    QString groupsCSV = "Groups Summary Matrix Format Comma Delimited (*.csv)";
+    QString groupsSCSV = "Groups Summary Matrix Format Comma Delimited Without Set Name (*.csv)";
+    QString peaksCSV =  "Peaks Detailed Format Comma Delimited (*.csv)";
+    //Added when Merging to Maven776 - Kiran
+    QString peaksListQE= "Inclusion List QE (*.csv)";
+    QString mascotMGF=   "Mascot Format MS2 Scans (*.mgf)";
+
+    QString sFilterSel;
+    QString fileName = QFileDialog::getSaveFileName(this,
+            tr("Export Groups"), dir,
+            groupsTAB + ";;" + groupsSTAB + ";;" + peaksTAB + ";;" + groupsCSV + ";;" + groupsSCSV + ";;" + peaksCSV + ";;" + peaksListQE + ";;" + mascotMGF,
+            &sFilterSel);
+
+    if(fileName.isEmpty()) return NULL;
+
+    if ( sFilterSel == groupsCSV || sFilterSel == peaksCSV) {
+        if(!fileName.endsWith(".csv",Qt::CaseInsensitive)) fileName = fileName + ".csv";
+    }
+    if ( sFilterSel == groupsSCSV) {
+        if(!fileName.endsWith(".csv",Qt::CaseInsensitive)) fileName = fileName + ".csv";
+        cerr <<"csv without:";
+        csvreports->flag = 0;
+        cerr <<"csv without:1";
+    }
+    if ( sFilterSel == groupsTAB || sFilterSel == peaksTAB) {
+        if(!fileName.endsWith(".tab",Qt::CaseInsensitive)) fileName = fileName + ".tab";
+    }
+    if ( sFilterSel == groupsSTAB) {
+        cerr <<"tab without:";
+        if(!fileName.endsWith(".tab",Qt::CaseInsensitive)) fileName = fileName + ".tab";
+        csvreports->flag = 0;
+        cerr <<"tab without:1";
+    }
+
+    if ( samples.size() == 0) return NULL;
+
+    //Added when Merging to Maven776 - Kiran
+    if (sFilterSel == peaksListQE ) {
+        writeQEInclusionList(fileName);
+        return NULL;
+    } else if (sFilterSel == mascotMGF ) {
+        writeMascotGeneric(fileName);
+        return NULL;
+    }
+
+
+    csvreports->setUserQuantType( _mainwindow->getUserQuantType() );
+
+    //Added to pass into csvreports file when merged with Maven776 - Kiran
+    bool includeSetNamesLines=true;
+
+    if (sFilterSel == groupsCSV) {
+        csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
+    } else if (sFilterSel == groupsTAB )  {
+        csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
+    } else if (sFilterSel == peaksCSV )  {
+        csvreports->openPeakReport(fileName.toStdString());
+    } else if (sFilterSel == peaksTAB )  {
+        csvreports->openPeakReport(fileName.toStdString());
+    } else { 	//default to group summary
+        //Updated when csvreports file was merged with Maven776 - Kiran
+        csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
+    }
+
+    csvreports->setSelectionFlag(static_cast<int>(peakTableSelection));
+    return csvreports;
+}
+
+void  TableDockWidget::exportAllGroups()
+{
+    LOGD;
+    CSVReports* csvreports = prepareCsvReport();
+
+    if(csvreports) {
+        for(int i=0; i<allgroups.size(); i++ ) {
+            csvreports->addGroup(&allgroups[i]);
+        }
+        csvreports->closeFiles();
+
+        if (csvreports->getErrorReport() != "") {
+            QMessageBox msgBox(_mainwindow);
+            msgBox.setIcon(QMessageBox::Critical);
+            msgBox.setText(csvreports->getErrorReport());
+            msgBox.exec();
+        }
+    }
+}
+
 void TableDockWidget::exportGroupsToSpreadsheet() {
     LOGD;
     //Merged to Maven776 - Kiran
@@ -2342,7 +2449,7 @@ QWidget* TableToolBarWidgetAction::createWidget(QWidget *parent) {
         
         connect(exportAll, SIGNAL(triggered()), td,  SLOT(wholePeakSet()));
         connect(exportAll, SIGNAL(triggered()), td->treeWidget, SLOT(selectAll()));
-        connect(exportAll, SIGNAL(triggered()), td,  SLOT(exportGroupsToSpreadsheet()));
+        connect(exportAll, SIGNAL(triggered()), td,  SLOT(exportAllGroups()));
 
         connect(exportGood, SIGNAL(triggered()), td,  SLOT(goodPeakSet()));
         connect(exportGood, SIGNAL(triggered()), td->treeWidget, SLOT(selectAll()));

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -490,6 +490,15 @@ PeakGroup* TableDockWidget::addPeakGroup(PeakGroup* group) {
             for (unsigned int i = 0; i <  allgroups.size(); i++) {
                 allgroups[i].groupId = i + 1;
             }
+            // keep note of the samples that were used for a group and it's child
+            for(mzSample* sm: _mainwindow->samples) {
+                if(sm->isSelected){
+                    g.samplesUsed.push_back(sm);
+                    for(PeakGroup &childGrp: g.children) {
+                        childGrp.samplesUsed.push_back(sm);
+                    }
+                }
+            }
             //g.groupId = allgroups.size();
             return &g;
         }

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -732,6 +732,8 @@ void TableDockWidget::writeGroupMzEICJson(PeakGroup& grp,ofstream& myfile, vecto
         myfile << "\"compoundId\": "<< sanitizeJSONstring(compoundID) ;
         string compoundName = grp.compound->name;
         myfile << ",\n" << "\"compoundName\": "<< sanitizeJSONstring(compoundName);
+        string formula = grp.compound->formula;
+        myfile << ",\n" << "\"formula\: "<< sanitizeJSONstring(formula);
 
         myfile << ",\n" << "\"expectedRt\": " << grp.compound->expectedRt;
 
@@ -1697,6 +1699,7 @@ void TableDockWidget::writeGroupXML(QXmlStreamWriter& stream, PeakGroup* g) {
 		stream.writeAttribute("compoundId",  QString(c->id.c_str()));
         stream.writeAttribute("compoundDB",  QString(c->db.c_str()) );
 		stream.writeAttribute("compoundName",  QString(c->name.c_str()));
+        stream.writeAttribute("formula", QString(c->id.c_str()));
     }
 
     for(int j=0; j < g->peaks.size(); j++ ) {

--- a/mzroll/tabledockwidget.h
+++ b/mzroll/tabledockwidget.h
@@ -16,6 +16,7 @@ class AlignmentVizWidget;
 class TrainDialog;
 class ClusterDialog;
 class NumericTreeWidgetItem;
+class CSVReports;
 using namespace std;
 
 class TableDockWidget: public QDockWidget {
@@ -77,6 +78,7 @@ public Q_SLOTS:
       //output to csv file
       //Added when Merging to Maven776 - Kiran
       void exportGroupsToSpreadsheet();
+      void exportAllGroups();
     void showTrainDialog();
     void showClusterDialog();
     inline void selectedPeakSet() {
@@ -168,6 +170,7 @@ private:
 	  void readPeakXML(QXmlStreamReader& xml,PeakGroup* parent);
 	  void setupFiltersDialog();
 	  QString groupTagString(PeakGroup* group);
+      CSVReports* prepareCsvReport();
 
           QList<PeakGroup>allgroups;
 


### PR DESCRIPTION
For each group that gets formed during the peak detection, keep track of the samples that were used for it

When exporting the groups to csv, intensities of the samples should be displayed only if they were used while peak detection

Issue: #261