### PR TITLE
Fix: Calculation of mz using formula and charge in json reports

### DIFF
--- a/libmaven/jsonReports.cpp
+++ b/libmaven/jsonReports.cpp
@@ -33,7 +33,8 @@ void JSONReports::writeGroupMzEICJson(PeakGroup& grp,ofstream& myfile, vector<mz
 
         mz = grp.compound->mass;
         if (!grp.compound->formula.empty()) {
-            float formula_mz =  mavenParameters->mcalc.computeMass(grp.compound->formula,mavenParameters->charge);
+            int charge = mavenParameters->getCharge(grp.compound);
+            float formula_mz =  mavenParameters->mcalc.computeMass(grp.compound->formula, charge);
             if(formula_mz) {
                 mz = formula_mz;
             }
@@ -143,7 +144,8 @@ void JSONReports::writeGroupMzEICJson(PeakGroup& grp,ofstream& myfile, vector<mz
                 //redoing it only for code clarity
                 mz = grp.compound->mass;
                 if (!grp.compound->formula.empty()) {
-                    float formula_mz =  mavenParameters->mcalc.computeMass(grp.compound->formula,mavenParameters->charge);
+                    int charge = mavenParameters->getCharge(grp.compound);
+                    float formula_mz =  mavenParameters->mcalc.computeMass(grp.compound->formula, charge);
                     if(formula_mz) {
                         mz = formula_mz;
                     }


### PR DESCRIPTION
mz is calculated using formula and charge of the compound. Charge
is calculated using ionization mode and magnitude of ionization
charge.

Charge calculated in json reports was not using ionization mode so
the mz value being calculated was wrong.