### PR TITLE
Fix: Fix csv report by shift+drag

### DIFF
--- a/libmaven/EIC.cpp
+++ b/libmaven/EIC.cpp
@@ -591,6 +591,10 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC*>& eics,
                                     double minSignalBaselineDifference) {
     // Merged to 776
 
+    vector<mzSample*> samples;
+    for(int i=0;i<eics.size();++i){
+            samples.push_back(eics[i]->sample); //collect all mzSample into vector samples 
+    }
     //list filled and return by this function
     vector<PeakGroup> pgroups;
 
@@ -603,19 +607,13 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC*>& eics,
             grp.groupId = i;
             grp.addPeak(m->peaks[i]);
             grp.groupStatistics();
-            if(m->sample->isSelected) grp.samples.push_back(m->sample);
+            grp.setSelectedSamples(samples);
             pgroups.push_back(grp);
         }
         return pgroups;
     }
 
     //create EIC compose from all sample eics
-    vector<mzSample*> samples;
-    for(int i=0;i<eics.size();++i){
-        if(eics[i]->sample->isSelected){
-            samples.push_back(eics[i]->sample);
-        }
-    }
     EIC* m = EIC::eicMerge(eics);
     if (!m) return pgroups;
 
@@ -627,7 +625,7 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC*>& eics,
     for(unsigned int i=0; i< m->peaks.size(); i++ ) {
         PeakGroup grp;
         grp.groupId = i;
-        grp.samples=samples;
+        grp.setSelectedSamples(samples);
         pgroups.push_back(grp);
     }
 

--- a/libmaven/PeakDetector.cpp
+++ b/libmaven/PeakDetector.cpp
@@ -630,7 +630,7 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
                     g.tagString = isotopeName;
                     g.expectedAbundance = expectedAbundance;
                     g.isotopeC13count = x.C13;
-                    g.samples=parentgroup->samples;
+                    g.setSelectedSamples(parentgroup->samples);
                     isotopes[isotopeName] = g;
                 }
                 isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list

--- a/libmaven/PeakGroup.cpp
+++ b/libmaven/PeakGroup.cpp
@@ -768,3 +768,12 @@ void PeakGroup::calGroupRank(bool deltaRtCheckFlag,
     }
 
 }
+
+void PeakGroup::setSelectedSamples(vector<mzSample*> vsamples){
+    samples.clear();
+    for(int i=0;i<vsamples.size();++i){
+        if(vsamples[i]->isSelected) {
+            samples.push_back(vsamples[i]);
+        }
+    }
+}

--- a/libmaven/PeakGroup.h
+++ b/libmaven/PeakGroup.h
@@ -540,5 +540,7 @@ class PeakGroup{
                             int qualityWeight,
                             int intensityWeight,
                             int deltaRTWeight);
+        
+        void setSelectedSamples(vector<mzSample*> vsamples);
 };
 #endif

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -151,6 +151,14 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
 	eicParameters->_integratedGroup.minQuality = settings->value("minQuality").toDouble();
 	eicParameters->_integratedGroup.compound = eicParameters->_slice.compound;
 	eicParameters->_integratedGroup.srmId = eicParameters->_slice.srmId;
+	eicParameters->_integratedGroup.samples.clear();
+	vector<mzSample*> samples=getMainWindow()->samples;
+	for(int i=0;i<samples.size();++i){
+		if(samples[i]->isSelected){
+			eicParameters->_integratedGroup.samples.push_back(samples[i]);		//insert all selected sample
+		}
+	}
+	
 
 	for (int i = 0; i < eicParameters->eics.size(); i++) {
 		EIC* eic = eicParameters->eics[i];

--- a/mzroll/eicwidget.cpp
+++ b/mzroll/eicwidget.cpp
@@ -151,13 +151,7 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
 	eicParameters->_integratedGroup.minQuality = settings->value("minQuality").toDouble();
 	eicParameters->_integratedGroup.compound = eicParameters->_slice.compound;
 	eicParameters->_integratedGroup.srmId = eicParameters->_slice.srmId;
-	eicParameters->_integratedGroup.samples.clear();
-	vector<mzSample*> samples=getMainWindow()->samples;
-	for(int i=0;i<samples.size();++i){
-		if(samples[i]->isSelected){
-			eicParameters->_integratedGroup.samples.push_back(samples[i]);		//insert all selected sample
-		}
-	}
+	eicParameters->_integratedGroup.setSelectedSamples(getMainWindow()->samples);
 	
 
 	for (int i = 0; i < eicParameters->eics.size(); i++) {


### PR DESCRIPTION
CSV exported by holding shift key down and dragging mouse
had no info for samples because here new object of <PeakGroup>
is generated but <samples> were not assigned to this group.
	Now all selected samples has been assigned to group and
problem is fixed.