### PR TITLE
UI: Rename EIC tab in Peak Detection dialog #217

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,15 +31,55 @@ You can file a new issue [here](https://github.com/ElucidataInc/ElMaven/issues/n
 
 
 ## Commit Guidelines
+* Start the subject line as "Ftr:", "Fix:", "Doc:", "Test:","Ref:" etc.
+  Ftr-for adding feature
+  Fix-for fixing bug
+  Doc-for documentation
+  Test- for testing
+  Ref-for code refactoring
 * Separate subject from body with a blank line
-* Limit the subject line to 50 characters- it's a rule of thumb. Follow it strictly
-  as long as possible, otherwise long subject line will get truncated.
+* Limit the subject line to 50 characters- it's a rule of thumb, follow it strictly
+  as long as possible otherwise long subject line will get truncated.
 * Capitalize the subject line
 * Do not end the subject line with a period
-* Use the imperative mood in the subject line i.e. as you are giving order.
-* keep the length of line in body at 72 character.
-* Use the body to explain what and why vs how in consize manner i.e. no story telling 
-  and no inferential statements. Explain these three things to the point.
+* Use the imperative mood in the subject line i.e. as you are giving command 
+  or instrcution
+  examples-all these commit guidelines have imperative mood
+* Keep the length of line in body at 72 character
+* Use the body to explain what and why vs how in concise manner i.e. no story telling 
+  and no inferential statements
+* Tag the issue number as last line of body, for example- issue #324 and
+  tag recommended issue to look over after this line if it's required
+ 
+  For example:
+
+  		Doc: Giving a good commit message subject line
+
+  		This commit message example is a good example of its own. Its  subject
+  		line has 50 or less than 50 characters and body lines have 72 or  less
+  		than 72 characters.This paragraph  of this message  is explaining what
+  		changes I'm making, next paragraph is going to  explain why I'm making
+  		this change and next of next one is going to  explain  how I'm  making
+  		this change.
+
+		Proper commit message is neccessary to understand the changes someone is
+		making and  impact  of these changes  to the codebase. It  helps fellow 
+		developers to understand the codebase and to save their time for faster
+		delivery of product. It also evaluates colaboration skill of a developer.
+
+		* First I have provided instructions to write good commit message.
+		* Next I have given an example.
+		* In this section I'm using bullet points,it could be "-" or "*" .
+		* Bullet points are not neccessary. It can also be simple paragraph.
+		* Last line have tag for issue this commit is going so resolve.
+		* There is no other issue related to this issue, that's why there is
+		  no "see also #IssueNo, #IssueNo ..." line after last line.
+
+		issue #324
+
+
+
+
 
 ## Documentation guidelines
 We make use of Doxygen for generating the code documentation. You can read more about Doxygen [here](http://www.stack.nl/~dimitri/doxygen/index.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,12 +31,13 @@ You can file a new issue [here](https://github.com/ElucidataInc/ElMaven/issues/n
 
 
 ## Commit Guidelines
-* Start the subject line as "Ftr:", "Fix:", "Doc:", "Test:","Ref:" etc.
+* Start the subject line as "Ftr:", "Fix:", "Doc:", "Test:","Ref:", "UI:" etc.
   Ftr-for adding feature
   Fix-for fixing bug
   Doc-for documentation
   Test- for testing
   Ref-for code refactoring
+  UI- for UI changes 
 * At the end of subject line, tag issue no
 * Separate subject from body with a blank line
 * Limit the subject line to 50 characters- it's a rule of thumb, follow it strictly
@@ -44,8 +45,8 @@ You can file a new issue [here](https://github.com/ElucidataInc/ElMaven/issues/n
 * Capitalize the subject line
 * Do not end the subject line with a period
 * Use the imperative mood in the subject line i.e. as you are giving command 
-  or instrcution
-  examples-all these commit guidelines have imperative mood
+  or instruction
+  Example: "Add a flag for ..." instead of "Adding a flag for ..."
 * Keep the length of line in body at 72 character
 * Use the body to explain what and why vs how in concise manner i.e. no story telling 
   and no inferential statements
@@ -54,7 +55,7 @@ You can file a new issue [here](https://github.com/ElucidataInc/ElMaven/issues/n
  
   For example:
 
-  		Doc:Giving a good commit message subject line #324
+  		Doc: Give a good commit message subject line #324
 
   		This commit message example is a good example of its own. Its  subject
   		line has 50 or less than 50 characters and body lines have 72 or  less

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,19 @@ You can file a new issue [here](https://github.com/ElucidataInc/ElMaven/issues/n
 * Pull a new branch from develop. Branch name should reflect the issue addressed in it
 * Get started!
 
+
+
+## Commit Guidelines
+* Separate subject from body with a blank line
+* Limit the subject line to 50 characters- it's a rule of thumb. Follow it strictly
+  as long as possible, otherwise long subject line will get truncated.
+* Capitalize the subject line
+* Do not end the subject line with a period
+* Use the imperative mood in the subject line i.e. as you are giving order.
+* keep the length of line in body at 72 character.
+* Use the body to explain what and why vs how in consize manner i.e. no story telling 
+  and no inferential statements. Explain these three things to the point.
+
 ## Documentation guidelines
 We make use of Doxygen for generating the code documentation. You can read more about Doxygen [here](http://www.stack.nl/~dimitri/doxygen/index.html).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ You can file a new issue [here](https://github.com/ElucidataInc/ElMaven/issues/n
   Doc-for documentation
   Test- for testing
   Ref-for code refactoring
+* At the end of subject line, tag issue no
 * Separate subject from body with a blank line
 * Limit the subject line to 50 characters- it's a rule of thumb, follow it strictly
   as long as possible otherwise long subject line will get truncated.
@@ -48,12 +49,12 @@ You can file a new issue [here](https://github.com/ElucidataInc/ElMaven/issues/n
 * Keep the length of line in body at 72 character
 * Use the body to explain what and why vs how in concise manner i.e. no story telling 
   and no inferential statements
-* Tag the issue number as last line of body, for example- issue #324 and
-  tag recommended issue to look over after this line if it's required
+* Tag the issue number as last line of body, for example- Issue: #324 with 
+  first letter capital and at end a colon and tag recommended issue to look over after this line if it's required
  
   For example:
 
-  		Doc: Giving a good commit message subject line
+  		Doc:Giving a good commit message subject line #324
 
   		This commit message example is a good example of its own. Its  subject
   		line has 50 or less than 50 characters and body lines have 72 or  less
@@ -73,9 +74,9 @@ You can file a new issue [here](https://github.com/ElucidataInc/ElMaven/issues/n
 		* Bullet points are not neccessary. It can also be simple paragraph.
 		* Last line have tag for issue this commit is going so resolve.
 		* There is no other issue related to this issue, that's why there is
-		  no "see also #IssueNo, #IssueNo ..." line after last line.
+		  no "See also: #IssueNo, #IssueNo ..." line after last line.
 
-		issue #324
+		Issue: #324
 
 
 

--- a/mzroll/forms/peakdetectiondialog.ui
+++ b/mzroll/forms/peakdetectiondialog.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QTabWidget" name="tabwidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="featureSelectionTab">
       <attribute name="title">
@@ -421,15 +421,15 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="eicProcessingTab">
+     <widget class="QWidget" name="groupFilteringTab">
       <attribute name="title">
-       <string>EIC Processing and Filtering</string>
+       <string>Group Filtering</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_13">
        <item row="0" column="0">
         <widget class="QGroupBox" name="peakScoringOptions">
          <property name="title">
-          <string>Peak Scoring and Filtering</string>
+          <string>Group Filtering</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
           <item row="0" column="0" colspan="4">


### PR DESCRIPTION
- "EIC Processing and Filtering" tab in Peak detection dialog has been renamed to "Group  Filtering" as EIC processing parameters are no longer present in this tab.
- Default tab has been changed to "Feature detection selection"

Issue: #217