### PR TITLE
Fix: Add bookmark by shift+drag #390

### DIFF
--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -729,6 +729,10 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC *> &eics,
                                   bool useOverlap,
                                   double minSignalBaselineDifference)
 {
+    vector<mzSample*> samples;
+    for(int i=0;i<eics.size();++i){
+            samples.push_back(eics[i]->sample); //collect all mzSample into vector samples 
+    }
     //list filled and return by this function
     vector<PeakGroup> pgroups;
 
@@ -743,22 +747,13 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC *> &eics,
             grp.groupId = i;
             grp.addPeak(m->peaks[i]);
             grp.groupStatistics();
-            if (m->sample->isSelected)
-                grp.samples.push_back(m->sample);
+            grp.setSelectedSamples(samples);
             pgroups.push_back(grp);
         }
         return pgroups;
     }
 
     //create EIC compose from all sample eics
-    vector<mzSample *> samples;
-    for (int i = 0; i < eics.size(); ++i)
-    {
-        if (eics[i]->sample->isSelected)
-        {
-            samples.push_back(eics[i]->sample);
-        }
-    }
     EIC *m = EIC::eicMerge(eics);
     if (!m)
         return pgroups;
@@ -772,7 +767,7 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC *> &eics,
     {
         PeakGroup grp;
         grp.groupId = i;
-        grp.samples = samples;
+        grp.setSelectedSamples(samples);
         pgroups.push_back(grp);
     }
 

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -630,7 +630,7 @@ void PeakDetector::pullIsotopes(PeakGroup* parentgroup) {
                     g.tagString = isotopeName;
                     g.expectedAbundance = expectedAbundance;
                     g.isotopeC13count = x.C13;
-                    g.samples=parentgroup->samples;
+                    g.setSelectedSamples(parentgroup->samples);
                     isotopes[isotopeName] = g;
                 }
                 isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list

--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -771,6 +771,10 @@ void PeakGroup::calGroupRank(bool deltaRtCheckFlag,
 
 void PeakGroup::setSelectedSamples(vector<mzSample*> vsamples){
     samples.clear();
+    /**
+     * @details- this method used for assigning samples to this group based on whether that samples
+     * are marked as selected.
+    */
     for(int i=0;i<vsamples.size();++i){
         if(vsamples[i]->isSelected) {
             samples.push_back(vsamples[i]);

--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -768,3 +768,12 @@ void PeakGroup::calGroupRank(bool deltaRtCheckFlag,
     }
 
 }
+
+void PeakGroup::setSelectedSamples(vector<mzSample*> vsamples){
+    samples.clear();
+    for(int i=0;i<vsamples.size();++i){
+        if(vsamples[i]->isSelected) {
+            samples.push_back(vsamples[i]);
+        }
+    }
+}

--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -540,7 +540,11 @@ class PeakGroup{
                             int qualityWeight,
                             int intensityWeight,
                             int deltaRTWeight);
-
-        void setSelectedSamples(vector<mzSample*> vsamples);    /**take list of sample and filter those which are marked as selected*/
+        /**
+         * @brief take list of sample and filter those which are marked as selected
+         * @details this method used for assigning samples to this group based on whether that samples
+         * are marked as selected.
+        */
+        void setSelectedSamples(vector<mzSample*> vsamples);
 };
 #endif

--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -541,6 +541,6 @@ class PeakGroup{
                             int intensityWeight,
                             int deltaRTWeight);
 
-        void setSelectedSamples(vector<mzSample*> vsamples);
+        void setSelectedSamples(vector<mzSample*> vsamples);    /**take list of sample and filter those which are marked as selected*/
 };
 #endif

--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -540,5 +540,7 @@ class PeakGroup{
                             int qualityWeight,
                             int intensityWeight,
                             int deltaRTWeight);
+
+        void setSelectedSamples(vector<mzSample*> vsamples);
 };
 #endif

--- a/src/core/libmaven/SRMList.cpp
+++ b/src/core/libmaven/SRMList.cpp
@@ -56,6 +56,10 @@ vector<mzSlice*> SRMList::getSrmSlices(double amuQ1, double amuQ3, int userPolar
             if (precursorMz != 0 && productMz != 0 ) {
                 compound = findSpeciesByPrecursor(precursorMz,productMz,rt,polarity,amuQ1,amuQ3);
             }
+            
+            if (annotation[string(filterLine.toStdString())]) {
+                compound = annotation[filterLine.toStdString()];
+            }
 
             if (compound) {
                 compound->srmId = filterLine.toStdString();

--- a/src/core/libmaven/SRMList.cpp
+++ b/src/core/libmaven/SRMList.cpp
@@ -147,3 +147,23 @@ double SRMList::getProductOfSrm(string srmId)
 
     return productMz;
 }
+
+deque<Compound*> SRMList::getMatchedCompounds(string srmId, double amuQ1, double amuQ3) {
+
+    deque<Compound*> matchedCompounds;
+
+    float precursorMz = getPrecursorOfSrm(srmId);
+    float productMz = getProductOfSrm(srmId);
+
+    for(unsigned int i=0; i < compoundsDB.size(); i++ ) {
+        if (compoundsDB[i]->precursorMz == 0 ) continue;
+        float a = abs(compoundsDB[i]->precursorMz - precursorMz);
+        if ( a > amuQ1 ) continue; // q1 tollorance
+        float b = abs(compoundsDB[i]->productMz - productMz);
+        if ( b > amuQ3 ) continue; // q2 tollarance
+
+        matchedCompounds.push_back(compoundsDB[i]);
+    }
+
+    return matchedCompounds;
+}

--- a/src/core/libmaven/SRMList.cpp
+++ b/src/core/libmaven/SRMList.cpp
@@ -83,9 +83,9 @@ Compound *SRMList::findSpeciesByPrecursor(float precursorMz, float productMz, fl
             //cerr << polarity << " " << compoundsDB[i]->charge << endl;
             if ((int) compoundsDB[i]->charge != polarity && compoundsDB[i]->charge != 0) continue;
             float a = abs(compoundsDB[i]->precursorMz - precursorMz);
-            if ( a > amuQ1 ) continue; // q1 tollorance
+            if ( a > amuQ1 ) continue; // q1 tolerance
             float b = abs(compoundsDB[i]->productMz - productMz);
-            if ( b > amuQ3 ) continue; // q2 tollarance
+            if ( b > amuQ3 ) continue; // q2 tolerance
             float dMz = sqrt(a*a+b*b);
             float dRt = abs(compoundsDB[i]->expectedRt - rt);
             if (  ( dMz < distMz)  ||   ((dMz == distMz) && (dRt < distRt))  ) { 
@@ -152,7 +152,7 @@ double SRMList::getProductOfSrm(string srmId)
     return productMz;
 }
 
-deque<Compound*> SRMList::getMatchedCompounds(string srmId, double amuQ1, double amuQ3) {
+deque<Compound*> SRMList::getMatchedCompounds(string srmId, double amuQ1, double amuQ3, int polarity) {
 
     deque<Compound*> matchedCompounds;
 
@@ -160,11 +160,12 @@ deque<Compound*> SRMList::getMatchedCompounds(string srmId, double amuQ1, double
     float productMz = getProductOfSrm(srmId);
 
     for(unsigned int i=0; i < compoundsDB.size(); i++ ) {
+        if ((int) compoundsDB[i]->charge != polarity && compoundsDB[i]->charge != 0) continue;
         if (compoundsDB[i]->precursorMz == 0 ) continue;
         float a = abs(compoundsDB[i]->precursorMz - precursorMz);
-        if ( a > amuQ1 ) continue; // q1 tollorance
+        if ( a > amuQ1 ) continue; // q1 tolerance
         float b = abs(compoundsDB[i]->productMz - productMz);
-        if ( b > amuQ3 ) continue; // q2 tollarance
+        if ( b > amuQ3 ) continue; // q2 tolerance
 
         matchedCompounds.push_back(compoundsDB[i]);
     }

--- a/src/core/libmaven/SRMList.h
+++ b/src/core/libmaven/SRMList.h
@@ -19,6 +19,7 @@ class SRMList{
     Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt, int polarity,double amuQ1, double amuQ3);
     static double getPrecursorOfSrm(string srmId);
     static double getProductOfSrm(string srmId);
-};
+    deque<Compound*> getMatchedCompounds(string srmId, double amuQ1, double amuQ3);
+  };
 
 #endif

--- a/src/core/libmaven/SRMList.h
+++ b/src/core/libmaven/SRMList.h
@@ -80,7 +80,7 @@ class SRMList{
      * @return deque<Compound*> List of compounds
      * @see Compound
      */
-    deque<Compound*> getMatchedCompounds(string srmId, double amuQ1, double amuQ3);
+    deque<Compound*> getMatchedCompounds(string srmId, double amuQ1, double amuQ3, int polarity);
 
     /**
      * @brief store manual annotation

--- a/src/core/libmaven/SRMList.h
+++ b/src/core/libmaven/SRMList.h
@@ -5,18 +5,20 @@
 #include "databases.h"
 #include "mzSample.h"
 #include "Scan.h"
- #include <QMap> 
+#include <QMap>
 
 class SRMList{
-    public:
+  public:
 
-        SRMList(vector<mzSample*>samples, deque<Compound*> compoundsDB);
-        vector<mzSample*>samples;
+    SRMList(vector<mzSample*>samples, deque<Compound*> compoundsDB);
+    vector<mzSample*>samples;
 
-        vector<mzSlice*> getSrmSlices(double amuQ1, double amuQ3, int userPolarity, bool associateCompoundNames);
-        deque<Compound*> compoundsDB;
+    vector<mzSlice*> getSrmSlices(double amuQ1, double amuQ3, int userPolarity, bool associateCompoundNames);
+    deque<Compound*> compoundsDB;
 
-        Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt, int polarity,double amuQ1, double amuQ3);
+    Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt, int polarity,double amuQ1, double amuQ3);
+    static double getPrecursorOfSrm(string srmId);
+    static double getProductOfSrm(string srmId);
 };
 
-#endif 
+#endif

--- a/src/core/libmaven/SRMList.h
+++ b/src/core/libmaven/SRMList.h
@@ -7,24 +7,93 @@
 #include "Scan.h"
 #include <QMap>
 
+/**
+ * @brief Calculate slices and annotate filterlines (srm-ids) 
+ * 
+ * @details Slices are calculated on the basis of filterline.
+ * Each slice will have unique filterline. Slice/filterline is
+ * annotated with compound based on precursor/product m/z and 
+ * expected rt.
+ * 
+ */
 class SRMList{
   public:
 
+    /**
+     * @brief Constructor of class SRMList
+     * @param samples Samples used
+     * @param compoundsDB Compounds from reference compound database
+     */
     SRMList(vector<mzSample*>samples, deque<Compound*> compoundsDB);
-    vector<mzSample*>samples;
 
+    /**
+     * @brief Calculates and annotate slices with compound names
+     * @param amuQ1 Q1 mass tolerance
+     * @param amuQ3 Q3 mass tolerance
+     * @param userPolarity User selected polarity
+     * @param associateCompoundNames If true, slices will be annotated
+     * with compound names
+     * @return vector<mzSlice*> vector of mzSlices objects
+     * @see mzSlice
+     */
     vector<mzSlice*> getSrmSlices(double amuQ1, double amuQ3, int userPolarity, bool associateCompoundNames);
-    deque<Compound*> compoundsDB;
     
+    /**
+     * @brief Get nearest compound to precursor m/z, product m/z and
+     * expected rt
+     * @param precursorMz Mass by charge ratio of precursor
+     * @param productMz Mass by charge ratio of product
+     * @param rt Rt of slice
+     * @param polarity user polarity
+     * @param amuQ1 Q1 mass tolerance
+     * @param amuQ3 Q3 mass tolerance
+     * @return Compound* Compound from compound database
+     * @see Compound
+     */
     Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt, int polarity,double amuQ1, double amuQ3);
+
+    /**
+     * @brief Get precursor m/z from filterline (srm-id)
+     * @param srmId Filterline of scan
+     * @return double precursor m/z
+     */
     static double getPrecursorOfSrm(string srmId);
+
+    /**
+     * @brief Get product m/z from filterline (srm-id)
+     * @param srmId Filterline of scan
+     * @return double product m/z
+     */
     static double getProductOfSrm(string srmId);
+
+    /**
+     * @brief Get all the compounds which share same precursor
+     * and product m/z as filterline
+     * @param srmId filterline of scan
+     * @param amuQ1 Q1 mass tolerance
+     * @param amuQ3 Q3 mass tolerance
+     * @return deque<Compound*> List of compounds
+     * @see Compound
+     */
     deque<Compound*> getMatchedCompounds(string srmId, double amuQ1, double amuQ3);
+
+    /**
+     * @brief store manual annotation
+     * @see annotation
+     */
     void setAnnotation(map<string, Compound*> annotationCompound) {
       annotation = annotationCompound;
     }
+
+    vector<mzSample*>samples;
+
+    deque<Compound*> compoundsDB;
     
   private:
+    /**
+     * @brief Manual annotation of filterline
+     * @details Key is filterline and value is compound manually annotated
+     */
     map<string, Compound*> annotation;
 
   };

--- a/src/core/libmaven/SRMList.h
+++ b/src/core/libmaven/SRMList.h
@@ -20,6 +20,11 @@ class SRMList{
   public:
 
     /**
+     * @brief Constructor with no input parameters
+     */
+    SRMList();
+
+    /**
      * @brief Constructor of class SRMList
      * @param samples Samples used
      * @param compoundsDB Compounds from reference compound database

--- a/src/core/libmaven/SRMList.h
+++ b/src/core/libmaven/SRMList.h
@@ -15,11 +15,18 @@ class SRMList{
 
     vector<mzSlice*> getSrmSlices(double amuQ1, double amuQ3, int userPolarity, bool associateCompoundNames);
     deque<Compound*> compoundsDB;
-
+    
     Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt, int polarity,double amuQ1, double amuQ3);
     static double getPrecursorOfSrm(string srmId);
     static double getProductOfSrm(string srmId);
     deque<Compound*> getMatchedCompounds(string srmId, double amuQ1, double amuQ3);
+    void setAnnotation(map<string, Compound*> annotationCompound) {
+      annotation = annotationCompound;
+    }
+    
+  private:
+    map<string, Compound*> annotation;
+
   };
 
 #endif

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -745,8 +745,7 @@ void BackgroundPeakUpdate::findPeaksQQQ() {
         double amuQ1 = mainwindow->getSettings()->value("amuQ1").toDouble();
         double amuQ3 = mainwindow->getSettings()->value("amuQ3").toDouble();
 
-        SRMList *srmList = new SRMList(mainwindow->samples, compoundsDB);
-	vector<mzSlice*>slices = srmList->getSrmSlices(amuQ1, amuQ3, userPolarity, associateCompoundNames);
+	vector<mzSlice*>slices = mainwindow->srmList->getSrmSlices(amuQ1, amuQ3, userPolarity, associateCompoundNames);
 
         processSlices(slices,"QQQ Peaks");
 	delete_all(slices);

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -730,14 +730,25 @@ void BackgroundPeakUpdate::computePeaks() {
         processCompounds(mavenParameters->compounds, "compounds");
 }
 
+//TODO: Not being used anywhere right now - Sahil
 void BackgroundPeakUpdate::findPeaksQQQ() {
-        //Merged with Maven776 - Kiran
-	if(mainwindow == NULL) return;
+
+        if(mainwindow == NULL) return;
+
+        int userPolarity = 0;
+	if (mainwindow->getIonizationMode()) userPolarity = mainwindow->getIonizationMode();
+        
+        bool associateCompoundNames = false;
+
+        deque<Compound*> compoundsDB = DB.getCompoundsDB();
+
         double amuQ1 = mainwindow->getSettings()->value("amuQ1").toDouble();
         double amuQ3 = mainwindow->getSettings()->value("amuQ3").toDouble();
-        bool associateCompoundNames=false;
-        vector<mzSlice*>slices = mainwindow->getSrmSlices(amuQ1,amuQ3,associateCompoundNames);
-	processSlices(slices,"QQQ Peaks");
+
+        SRMList *srmList = new SRMList(mainwindow->samples, compoundsDB);
+	vector<mzSlice*>slices = srmList->getSrmSlices(amuQ1, amuQ3, userPolarity, associateCompoundNames);
+
+        processSlices(slices,"QQQ Peaks");
 	delete_all(slices);
 	slices.clear();
 }

--- a/src/gui/mzroll/background_peaks_update.h
+++ b/src/gui/mzroll/background_peaks_update.h
@@ -218,7 +218,10 @@ private:
 	void findPeaksOrbi(void);
 
 	/**
-	 * [find Peaks for QQQ mode]
+	 * @brief Find peaks using SRM Slices
+	 * @details SRM Slices are calculated on the basis of filterline (srm id).
+	 * These mzSlices are then used to find peaks.
+	 * @see SRMList
 	 */
 	void findPeaksQQQ(void);
 

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -151,7 +151,7 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
 	eicParameters->_integratedGroup.minQuality = settings->value("minQuality").toDouble();
 	eicParameters->_integratedGroup.compound = eicParameters->_slice.compound;
 	eicParameters->_integratedGroup.srmId = eicParameters->_slice.srmId;
-
+	eicParameters->_integratedGroup.setSelectedSamples(getMainWindow()->samples);
 	for (int i = 0; i < eicParameters->eics.size(); i++) {
 		EIC* eic = eicParameters->eics[i];
 		Peak peak(eic, 0);

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2748,7 +2748,7 @@ void MainWindow::showSRMList() {
 		double amuQ1 = getSettings()->value("amuQ1").toDouble();
         double amuQ3 = getSettings()->value("amuQ3").toDouble();
 
-		SRMList *srmList = new SRMList(samples, compoundsDB);
+		srmList = new SRMList(samples, compoundsDB);
 		vector<mzSlice*>slices = srmList->getSrmSlices(amuQ1, amuQ3, userPolarity, associateCompoundNames);
 
 		if (slices.size() ==  0 ) return;

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2749,6 +2749,7 @@ void MainWindow::showSRMList() {
         double amuQ3 = getSettings()->value("amuQ3").toDouble();
 
 		srmList = new SRMList(samples, compoundsDB);
+		srmList->setAnnotation(annotation);
 		vector<mzSlice*>slices = srmList->getSrmSlices(amuQ1, amuQ3, userPolarity, associateCompoundNames);
 
 		if (slices.size() ==  0 ) return;

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2728,37 +2728,30 @@ bool MainWindow::addSample(mzSample* sample) {
 	}
 }
 
-/*
-@author: Sahil-Kiran\
-*/
-//TODO: Sahil-Kiran, Added while merging mainwindow
 void MainWindow::showPeakdetectionDialog() {
 	LOGD;
     peakDetectionDialog->show();      
 }
 
-// void MainWindow::showMassSlices() {
-//    peakDetectionDialog->initPeakDetectionDialogWindow(
-//    PeakDetectionDialog::FullSpectrum );
-//    peakDetectionDialog->show(); //TODO: Sahil-Kiran, Added while merging
-//    mainwindow
-//}
-
-// void MainWindow::compoundDatabaseSearch() {
-//    peakDetectionDialog->initPeakDetectionDialogWindow(PeakDetectionDialog::CompoundDB);
-//    peakDetectionDialog->show(); //TODO: Sahil-Kiran, Added while merging
-//    mainwindow
-//}
-
 void MainWindow::showSRMList() {
 	LOGD;
-     //added while merging with Maven776 - Kiran
-     if (srmDockWidget->isVisible()) {
-        double amuQ1 = getSettings()->value("amuQ1").toDouble();
+
+	if (srmDockWidget->isVisible()) {
+
+        int userPolarity = 0;
+		if (getIonizationMode()) userPolarity = getIonizationMode();
+
+		bool associateCompoundNames = true;
+
+        deque<Compound*> compoundsDB = DB.getCompoundsDB();
+
+		double amuQ1 = getSettings()->value("amuQ1").toDouble();
         double amuQ3 = getSettings()->value("amuQ3").toDouble();
-        bool associateCompoundNames=true;
-        vector<mzSlice*>slices = getSrmSlices(amuQ1,amuQ3,associateCompoundNames);
-        if (slices.size() ==  0 ) return;
+
+		SRMList *srmList = new SRMList(samples, compoundsDB);
+		vector<mzSlice*>slices = srmList->getSrmSlices(amuQ1, amuQ3, userPolarity, associateCompoundNames);
+
+		if (slices.size() ==  0 ) return;
         srmDockWidget->setInfo(slices);
         delete_all(slices);
      }
@@ -2905,15 +2898,6 @@ void MainWindow::UndoAlignment() {
 
 	Q_EMIT(undoAlignment(listGroups));
 
-}
-
-vector<mzSlice*> MainWindow::getSrmSlices(double amuQ1, double amuQ3, bool associateCompoundNames){
-	int userPolarity = 0;
-	if (getIonizationMode()) userPolarity=getIonizationMode();
-	deque<Compound*> compoundsDB = DB.getCompoundsDB();
-	SRMList *srmList = new SRMList(samples, compoundsDB);
-	vector<mzSlice*>slices = srmList->getSrmSlices(amuQ1,amuQ3,userPolarity,associateCompoundNames);
-	return slices;
 }
 
 

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -145,7 +145,8 @@ public:
 	QString currentIntensityName;
 
 	SRMList *srmList;
-
+    map<string, Compound*> annotation;
+	
 	PathwayWidget *pathwayWidget;
 	SpectraWidget *spectraWidget;
 	AlignmentVizWidget *alignmentVizWidget;

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -336,10 +336,7 @@ public Q_SLOTS:
 	void findCovariants(Peak* _peak);
 	void reportBugs();
 	void updateEicSmoothingWindow(int value);
-    bool setPeptideSequence(QString peptideSeq); //TODO: Sahil, Added while merging point
-	//Added when merging with Maven776 - Kiran
-	vector<mzSlice*> getSrmSlices(double q1tol, double q3tol, bool associateCompoundNames);
-
+    bool setPeptideSequence(QString peptideSeq);
 	void open();
 	void print();
 	void exportPDF();

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -144,6 +144,8 @@ public:
 	QStringList pathlist;
 	QString currentIntensityName;
 
+	SRMList *srmList;
+
 	PathwayWidget *pathwayWidget;
 	SpectraWidget *spectraWidget;
 	AlignmentVizWidget *alignmentVizWidget;

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -130,6 +130,9 @@ TableDockWidget::TableDockWidget(MainWindow* mw, QString title, int numColms, in
     lowerLabel=new QLabel();
     lowerLabel->setText("Add this group too ?");
 
+    listTextView=new ListView();
+    stringModel=new QStringListModel(promptDialog);
+
 }
 
 TableDockWidget::~TableDockWidget() { 
@@ -493,23 +496,40 @@ void TableDockWidget::addRow(PeakGroup* group, QTreeWidgetItem* root) {
 
 void TableDockWidget::acceptGroup(){
     addSameMzRtGroup=true;
-    qDebug()<<"acceptedddddddddd";
     promptDialog->close();
 }
 
 void TableDockWidget::rejectGroup(){
     addSameMzRtGroup=false;
-    qDebug()<<"rejectedddddddddd";
     promptDialog->close();
 }
 
+void ListView::keyPressEvent(QKeyEvent * event){
+    if (event->matches(QKeySequence::Copy)) {
+        QApplication::clipboard()->setText(strings.join("\n"));
+      }
+}
+
 void TableDockWidget::showSameGroup(int sameMzRtGroupIndexHash){
+
+    QStringList list;
+
     for(int i=0;i<sameMzRtGroups[sameMzRtGroupIndexHash].size();++i){
+        list.append(sameMzRtGroups[sameMzRtGroupIndexHash][i]);
         qDebug()<<sameMzRtGroups[sameMzRtGroupIndexHash][i];
     }
+
+    stringModel->setStringList(list);
+
+    listTextView->setModel(stringModel);
+    listTextView->setData(list);
+    listTextView->setSelectionMode(QAbstractItemView::MultiSelection);
+    listTextView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+
     promptDialogLayout->insertWidget(0,upperLabel);
-    promptDialogLayout->insertWidget(1,lowerLabel);
-    promptDialogLayout->insertLayout(2,buttonLayout);
+    promptDialogLayout->insertWidget(1,listTextView);
+    promptDialogLayout->insertWidget(2,lowerLabel);
+    promptDialogLayout->insertLayout(3,buttonLayout);
     promptDialog->setLayout(promptDialogLayout);
     promptDialog->exec();
 
@@ -541,6 +561,7 @@ bool TableDockWidget::hasPeakGroup(PeakGroup* group) {
             }
             if(addSameMzRtGroup){
                 sameMzRtGroups[sameMzRtGroupIndexHash].append(compoundName);
+                return false;
             }
 
             return true;

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -529,7 +529,7 @@ void ListView::keyPressEvent(QKeyEvent * event){
       }
 }
 
-void TableDockWidget::showSameGroup(int sameMzRtGroupIndexHash){
+void TableDockWidget::showSameGroup(QPair<int, int> sameMzRtGroupIndexHash){
     /**
      * @details- this method will set the prompt dialog to show already bookmared
      * groups.
@@ -573,9 +573,9 @@ bool TableDockWidget::hasPeakGroup(PeakGroup* group) {
     */
 
 
-    int intMz=std::ceil(group->meanMz);
-    int intRt=std::ceil(group->meanRt);
-    int sameMzRtGroupIndexHash=intMz*intRt;
+    int intMz=group->meanMz*1e5;
+    int intRt=group->meanRt*1e5;
+    QPair<int,int> sameMzRtGroupIndexHash(intMz,intRt);
     QString compoundName=QString::fromStdString(group->compound->name);
 
     if(allgroups.size()==0){

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -110,6 +110,26 @@ TableDockWidget::TableDockWidget(MainWindow* mw, QString title, int numColms, in
 
     setAcceptDrops(true);
 
+    promptDialog=new QDialog(this);
+    promptDialogLayout=new QVBoxLayout();
+
+    QPushButton *cancel=new QPushButton();
+    cancel->setText("cancel");
+    connect(cancel,SIGNAL(clicked()),this,SLOT(rejectGroup()));
+
+    QPushButton * save=new QPushButton();
+    save->setText("save");
+    connect(save,SIGNAL(clicked()),this, SLOT(acceptGroup()));
+
+    buttonLayout=new QHBoxLayout();
+    buttonLayout->addWidget(cancel);
+    buttonLayout->addWidget(save);
+
+    upperLabel=new QLabel();
+    upperLabel->setText("Groups with same mz and rt.\nSelect and (ctrl+c) to copy");
+    lowerLabel=new QLabel();
+    lowerLabel->setText("Add this group too ?");
+
 }
 
 TableDockWidget::~TableDockWidget() { 
@@ -469,6 +489,25 @@ void TableDockWidget::addRow(PeakGroup* group, QTreeWidgetItem* root) {
     if ( group->childCount() > 0 ) {
         for( int i=0; i < group->childCount(); i++ ) addRow(&(group->children[i]), item);
     }
+}
+
+void TableDockWidget::acceptGroup(){
+    qDebug()<<"acceptedddddddddd";
+    promptDialog->close();
+}
+
+void TableDockWidget::rejectGroup(){
+    qDebug()<<"rejectedddddddddd";
+    promptDialog->close();
+}
+
+void TableDockWidget::showSameGroup(){
+    promptDialogLayout->insertWidget(0,upperLabel);
+    promptDialogLayout->insertWidget(1,lowerLabel);
+    promptDialogLayout->insertLayout(2,buttonLayout);
+    promptDialog->setLayout(promptDialogLayout);
+    promptDialog->exec();
+
 }
 
 bool TableDockWidget::hasPeakGroup(PeakGroup* group) {

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -577,8 +577,8 @@ bool TableDockWidget::hasPeakGroup(PeakGroup* group) {
     int intRt=group->meanRt*1e5;
     QPair<int,int> sameMzRtGroupIndexHash(intMz,intRt);
     QString compoundName=QString::fromStdString(group->compound->name);
-
-    if(allgroups.size()==0){
+    
+    if(allgroups.size()==0 || sameMzRtGroups[sameMzRtGroupIndexHash].size()==0){
         /**
          * add this group corresponding compound name to list of string which all share
          * same mz and rt value. Both mz and rt are hashed in sameMzRtGroupIndexHash.

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -495,34 +495,16 @@ void TableDockWidget::addRow(PeakGroup* group, QTreeWidgetItem* root) {
 }
 
 void TableDockWidget::acceptGroup(){
-    /**
-     * @details-this is a slot tied with <save> button of prompt dialog <promptDialog>
-     * to show already bookmarked group with same mz and rt value.
-     * If user press <save> button <addSameMzRtGroup> sets to true which will be used
-     * to add this group's corresponding compound name to already bookmarked group
-     * of same rt and mz value.
-    */
     addSameMzRtGroup=true;
     promptDialog->close();
 }
 
 void TableDockWidget::rejectGroup(){
-    /**
-     * @details-this is a slot tied with <save> button of prompt dialog <promptDialog>
-     * to show already bookmarked group with same mz and rt value.
-     * If user press <cancel> button <addSameMzRtGroup> sets to false which will be used
-     * to reject this group's corresponding compound name.
-    */
     addSameMzRtGroup=false;
     promptDialog->close();
 }
 
 void ListView::keyPressEvent(QKeyEvent * event){
-    /**
-     * @details- this method will execute when user select and press <ctrl + c> to copy
-     * list of compound from prompt dialog which show already bookmarked group
-     * with same rt and mz value.
-    */
     if (event->matches(QKeySequence::Copy)) {
         /**set all selected compound name to clipboard*/
         QApplication::clipboard()->setText(strings.join("\n"));
@@ -562,21 +544,10 @@ void TableDockWidget::showSameGroup(QPair<int, int> sameMzRtGroupIndexHash){
 
 bool TableDockWidget::hasPeakGroup(PeakGroup* group) {
 
-    /**
-     * @detail- this function return true if this group already present in
-     * bookmrked group <allgroups>.
-     * In case of groups with same mz and rt value, this will holds its execution
-     * by QEventLoop <loop> and show a prompt to user whether he wants to add
-     * this group to bookmarked groups or not by executing method <showSameGroup>.
-     * <loop> will hold execution of this funtion till user press a button on prompt
-     * dialog.
-    */
-
-
     int intMz=group->meanMz*1e5;
     int intRt=group->meanRt*1e5;
     QPair<int,int> sameMzRtGroupIndexHash(intMz,intRt);
-    QString compoundName=QString::fromStdString(group->compound->name);
+    QString compoundName=QString::fromStdString(group->compound->name);//
     
     if(allgroups.size()==0 || sameMzRtGroups[sameMzRtGroupIndexHash].size()==0){
         /**
@@ -1000,6 +971,24 @@ void TableDockWidget::deleteGroup(PeakGroup *groupX) {
             //Deleteing
             int posTree = treeWidget->indexOfTopLevelItem(item);
             if (posTree != -1) treeWidget->takeTopLevelItem(posTree);
+
+            /**
+             * delete name of compound associated with this group stored in <sameMzRtGroups> with
+             * given mz and rt
+             */
+            int intMz=group->meanMz*1e5;
+            int intRt=group->meanRt*1e5;
+            QPair<int,int> sameMzRtGroupIndexHash(intMz,intRt);
+            QString compoundName=QString::fromStdString(groupX->compound->name);
+            if( sameMzRtGroups[sameMzRtGroupIndexHash].contains(compoundName)){
+                for(int i=0;i<sameMzRtGroups[sameMzRtGroupIndexHash].size();++i){
+                    if(sameMzRtGroups[sameMzRtGroupIndexHash][i]==compoundName){
+                        sameMzRtGroups[sameMzRtGroupIndexHash].removeAt(i);
+                        break;
+                    }
+                }
+            }
+
             allgroups.erase(allgroups.begin()+pos);
             break;
         }

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -495,26 +495,50 @@ void TableDockWidget::addRow(PeakGroup* group, QTreeWidgetItem* root) {
 }
 
 void TableDockWidget::acceptGroup(){
+    /**
+     * @details-this is a slot tied with <save> button of prompt dialog <promptDialog>
+     * to show already bookmarked group with same mz and rt value.
+     * If user press <save> button <addSameMzRtGroup> sets to true which will be used
+     * to add this group's corresponding compound name to already bookmarked group
+     * of same rt and mz value.
+    */
     addSameMzRtGroup=true;
     promptDialog->close();
 }
 
 void TableDockWidget::rejectGroup(){
+    /**
+     * @details-this is a slot tied with <save> button of prompt dialog <promptDialog>
+     * to show already bookmarked group with same mz and rt value.
+     * If user press <cancel> button <addSameMzRtGroup> sets to false which will be used
+     * to reject this group's corresponding compound name.
+    */
     addSameMzRtGroup=false;
     promptDialog->close();
 }
 
 void ListView::keyPressEvent(QKeyEvent * event){
+    /**
+     * @details- this method will execute when user select and press <ctrl + c> to copy
+     * list of compound from prompt dialog which show already bookmarked group
+     * with same rt and mz value.
+    */
     if (event->matches(QKeySequence::Copy)) {
+        /**set all selected compound name to clipboard*/
         QApplication::clipboard()->setText(strings.join("\n"));
       }
 }
 
 void TableDockWidget::showSameGroup(int sameMzRtGroupIndexHash){
+    /**
+     * @details- this method will set the prompt dialog to show already bookmared
+     * groups.
+    */
 
     QStringList list;
 
     for(int i=0;i<sameMzRtGroups[sameMzRtGroupIndexHash].size();++i){
+        /**saving all compound name of same rt and mz value to <list> variable*/
         list.append(sameMzRtGroups[sameMzRtGroupIndexHash][i]);
         qDebug()<<sameMzRtGroups[sameMzRtGroupIndexHash][i];
     }
@@ -526,6 +550,7 @@ void TableDockWidget::showSameGroup(int sameMzRtGroupIndexHash){
     listTextView->setSelectionMode(QAbstractItemView::MultiSelection);
     listTextView->setEditTriggers(QAbstractItemView::NoEditTriggers);
 
+    /**set all widget and labels to prompt dailog*/
     promptDialogLayout->insertWidget(0,upperLabel);
     promptDialogLayout->insertWidget(1,listTextView);
     promptDialogLayout->insertWidget(2,lowerLabel);
@@ -537,12 +562,27 @@ void TableDockWidget::showSameGroup(int sameMzRtGroupIndexHash){
 
 bool TableDockWidget::hasPeakGroup(PeakGroup* group) {
 
+    /**
+     * @detail- this function return true if this group already present in
+     * bookmrked group <allgroups>.
+     * In case of groups with same mz and rt value, this will holds its execution
+     * by QEventLoop <loop> and show a prompt to user whether he wants to add
+     * this group to bookmarked groups or not by executing method <showSameGroup>.
+     * <loop> will hold execution of this funtion till user press a button on prompt
+     * dialog.
+    */
+
+
     int intMz=std::ceil(group->meanMz);
     int intRt=std::ceil(group->meanRt);
     int sameMzRtGroupIndexHash=intMz*intRt;
     QString compoundName=QString::fromStdString(group->compound->name);
 
     if(allgroups.size()==0){
+        /**
+         * add this group corresponding compound name to list of string which all share
+         * same mz and rt value. Both mz and rt are hashed in sameMzRtGroupIndexHash.
+        */
         sameMzRtGroups[sameMzRtGroupIndexHash].append(compoundName);
     }
 
@@ -553,14 +593,28 @@ bool TableDockWidget::hasPeakGroup(PeakGroup* group) {
 
             addSameMzRtGroup=false;
             if( !sameMzRtGroups[sameMzRtGroupIndexHash].contains(compoundName)){
-                showSameGroup(sameMzRtGroupIndexHash);
 
+                showSameGroup(sameMzRtGroupIndexHash);
+                /**
+                 * if bookmarked list has group with same mz and rt, loop will hold the execution
+                 * of this method after showing the prompt dialog to choose whether to add this group
+                 * by above method <showSameGroup>.
+                */
                 QEventLoop loop;
                 connect(save,SIGNAL(clicked()),&loop,SLOT(quit()));
                 connect(cancel,SIGNAL(clicked()),&loop,SLOT(quit()));
             }
             if(addSameMzRtGroup){
+                /**
+                 * if user pressed <save> button <addSameMzRtGroup> will be set to true otherwise false.
+                 * if it is true, this groups corresponding compound name will we saved by an index of 
+                 * sameMzRtGroupIndexHash to show all these string next time if a group with same rt
+                 * and mz is encountered.
+                */
                 sameMzRtGroups[sameMzRtGroupIndexHash].append(compoundName);
+                /**
+                 * return false such that calling method will add this group to bookmarked group.
+                */
                 return false;
             }
 

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -30,7 +30,8 @@ public:
     QLabel* lowerLabel;
     QPushButton *cancel;
     QPushButton * save;
-    //ListView listTextView;
+    ListView *listTextView;
+    QStringListModel* stringModel;
 
     MainWindow* _mainwindow;
     QWidget 	*dockWidgetContents;
@@ -226,6 +227,7 @@ private:
     QStringList strings;
 public:
     virtual void keyPressEvent(QKeyEvent *event) ;
+    void setData(QStringList vstrings){strings=vstrings;}
 };
 
 #endif

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -45,7 +45,7 @@ public:
     QToolButton *btnMerge;
     QMenu* btnMergeMenu;
     QLabel *titlePeakTable;
-    QMap<int,QList<QString> > sameMzRtGroups;
+    QMap<QPair<int, int>,QList<QString> > sameMzRtGroups;
     bool addSameMzRtGroup;
     vector<PeakGroup> vallgroups;  //vallgroups will be used by libmaven/jsonReports.cpp
                                 //for json export
@@ -179,7 +179,7 @@ protected Q_SLOTS:
 	  void contextMenuEvent ( QContextMenuEvent * event );
 
 private:
-    void showSameGroup(int sameMzRtGroupIndexHash);
+    void showSameGroup(QPair<int, int> sameMzRtGroupIndexHash);
           void deletePeaks();
           void addRow(PeakGroup* group, QTreeWidgetItem* root);
           void heatmapBackground(QTreeWidgetItem* item);

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -28,6 +28,8 @@ public:
     QVBoxLayout* promptDialogLayout;
     QLabel *upperLabel;
     QLabel* lowerLabel;
+    QPushButton *cancel;
+    QPushButton * save;
     //ListView listTextView;
 
     MainWindow* _mainwindow;
@@ -37,6 +39,8 @@ public:
     QToolButton *btnMerge;
     QMenu* btnMergeMenu;
     QLabel *titlePeakTable;
+    QMap<int,QList<QString> > sameMzRtGroups;
+    bool addSameMzRtGroup;
     vector<PeakGroup> vallgroups;  //vallgroups will be used by libmaven/jsonReports.cpp
                                 //for json export
     QMap<QAction*,int> mergeAction;
@@ -169,7 +173,7 @@ protected Q_SLOTS:
 	  void contextMenuEvent ( QContextMenuEvent * event );
 
 private:
-    void showSameGroup();
+    void showSameGroup(int sameMzRtGroupIndexHash);
           void deletePeaks();
           void addRow(PeakGroup* group, QTreeWidgetItem* root);
           void heatmapBackground(QTreeWidgetItem* item);

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -23,15 +23,20 @@ class TableDockWidget: public QDockWidget {
       Q_OBJECT
 
 public:
+    /**
+     * @param- promptDialog is main dialog box to show user prompt for already bookmarked
+     * groups with same mz and rt value. It will hold <save> ,<cancel>,text labels (<upperLabel>
+     * and <lowerLabel>), list of already bookmarked groups <listTextView>.
+    */
     QDialog* promptDialog;
     QHBoxLayout * buttonLayout;
-    QVBoxLayout* promptDialogLayout;
+    QVBoxLayout* promptDialogLayout;    /**@param- holds all widget (upperLabel,listTextView,lowerLabel) and <buttonLayout>*/
     QLabel *upperLabel;
     QLabel* lowerLabel;
     QPushButton *cancel;
     QPushButton * save;
-    ListView *listTextView;
-    QStringListModel* stringModel;
+    ListView *listTextView; /**@param-  holds all already group's correcponding compound name*/
+    QStringListModel* stringModel;  /**@param-  model of compound name,will be set to <listTextView>*/
 
     MainWindow* _mainwindow;
     QWidget 	*dockWidgetContents;
@@ -223,7 +228,6 @@ class TableToolBarWidgetAction : public QWidgetAction
 
 class ListView: public QListView{
 private:
-    QAbstractItemModel* itemModel;
     QStringList strings;
 public:
     virtual void keyPressEvent(QKeyEvent *event) ;

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -59,7 +59,16 @@ public:
     TableDockWidget(MainWindow* mw, QString title, int numColms, int bookmarkFlag = 0);
 	~TableDockWidget();
 
-	int  groupCount() { return allgroups.size(); }
+    int  groupCount() { return allgroups.size(); }
+    /**
+     * @detail- this function return true if this group already present in
+     * bookmrked group <allgroups>.
+     * In case of groups with same mz and rt value, this will holds its execution
+     * by QEventLoop <loop> and show a prompt to user whether he wants to add
+     * this group to bookmarked groups or not by executing method <showSameGroup>.
+     * <loop> will hold execution of this funtion till user press a button on prompt
+     * dialog.
+    */
     bool hasPeakGroup(PeakGroup* group);
 	QList<PeakGroup*> getGroups();
     int tableId;
@@ -111,8 +120,20 @@ public Q_SLOTS:
     inline void badPeakSet () {
         peakTableSelection = peakTableSelectionType::Bad;
     };
-    
+    /**
+     * @details-this is a slot tied with <save> button of prompt dialog <promptDialog>
+     * to show already bookmarked group with same mz and rt value.
+     * If user press <save> button <addSameMzRtGroup> sets to true which will be used
+     * to add this group's corresponding compound name to already bookmarked group
+     * of same rt and mz value.
+    */
     void acceptGroup();
+    /**
+     * @details-this is a slot tied with <save> button of prompt dialog <promptDialog>
+     * to show already bookmarked group with same mz and rt value.
+     * If user press <cancel> button <addSameMzRtGroup> sets to false which will be used
+     * to reject this group's corresponding compound name.
+    */
     void rejectGroup();
     void exportJson();
 	  void showSelectedGroup();
@@ -230,6 +251,11 @@ class ListView: public QListView{
 private:
     QStringList strings;
 public:
+     /**
+     * @details- this method will execute when user select and press <ctrl + c> to copy
+     * list of compound from prompt dialog which show already bookmarked group
+     * with same rt and mz value.
+    */
     virtual void keyPressEvent(QKeyEvent *event) ;
     void setData(QStringList vstrings){strings=vstrings;}
 };

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -23,6 +23,13 @@ class TableDockWidget: public QDockWidget {
       Q_OBJECT
 
 public:
+    QDialog* promptDialog;
+    QHBoxLayout * buttonLayout;
+    QVBoxLayout* promptDialogLayout;
+    QLabel *upperLabel;
+    QLabel* lowerLabel;
+    //ListView listTextView;
+
     MainWindow* _mainwindow;
     QWidget 	*dockWidgetContents;
     QHBoxLayout *horizontalLayout;
@@ -95,6 +102,8 @@ public Q_SLOTS:
         peakTableSelection = peakTableSelectionType::Bad;
     };
     
+    void acceptGroup();
+    void rejectGroup();
     void exportJson();
 	  void showSelectedGroup();
 	  void setGroupLabel(char label);
@@ -160,6 +169,7 @@ protected Q_SLOTS:
 	  void contextMenuEvent ( QContextMenuEvent * event );
 
 private:
+    void showSameGroup();
           void deletePeaks();
           void addRow(PeakGroup* group, QTreeWidgetItem* root);
           void heatmapBackground(QTreeWidgetItem* item);

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -16,6 +16,7 @@ class AlignmentVizWidget;
 class TrainDialog;
 class ClusterDialog;
 class NumericTreeWidgetItem;
+class ListView;
 using namespace std;
 
 class TableDockWidget: public QDockWidget {
@@ -42,7 +43,7 @@ public:
 	~TableDockWidget();
 
 	int  groupCount() { return allgroups.size(); }
-	bool hasPeakGroup(PeakGroup* group);
+    bool hasPeakGroup(PeakGroup* group);
 	QList<PeakGroup*> getGroups();
     int tableId;
     //Added when Merging to Maven776 - Kiran
@@ -203,6 +204,14 @@ class TableToolBarWidgetAction : public QWidgetAction
 
     private:
         QString btnName;
+};
+
+class ListView: public QListView{
+private:
+    QAbstractItemModel* itemModel;
+    QStringList strings;
+public:
+    virtual void keyPressEvent(QKeyEvent *event) ;
 };
 
 #endif

--- a/src/gui/mzroll/treedockwidget.cpp
+++ b/src/gui/mzroll/treedockwidget.cpp
@@ -412,7 +412,7 @@ void TreeDockWidget::setQQQToolBar() {
     amuQ1->setRange(0.001, 2.0);
     amuQ1->setValue(_mainWindow->getSettings()->value("amuQ1").toDouble());
     amuQ1->setSingleStep(0.1);	//amu step
-    amuQ1->setToolTip("PrecursorMz Tollarance");
+    amuQ1->setToolTip("PrecursorMz Tolerance");
     amuQ1->setSuffix(" amu");
     amuQ1->setMinimumWidth(20);
 
@@ -423,7 +423,7 @@ void TreeDockWidget::setQQQToolBar() {
     amuQ3->setRange(0.001, 2.0);
     amuQ3->setValue(_mainWindow->getSettings()->value("amuQ3").toDouble());
     amuQ3->setSingleStep(0.1);	//amu step
-    amuQ3->setToolTip("ProductMz Tollarance");
+    amuQ3->setToolTip("ProductMz Tolerance");
     amuQ3->setSuffix(" amu");
     amuQ3->setMinimumWidth(20);
     connect(amuQ3, SIGNAL(valueChanged(double)),_mainWindow->getSettingsForm(), SLOT(setQ3Tollrance(double)));
@@ -459,7 +459,10 @@ void TreeDockWidget::manualAnnotation(QTreeWidgetItem * item) {
     double amuq1 = amuQ1->value();
     double amuq3 = amuQ3->value();
 
-    deque<Compound*> matchedCompounds = _mainWindow->srmList->getMatchedCompounds(srmId, amuq1, amuq3);
+    int polarity = 0;
+    if (_mainWindow->getIonizationMode()) polarity = _mainWindow->getIonizationMode();
+
+    deque<Compound*> matchedCompounds = _mainWindow->srmList->getMatchedCompounds(srmId, amuq1, amuq3, polarity);
 
     matchCompoundMenu->clear();
     connect(matchCompoundMenu, SIGNAL(triggered(QAction*)), SLOT(annotateCompound(QAction*)));

--- a/src/gui/mzroll/treedockwidget.cpp
+++ b/src/gui/mzroll/treedockwidget.cpp
@@ -455,19 +455,24 @@ void TreeDockWidget::manualAnnotation(QTreeWidgetItem * item) {
     associateCompounds->setMenu(matchCompoundMenu);
     associateCompounds->setPopupMode(QToolButton::InstantPopup);
 
-    SRMList *srmList = new SRMList(_mainWindow->samples, DB.getCompoundsDB());
 
     double amuq1 = amuQ1->value();
     double amuq3 = amuQ3->value();
 
-    deque<Compound*> matchedCompounds = srmList->getMatchedCompounds(srmId, amuq1, amuq3);
+    deque<Compound*> matchedCompounds = _mainWindow->srmList->getMatchedCompounds(srmId, amuq1, amuq3);
 
     matchCompoundMenu->clear();
+    connect(matchCompoundMenu, SIGNAL(triggered(QAction*)), SLOT(annotateCompound(QAction*)));
 
     for (unsigned int i=0; i< matchedCompounds.size(); i++) {
         QAction* action = matchCompoundMenu->addAction(QString::fromStdString(matchedCompounds[i]->name));
-        connect(action, SIGNAL(triggered(QAction*)), SLOT(annotateCompound(QAction*)));
     }
+
+
+}
+
+void TreeDockWidget::annotateCompound(QAction* action) {
+    
 
 
 }

--- a/src/gui/mzroll/treedockwidget.cpp
+++ b/src/gui/mzroll/treedockwidget.cpp
@@ -472,7 +472,28 @@ void TreeDockWidget::manualAnnotation(QTreeWidgetItem * item) {
 }
 
 void TreeDockWidget::annotateCompound(QAction* action) {
-    
 
+    QTreeWidgetItem *item = treeWidget->currentItem();
+    QVariant v =   item->data(0,Qt::UserRole);
+    
+    QTreeWidgetItem *childItem = item->child(0);
+    string existingCompound = childItem->text(0).toStdString();
+
+    mzSlice slice = v.value<mzSlice>();
+    string srmId = slice.srmId;
+    if (srmId.empty()) return;
+
+    string compoundName = action->text().toStdString();
+
+    if (compoundName == existingCompound) return;
+
+    Q_FOREACH(Compound* compound, _mainWindow->srmList->compoundsDB) {
+
+        if(compoundName == compound->name) {
+            _mainWindow->annotation[srmId] = compound;
+        }
+    }
+
+    _mainWindow->showSRMList();
 
 }

--- a/src/gui/mzroll/treedockwidget.h
+++ b/src/gui/mzroll/treedockwidget.h
@@ -56,11 +56,16 @@ public Q_SLOTS:
       QTreeWidgetItem* addLink(mzLink* s,  QTreeWidgetItem* parent);
 
       void unlinkGroup();
+      void manualAnnotation(QTreeWidgetItem * item);
 
     private:
       //Added while merging with Maven776 - Kiran
       MainWindow* _mainWindow;
       void itemToClipboard(QTreeWidgetItem* item, QString& clipboardtext);
+      QDoubleSpinBox* amuQ1;
+      QDoubleSpinBox* amuQ3;
+      QToolButton* associateCompounds;
+      QMenu* matchCompoundMenu;
 
 };
 

--- a/src/gui/mzroll/treedockwidget.h
+++ b/src/gui/mzroll/treedockwidget.h
@@ -57,6 +57,7 @@ public Q_SLOTS:
 
       void unlinkGroup();
       void manualAnnotation(QTreeWidgetItem * item);
+      void annotateCompound(QAction* action);
 
     private:
       //Added while merging with Maven776 - Kiran

--- a/src/gui/mzroll/treedockwidget.h
+++ b/src/gui/mzroll/treedockwidget.h
@@ -56,7 +56,23 @@ public Q_SLOTS:
       QTreeWidgetItem* addLink(mzLink* s,  QTreeWidgetItem* parent);
 
       void unlinkGroup();
+
+      /**
+       * @brief Add compound selection menu to annotate compounds manually
+       * @details This slot insert menu items which contains compounds. Compounds
+       * are selected on the basis of filterline of item selected. Precursor and
+       * product m/z are calculated for the filterline and then matched with
+       * compounds in compound database with some tolerance.
+       * @param item Selected item from the qtreewidget
+       * @see SRMList
+       */
       void manualAnnotation(QTreeWidgetItem * item);
+
+      /**
+       * @brief Annotate filterline with the selected compound from the menu
+       * @param action This QAction updates the annotation of the mzSlice (filterline)
+       * @see manualAnnotation
+       */
       void annotateCompound(QAction* action);
 
     private:

--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -43,6 +43,7 @@ HEADERS += \
     testMzAligner.h \
     testCLI.h \
     testCharge.h \
+    testSRMList.h \
     $$top_srcdir/src/cli/peakdetector/PeakDetectorCLI.h \
     $$top_srcdir/src/core/libmaven/classifier.h \
     $$top_srcdir/src/core/libmaven/classifierNeuralNet.h \
@@ -64,6 +65,7 @@ SOURCES += \
     testMzAligner.cpp \
     testCLI.cpp \
     testCharge.cpp \
+    testSRMList.cpp \
     main.cpp \
     $$top_srcdir/src/cli/peakdetector/PeakDetectorCLI.cpp  \
     $$top_srcdir/src/cli/peakdetector/options.cpp \

--- a/tests/MavenTests/main.cpp
+++ b/tests/MavenTests/main.cpp
@@ -13,6 +13,7 @@
 #include "testMzAligner.h"
 #include "testCLI.h"
 #include "testCharge.h"
+#include "testSRMList.h"
 
 int readLog(QString);
 

--- a/tests/MavenTests/main.cpp
+++ b/tests/MavenTests/main.cpp
@@ -18,9 +18,6 @@ int readLog(QString);
 
 int main(int argc, char** argv) {
     QCoreApplication app(argc, argv);
-    // QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));
-    // QTextCodec::setCodecForCStrings(QTextCodec::codecForName("UTF-8"));
-
 
     int result = 0;
 
@@ -72,9 +69,9 @@ int main(int argc, char** argv) {
         result |= QTest::qExec(new TestCSVReports, argc, argv);
     result|=readLog("testCSVReports.xml");
 
-    // if(freopen("testMzAligner.xml",  "w", stdout))
-    //     result |= QTest::qExec(new TestMzAligner, argc, argv);
-    // result|=readLog("testMzAligner.xml");
+    if (freopen("testSRMList.xml", "w", stdout))
+        result |= QTest::qExec(new TestSRMList, argc, argv);
+    result|=readLog("testSRMList.xml");
 
     return result;
 }

--- a/tests/MavenTests/testSRMList.cpp
+++ b/tests/MavenTests/testSRMList.cpp
@@ -1,0 +1,32 @@
+#include "testSRMList.h"
+
+void TestSRMList::initTestCase() {
+    // This function is being executed at the beginning of each test suite
+    // That is - before other tests from this class run
+    //MavenParameters* mavenparemeters = new MavenParameters();
+    //mavenparemeters->printettings();
+}
+
+void TestSRMList::cleanupTestCase() {
+    // Similarly to initTestCase(), this function is executed at the end of test suite
+}
+
+void TestEIC::init() {
+    // This function is executed before each test
+}
+
+void TestSRMListTestSRMList::cleanup() {
+    // This function is executed after each test
+}
+
+void TestSRMList::testGetPrecursorOfSrm() {
+
+}
+
+void TestSRMList::testGetProductOfSrm() {
+
+}
+
+void TestSRMList::testGetMatchedCompounds() {
+
+}

--- a/tests/MavenTests/testSRMList.cpp
+++ b/tests/MavenTests/testSRMList.cpp
@@ -1,32 +1,52 @@
 #include "testSRMList.h"
 
+TestSRMList::TestSRMList() {
+
+    filterline1 = "- SRM SIC Q1=124 Q3=80 sample=157 period=1 experiment=1 transition=0";
+    filterline2 = "FTMS + p ESI Full ms2 209.19@hcd35.00 [50.00-230.00]";
+    filterline3 = "FTMS - p ESI Full ms [70.00-800.00]";
+}
+
 void TestSRMList::initTestCase() {
     // This function is being executed at the beginning of each test suite
     // That is - before other tests from this class run
-    //MavenParameters* mavenparemeters = new MavenParameters();
-    //mavenparemeters->printettings();
 }
 
 void TestSRMList::cleanupTestCase() {
     // Similarly to initTestCase(), this function is executed at the end of test suite
 }
 
-void TestEIC::init() {
+void TestSRMList::init() {
     // This function is executed before each test
 }
 
-void TestSRMListTestSRMList::cleanup() {
+void TestSRMList::cleanup() {
     // This function is executed after each test
 }
 
 void TestSRMList::testGetPrecursorOfSrm() {
 
+    SRMList* srmList;
+
+    double precursorMz1 = srmList->getPrecursorOfSrm(filterline1);
+    double precursorMz2 = srmList->getPrecursorOfSrm(filterline2);
+    double precursorMz3 = srmList->getPrecursorOfSrm(filterline3);
+    
+    QVERIFY(precursorMz1 == 124);
+    QVERIFY(precursorMz2 == 209.19);
+    QVERIFY(precursorMz3 == 0);
+    
 }
 
 void TestSRMList::testGetProductOfSrm() {
 
-}
+    SRMList* srmList;
 
-void TestSRMList::testGetMatchedCompounds() {
-
+    double productMz1 = srmList->getProductOfSrm(filterline1);
+    double productMz2 = srmList->getProductOfSrm(filterline2);
+    double productMz3 = srmList->getProductOfSrm(filterline3);
+    
+    QVERIFY(productMz1 == 80);
+    QVERIFY(productMz2 == 140);
+    QVERIFY(productMz3 == 435);
 }

--- a/tests/MavenTests/testSRMList.h
+++ b/tests/MavenTests/testSRMList.h
@@ -1,6 +1,10 @@
 #ifndef TESTSRMLIST_H
 #define TESTSRMLIST_H
 
+#include <QtTest>
+#include "common.h"
+#include "SRMList.h"
+
 class TestSRMList : public QObject {
     Q_OBJECT
 
@@ -17,10 +21,21 @@ class TestSRMList : public QObject {
         void init();
         void cleanup();
 
+        /**
+         * @see SRMList
+         */
         void testGetPrecursorOfSrm();
-        void testGetProductOfSrm();
-        void testGetMatchedCompounds();
 
+        /**
+         * @see SRMList
+         */
+        void testGetProductOfSrm();
+
+    private:
+        string filterline1;
+        string filterline2;
+        string filterline3;
+        
 };
 
 #endif // TESTSRMLIST_H

--- a/tests/MavenTests/testSRMList.h
+++ b/tests/MavenTests/testSRMList.h
@@ -1,0 +1,26 @@
+#ifndef TESTSRMLIST_H
+#define TESTSRMLIST_H
+
+class TestSRMList : public QObject {
+    Q_OBJECT
+
+    public:
+        TestSRMList();
+
+    private Q_SLOTS:
+
+        // functions executed by QtTest before and after test suite
+        void initTestCase();
+        void cleanupTestCase();
+
+        // functions executed by QtTest before and after each test
+        void init();
+        void cleanup();
+
+        void testGetPrecursorOfSrm();
+        void testGetProductOfSrm();
+        void testGetMatchedCompounds();
+
+};
+
+#endif // TESTSRMLIST_H


### PR DESCRIPTION
This branch has all changes of one previousy branch
<fix_csv_export_shift_drag> which was based on <develop>
,but this one is based on <new_dir_structure>.

        CSV exported by holding shift key down and dragging mouse
had no info for samples because here new object of <PeakGroup>
is generated but <samples> were not assigned to this group.
        Now all selected samples has been assigned to group.

One new function <setSelectedSamples> has been introduced into
<PeakGroup.cpp> file which will assign all selected samples to it's
<samples> varible and all manual sample selection and assignment
has been removed from all other places

Issue:#390