### PR TITLE
Fix: Remove binary to new directory <target>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,10 +51,10 @@ mzroll/qrc_mzroll.cpp
 # Compiled Binaries
 bin/maven_dev_769
 bin/mzWatcher
-bin/peakdetector
-bin/MavenTests
-bin/El_Maven*
-bin/CrashReporter*
+target/peakdetector
+target/MavenTests
+target/El_Maven*
+target/CrashReporter*
 
 #Documentation files
 docs/html

--- a/.qmake.conf
+++ b/.qmake.conf
@@ -1,3 +1,3 @@
 top_srcdir=$$PWD
-top_builddir=$$top_srcdir/../build
+top_builddir=$$top_srcdir/target
 mzroll_pri=$$top_srcdir/mzroll.pri

--- a/CrashReporter/CrashReporter.pro
+++ b/CrashReporter/CrashReporter.pro
@@ -15,7 +15,7 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TARGET = CrashReporter
 TEMPLATE = app
 
-DESTDIR = $$top_builddir/bin/
+DESTDIR = $$top_builddir/
 
 SOURCES += main.cpp\
         mainwindow.cpp

--- a/src/cli/peakdetector/peakdetector.pro
+++ b/src/cli/peakdetector/peakdetector.pro
@@ -1,5 +1,5 @@
 include($$mzroll_pri)
-DESTDIR = $$top_builddir/bin/
+DESTDIR = $$top_builddir/
 
 MOC_DIR=$$top_builddir/tmp/peakdetector/
 OBJECTS_DIR=$$top_builddir/tmp/peakdetector/

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -3,7 +3,7 @@ include($$mzroll_pri)
 MOC_DIR=$$top_builddir/tmp/mzroll/
 OBJECTS_DIR=$$top_builddir/tmp/mzroll/
 
-DESTDIR = $$top_builddir/bin/
+DESTDIR = $$top_builddir/
 #TEMPLATE = app
 
 CONFIG += qt thread warn_off sql svg console precompile_header

--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -1,5 +1,5 @@
 include($$mzroll_pri)
-DESTDIR = $$top_builddir/bin/
+DESTDIR = $$top_builddir/
 
 MOC_DIR=$$top_builddir/tmp/maven_tests/
 OBJECTS_DIR=$$top_builddir/tmp/maven_tests/


### PR DESCRIPTION
Previously, binary executables and static libraries were
generated to build folder out side of main directory
which was inconvinient to access.
	Now destination directory for all binary
executables is changed to a new directory <target> which
is a subdirectory of main directory and static libraries
are in <bin> and temprory object files are in <tmp>
folder of this new directory<target>
	These binary are also included in .gitignore file