### PR TITLE
Fix: barplot/boxplot missing #316

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -73,6 +73,8 @@ This code of conduct and its related procedures also applies to unacceptable beh
 
 ## 9. Contact info
 
+info@elucidata.io
+
 abhishek.jha@elucidata.io
 
 swetabh.pathak@elucidata.io

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,90 @@
+# Code of Conduct
+
+## 1. Purpose
+
+A primary goal of El-Maven is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
+
+This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in El-Maven to help us create safe and positive experiences for everyone.
+
+## 2. Open Source Citizenship
+
+A supplemental goal of this Code of Conduct is to increase open source citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
+
+## 3. Expected Behavior
+
+The following behaviors are expected and requested of all community members:
+
+*   Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+*   Exercise consideration and respect in your speech and actions.
+*   Attempt collaboration before conflict.
+*   Refrain from demeaning, discriminatory, or harassing behavior and speech.
+*   Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+*   Remember that community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+## 4. Unacceptable Behavior
+
+The following behaviors are considered harassment and are unacceptable within our community:
+
+*   Violence, threats of violence or violent language directed against another person.
+*   Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+*   Posting or displaying sexually explicit or violent material.
+*   Posting or threatening to post other people’s personally identifying information ("doxing").
+*   Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+*   Inappropriate photography or recording.
+*   Inappropriate physical contact. You should have someone’s consent before touching them.
+*   Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
+*   Deliberate intimidation, stalking or following (online or in person).
+*   Advocating for, or encouraging, any of the above behavior.
+*   Sustained disruption of community events, including talks and presentations.
+
+## 5. Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
+
+## 6. Reporting Guidelines
+
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible.
+
+
+
+Additionally, community organizers are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.
+
+## 7. Addressing Grievances
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify Elucidata Inc (elucidata.io) with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies.
+
+
+
+## 8. Scope
+
+We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues–online and in-person–as well as in all one-on-one communications pertaining to community business.
+
+This code of conduct and its related procedures also applies to unacceptable behavior occurring outside the scope of community activities when such behavior has the potential to adversely affect the safety and well-being of community members.
+
+## 9. Contact info
+
+abhishek.jha@elucidata.io
+
+swetabh.pathak@elucidata.io
+
+sabu.george@elucidata.io
+
+sahil@elucidata.io
+
+## 10. License and attribution
+
+This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
+
+Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+
+Retrieved on November 22, 2016 from [http://citizencodeofconduct.org/](http://citizencodeofconduct.org/)

--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -234,13 +234,7 @@ vector<float> PeakGroup::getOrderedIntensityVector(vector<mzSample*>& samples, Q
 
     for( unsigned int j=0; j < samples.size(); j++) {
         sampleOrder[samples[j]]=j;
-        // check if the the sample was used while peak detection or not
-        // samplesUsed is populate during peakDetection
-        auto it = std::find(std::begin(samplesUsed), std::end(samplesUsed), samples[j]);
-        if(it != std::end(samplesUsed))
-            maxIntensity[j]=0;
-        else
-            maxIntensity[j] = -1;
+        maxIntensity[j]=0;
     }
 
     for( unsigned int j=0; j < peaks.size(); j++) {
@@ -264,15 +258,7 @@ vector<float> PeakGroup::getOrderedIntensityVector(vector<mzSample*>& samples, Q
 
             //normalize
             if(sample) y *= sample->getNormalizationConstant();
-            if(maxIntensity[s] < y) {
-                // check if the the sample was used while peak detection or not
-                // samplesUsed is populate during peakDetection
-                auto it = std::find(std::begin(samplesUsed), std::end(samplesUsed), sample);
-                if(it != std::end(samplesUsed))
-                    maxIntensity[s]=y;
-                else
-                    maxIntensity[s] = -1;
-            }
+            if(maxIntensity[s] < y) { maxIntensity[s]=y;}
         }
     }
     return maxIntensity;

--- a/libmaven/csvreports.cpp
+++ b/libmaven/csvreports.cpp
@@ -313,11 +313,11 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
 
 
     for (unsigned int j = 0; j < samples.size(); j++){
-        // -1 value means a particular sample was not used in peak detection
-        if(yvalues[j] == -1)
-            groupReport << SEP << "NA";
-        else
+        auto it = std::find(std::begin(group->samplesUsed), std::end(group->samplesUsed), samples[j]);
+        if(it != std::end(group->samplesUsed))
             groupReport << SEP << yvalues[j];
+        else
+            groupReport << SEP << "NA";
     }
     groupReport << endl;
 


### PR DESCRIPTION
Barplot, Boxplot and Isotopeplot were missing because of minor change in computation method for maxIntensity vector.This change was introduced while resolving issue #261. When a sample was not selected for peak finding, maxIntensity for this sample in a group was being assigned -1 instead of 0.

Now it's been restored to previous state and to ressolve issue #261 we are directly checking by comparing all sample and used sample ( samplesUsed ) for peak finding .

issue #316