### PR TITLE
Fix: zoom in/out along Y-axis #292

### DIFF
--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -234,7 +234,13 @@ vector<float> PeakGroup::getOrderedIntensityVector(vector<mzSample*>& samples, Q
 
     for( unsigned int j=0; j < samples.size(); j++) {
         sampleOrder[samples[j]]=j;
-        maxIntensity[j]=0;
+        // check if the the sample was used while peak detection or not
+        // samplesUsed is populate during peakDetection
+        auto it = std::find(std::begin(samplesUsed), std::end(samplesUsed), samples[j]);
+        if(it != std::end(samplesUsed))
+            maxIntensity[j]=0;
+        else
+            maxIntensity[j] = -1;
     }
 
     for( unsigned int j=0; j < peaks.size(); j++) {
@@ -258,7 +264,15 @@ vector<float> PeakGroup::getOrderedIntensityVector(vector<mzSample*>& samples, Q
 
             //normalize
             if(sample) y *= sample->getNormalizationConstant();
-            if(maxIntensity[s] < y) { maxIntensity[s] = y; }
+            if(maxIntensity[s] < y) {
+                // check if the the sample was used while peak detection or not
+                // samplesUsed is populate during peakDetection
+                auto it = std::find(std::begin(samplesUsed), std::end(samplesUsed), sample);
+                if(it != std::end(samplesUsed))
+                    maxIntensity[s]=y;
+                else
+                    maxIntensity[s] = -1;
+            }
         }
     }
     return maxIntensity;

--- a/libmaven/PeakGroup.h
+++ b/libmaven/PeakGroup.h
@@ -62,6 +62,7 @@ class PeakGroup{
         deque<PeakGroup> children;
         deque<PeakGroup> childrenBarPlot;
         deque<PeakGroup> childrenIsoWidget;
+        vector<mzSample*> samplesUsed;
 
         string srmId;
         string tagString;

--- a/libmaven/csvreports.cpp
+++ b/libmaven/csvreports.cpp
@@ -240,7 +240,6 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         return;
     groupId++;
 
-
     char lab;
     lab = group->label;
 
@@ -312,8 +311,14 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         groupReport << SEP << group->meanMz;
     }
 
-    for (unsigned int j = 0; j < samples.size(); j++)
-        groupReport << SEP << yvalues[j];
+
+    for (unsigned int j = 0; j < samples.size(); j++){
+        // -1 value means a particular sample was not used in peak detection
+        if(yvalues[j] == -1)
+            groupReport << SEP << "NA";
+        else
+            groupReport << SEP << yvalues[j];
+    }
     groupReport << endl;
 
 }

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -13,6 +13,10 @@ EicWidget::EicWidget(QWidget *p) {
 	_minX = _minY = 0;
 	_maxX = _maxY = 0;
 
+	ymin=0;
+	ymax=0;
+	zoomFlag=false;
+
 	setScene(new QGraphicsScene(this));
 
 	_barplot = NULL;
@@ -87,6 +91,8 @@ void EicWidget::mouseReleaseEvent(QMouseEvent *event) {
 	float rtmin = invX(std::min(_mouseStartPos.x(), _mouseEndPos.x()));
 	float rtmax = invX(std::max(_mouseStartPos.x(), _mouseEndPos.x()));
 	int deltaX = _mouseEndPos.x() - _mouseStartPos.x();
+	ymin=invY(_mouseEndPos.y());
+	ymax=invY(_mouseStartPos.y());
 	_mouseStartPos = _mouseEndPos; //
 
 	//user is holding shift while releasing the mouse.. integrate area
@@ -121,6 +127,7 @@ void EicWidget::mouseReleaseEvent(QMouseEvent *event) {
 							eicParameters->selectedGroup->meanRt + d;
 				}
 			}
+			zoomFlag=true;
 		} else if (deltaX < 0) {	 //zoomout
 			//zoom(_zoomFactor * 1.2 );
 			eicParameters->_slice.rtmin *= 0.8;
@@ -350,8 +357,14 @@ void EicWidget::findPlotBounds() {
 	_minX = eicParameters->_slice.rtmin;
 	_maxX = eicParameters->_slice.rtmax;
 
-	_minY = 0;
+	_minY =0 ;
 	_maxY = 0;       //intensity
+	if(zoomFlag){
+		_maxY=std::max(ymin,ymax);
+		_maxY = (_maxY * 1.3) + 1;
+		zoomFlag=false;
+		return;
+	}
 
 	/*/
 	 //full proof version

--- a/mzroll/eicwidget.h
+++ b/mzroll/eicwidget.h
@@ -203,6 +203,9 @@ private:
 	float _maxY;
 	float _zoomFactor;					//scaling of zoom in
 
+	float ymin;
+	float ymax;
+	bool zoomFlag;
 	QPointF _lastClickPos;
 	QPointF _mouseStartPos;
 	QPointF _mouseEndPos;

--- a/mzroll/projectdockwidget.cpp
+++ b/mzroll/projectdockwidget.cpp
@@ -926,6 +926,19 @@ void ProjectDockWidget::unloadSample(mzSample* sample) {
     Q_FOREACH(peaksTable, peaksTableList) {
         PeakGroup* grp;
         Q_FOREACH(grp, peaksTable->getGroups()) {
+
+            auto it = std::find(std::begin(grp->samplesUsed), std::end(grp->samplesUsed), sample);
+            if(it != std::end(grp->samplesUsed)){
+                grp->samplesUsed.erase(it);
+            }
+
+            for(PeakGroup& childGrp: grp->children) {
+                auto it = std::find(std::begin(childGrp.samplesUsed), std::end(childGrp.samplesUsed), sample);
+                if(it != std::end(childGrp.samplesUsed)){
+                    childGrp.samplesUsed.erase(it);
+                }
+            }
+
             vector<Peak>& peaks = grp->getPeaks();
             for(unsigned int j=0; j< peaks.size(); j++) {
                 Peak p = peaks.at(j);

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -490,6 +490,15 @@ PeakGroup* TableDockWidget::addPeakGroup(PeakGroup* group) {
             for (unsigned int i = 0; i <  allgroups.size(); i++) {
                 allgroups[i].groupId = i + 1;
             }
+            // keep note of the samples that were used for a group and it's child
+            for(mzSample* sm: _mainwindow->samples) {
+                if(sm->isSelected){
+                    g.samplesUsed.push_back(sm);
+                    for(PeakGroup &childGrp: g.children) {
+                        childGrp.samplesUsed.push_back(sm);
+                    }
+                }
+            }
             //g.groupId = allgroups.size();
             return &g;
         }


### PR DESCRIPTION
Previously zoom in was enabled only along x-axis.

Now it is enabled along both axis and by dragging a square,
that area can be zoomed in.

issue #292