### PR TITLE
Changes required to compile El-Maven on Mac OS

### DIFF
--- a/3rdparty/3rdparty.pro
+++ b/3rdparty/3rdparty.pro
@@ -2,4 +2,7 @@ TEMPLATE = subdirs
 CONFIG += ordered qt thread
 
 
-SUBDIRS += libneural libcdfread libplog libcsvparser pugixml/src  libpillow libpls
+SUBDIRS += libneural libcdfread  libcsvparser pugixml/src  libpillow libpls
+!macx {
+    SUBDIRS += libplog
+}

--- a/3rdparty/libcdfread/libcdfread.pro
+++ b/3rdparty/libcdfread/libcdfread.pro
@@ -13,6 +13,12 @@ INCLUDEPATH += ./include
 
 LIBS += -lnetcdf
 
+macx {
+        INCLUDEPATH += /usr/local/opt/netcdf/include
+        QMAKE_LFLAGS += -L/usr/local/opt/netcdf/lib
+        LIBS += -lnetcdf
+}
+
 SOURCES=ms10aux.c ms10enum.c ms10io.c
 HEADERS=ms10.h ms10io.h
 

--- a/build.pro
+++ b/build.pro
@@ -1,5 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered qt thread
 
+macx{
+    QMAKE_CXX = /usr/local/opt/llvm@3.7/lib/llvm-3.7/bin/clang++
+}
+
 SUBDIRS += 3rdparty src tests/MavenTests CrashReporter
 

--- a/mzroll.pri
+++ b/mzroll.pri
@@ -18,6 +18,12 @@ win32 {
     DEFINES += WIN32
 }
 
+unix: {
+    INCLUDEPATH += /usr/local/include/
+    QMAKE_LFLAGS += -L/usr/local/lib/
+    LIBS +=  -lboost_signals
+}
+
 #INSTALL_LIBDIR = $$(INSTALL_LIBDIR)
 #unix {
 #  !mac {

--- a/src/cli/peakdetector/peakdetector.pro
+++ b/src/cli/peakdetector/peakdetector.pro
@@ -9,7 +9,7 @@ TARGET = peakdetector
 
 CONFIG += warn_off xml -std=c++14
 
-LIBS += -fopenmp
+!macx: LIBS += -fopenmp
 
 INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  $$top_srcdir/3rdparty/pugixml/src $$top_srcdir/3rdparty/libneural $$top_srcdir/3rdparty/libpls \
 				$$top_srcdir/3rdparty/libcsvparser

--- a/src/core/libmaven/libmaven.pro
+++ b/src/core/libmaven/libmaven.pro
@@ -14,8 +14,8 @@ CONFIG += staticlib warn_off console silent
 QMAKE_CXXFLAGS += -Ofast -ffast-math -march=native -std=c++11
 QMAKE_CXXFLAGS += -DOMP_PARALLEL
 
-QMAKE_CXXFLAGS += -fopenmp
-LIBS += -fopenmp
+!macx: QMAKE_CXXFLAGS += -fopenmp
+!macx: LIBS += -fopenmp
 
 TARGET = maven
 
@@ -23,6 +23,14 @@ LIBS += -L. -lcsvparser
 
 INCLUDEPATH +=  $$top_srcdir/3rdparty/pugixml/src/ $$top_srcdir/3rdparty/libcdfread/  $$top_srcdir/src/gui/mzroll/ $$top_srcdir/3rdparty/libneural/ \
                 $$top_srcdir/3rdparty/libcsvparser
+
+
+macx{
+
+    INCLUDEPATH += /usr/local/include/
+    QMAKE_LFLAGS += -L/usr/local/lib/
+    LIBS +=  -lboost_signals
+}
 
 message($$INCLUDEPATH)
 SOURCES = 	base64.cpp \

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -12,8 +12,8 @@ CONFIG += qt thread warn_off sql svg console precompile_header
 
 QMAKE_CXXFLAGS += -Ofast -ffast-math -march=native -std=c++11
 QMAKE_CXXFLAGS += -DOMP_PARALLEL
-QMAKE_CXXFLAGS += -fopenmp
-LIBS += -fopenmp
+!macx: QMAKE_CXXFLAGS += -fopenmp
+!macx: LIBS += -fopenmp
 
 
 QMAKE_STRIP=echo
@@ -50,6 +50,9 @@ win32 {
 
 
 LIBS +=  -lmaven -lpugixml -lneural -lcsvparser -lpls -lplog                  #64bit
+macx {
+    LIBS -= -lplog
+}
 message($$LDFLAGS)
 
 INSTALLS += sources target

--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -16,7 +16,7 @@ CONFIG += qtestlib warn_off
 
 QMAKE_CXXFLAGS += -Ofast -ffast-math -march=native -std=c++11
 QMAKE_CXXFLAGS += -DOMP_PARALLEL
-QMAKE_CXXFLAGS += -fopenmp
+!macx: QMAKE_CXXFLAGS += -fopenmp
 
 INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  $$top_srcdir/3rdparty/pugixml/src $$top_srcdir/3rdparty/libneural $$top_srcdir/3rdparty/libpls \
 				$$top_srcdir/3rdparty/libcsvparser $$top_srcdir/src/cli/peakdetector
@@ -24,7 +24,8 @@ INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  $$top_srcdir/3rdparty/pugixml/sr
 
 QMAKE_LFLAGS += -L$$top_builddir/libs/
 
-LIBS += -lmaven -lpugixml -lneural -lcsvparser -lpls -fopenmp
+LIBS += -lmaven -lpugixml -lneural -lcsvparser -lpls
+!macx: LIBS += -fopenmp
 
 
 # Input


### PR DESCRIPTION
* Disable openmp
* use llvm/clang version 3.7
* disable libplog
* set correct path for boost and netcdf