### PR TITLE
Fix: Change number of groups

### DIFF
--- a/tests/MavenTests/testCLI.cpp
+++ b/tests/MavenTests/testCLI.cpp
@@ -138,10 +138,9 @@ void TestCLI::testReduceGroups() {
 		vector<mzSlice*> slices = peakdetectorCLI->peakDetector->processCompounds(
 				peakdetectorCLI->mavenParameters->compounds, "compounds");
         peakdetectorCLI->peakDetector->processSlices(slices, "compounds");
-
-        QVERIFY(peakdetectorCLI->mavenParameters->allgroups.size() == 28);
+        QVERIFY(peakdetectorCLI->mavenParameters->allgroups.size() == 21);
         peakdetectorCLI->reduceGroups();
-        QVERIFY(peakdetectorCLI->mavenParameters->allgroups.size() == 26);
+        QVERIFY(peakdetectorCLI->mavenParameters->allgroups.size() == 19);
 		delete_all(slices);
 	}
 


### PR DESCRIPTION
	Test case is failing because in commit #7aa394d , smoothening
algorithm changed. This produces different number of groups.