### PR TITLE
Fix: eic window display when no peaks #285

### DIFF
--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -375,7 +375,10 @@ void EicWidget::findPlotBounds() {
 			}
 		}
 	}
-
+	float mx=0;
+	for(int i=0;i<eicParameters->eics.size();++i)
+			mx=max(mx,eicParameters->eics[i]->maxIntensity);
+	if(_maxY==0) _maxY=mx;
 	//if(_minY <= 0) _minY = 0;
 	_maxY = (_maxY * 1.3) + 1;
 	if (_minX > _maxX)


### PR DESCRIPTION
Previosly y-axis bound  was based on maxHeightIntensity of peaks of all groups.
But when there wasn't any group of peaks, it was set to 1 for one eic plot.

Now when there isn't any group of peaks, y-axis bound is recalculated on basis of
maxIntensity of corresponding eic.

issue: #285