### PR TITLE
Keep track of samples that were used during peak detection

### DIFF
--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -234,7 +234,13 @@ vector<float> PeakGroup::getOrderedIntensityVector(vector<mzSample*>& samples, Q
 
     for( unsigned int j=0; j < samples.size(); j++) {
         sampleOrder[samples[j]]=j;
-        maxIntensity[j]=0;
+        // check if the the sample was used while peak detection or not
+        // samplesUsed is populate during peakDetection
+        auto it = std::find(std::begin(samplesUsed), std::end(samplesUsed), samples[j]);
+        if(it != std::end(samplesUsed))
+            maxIntensity[j]=0;
+        else
+            maxIntensity[j] = -1;
     }
 
     for( unsigned int j=0; j < peaks.size(); j++) {
@@ -258,7 +264,15 @@ vector<float> PeakGroup::getOrderedIntensityVector(vector<mzSample*>& samples, Q
 
             //normalize
             if(sample) y *= sample->getNormalizationConstant();
-            if(maxIntensity[s] < y) { maxIntensity[s] = y; }
+            if(maxIntensity[s] < y) {
+                // check if the the sample was used while peak detection or not
+                // samplesUsed is populate during peakDetection
+                auto it = std::find(std::begin(samplesUsed), std::end(samplesUsed), sample);
+                if(it != std::end(samplesUsed))
+                    maxIntensity[s]=y;
+                else
+                    maxIntensity[s] = -1;
+            }
         }
     }
     return maxIntensity;

--- a/libmaven/PeakGroup.h
+++ b/libmaven/PeakGroup.h
@@ -62,6 +62,7 @@ class PeakGroup{
         deque<PeakGroup> children;
         deque<PeakGroup> childrenBarPlot;
         deque<PeakGroup> childrenIsoWidget;
+        vector<mzSample*> samplesUsed;
 
         string srmId;
         string tagString;

--- a/libmaven/csvreports.cpp
+++ b/libmaven/csvreports.cpp
@@ -240,7 +240,6 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         return;
     groupId++;
 
-
     char lab;
     lab = group->label;
 
@@ -312,8 +311,14 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         groupReport << SEP << group->meanMz;
     }
 
-    for (unsigned int j = 0; j < samples.size(); j++)
-        groupReport << SEP << yvalues[j];
+
+    for (unsigned int j = 0; j < samples.size(); j++){
+        // -1 value means a particular sample was not used in peak detection
+        if(yvalues[j] == -1)
+            groupReport << SEP << "NA";
+        else
+            groupReport << SEP << yvalues[j];
+    }
     groupReport << endl;
 
 }

--- a/mzroll/projectdockwidget.cpp
+++ b/mzroll/projectdockwidget.cpp
@@ -926,6 +926,19 @@ void ProjectDockWidget::unloadSample(mzSample* sample) {
     Q_FOREACH(peaksTable, peaksTableList) {
         PeakGroup* grp;
         Q_FOREACH(grp, peaksTable->getGroups()) {
+
+            auto it = std::find(std::begin(grp->samplesUsed), std::end(grp->samplesUsed), sample);
+            if(it != std::end(grp->samplesUsed)){
+                grp->samplesUsed.erase(it);
+            }
+
+            for(PeakGroup& childGrp: grp->children) {
+                auto it = std::find(std::begin(childGrp.samplesUsed), std::end(childGrp.samplesUsed), sample);
+                if(it != std::end(childGrp.samplesUsed)){
+                    childGrp.samplesUsed.erase(it);
+                }
+            }
+
             vector<Peak>& peaks = grp->getPeaks();
             for(unsigned int j=0; j< peaks.size(); j++) {
                 Peak p = peaks.at(j);

--- a/mzroll/tabledockwidget.cpp
+++ b/mzroll/tabledockwidget.cpp
@@ -490,6 +490,15 @@ PeakGroup* TableDockWidget::addPeakGroup(PeakGroup* group) {
             for (unsigned int i = 0; i <  allgroups.size(); i++) {
                 allgroups[i].groupId = i + 1;
             }
+            // keep note of the samples that were used for a group and it's child
+            for(mzSample* sm: _mainwindow->samples) {
+                if(sm->isSelected){
+                    g.samplesUsed.push_back(sm);
+                    for(PeakGroup &childGrp: g.children) {
+                        childGrp.samplesUsed.push_back(sm);
+                    }
+                }
+            }
             //g.groupId = allgroups.size();
             return &g;
         }


### PR DESCRIPTION
Keep track of samples that were used during peak detection

When exporting groups to csv, intensities of only used samples should be displayed