### PR TITLE
Fix: fix segmentation fault

### DIFF
--- a/MavenTests/testCSVReports.cpp
+++ b/MavenTests/testCSVReports.cpp
@@ -132,6 +132,7 @@ void TestCSVReports::testaddGroups() {
     peakDetector.pullIsotopes(&parent);
 
     CSVReports* csvreports =  new CSVReports(samplesToLoad);
+    csvreports->setMavenParameters(mavenparameters);    
     csvreports->openGroupReport(outputfile,true);
     csvreports->addGroup(&(parent));
 


### PR DESCRIPTION
We were getting segmenation fault error while running
Maventests executable because <csvreports> object wasn't
given <mavenparameters>.
	<mavenparameters> has been set in <csvreports> objects