### PR TITLE
Fix: Use adjusted mass for calculating ppmdiff when formula is given

### DIFF
--- a/src/core/libmaven/Compound.cpp
+++ b/src/core/libmaven/Compound.cpp
@@ -19,7 +19,7 @@ Compound::Compound(string id, string name, string formula, int charge ) {
     _groupUnlinked=false;
 }
 
-float Compound::ajustedMass(int charge) { 
+float Compound::adjustedMass(int charge) { 
      /**   
     *@return    -    total mass by formula minus loss of electrons' mass 
     *@see  -  double MassCalculator::computeMass(string formula, int charge) in mzMassCalculator.cpp

--- a/src/core/libmaven/Compound.h
+++ b/src/core/libmaven/Compound.h
@@ -81,7 +81,7 @@ class Compound{
         vector<float>fragment_intensity;    /**@param  -  intensities of fragments generated from this compund     */
         vector<string> category;    /**@param  -   categories of this compund- peptide etc.   */
 
-        float ajustedMass(int charge);  /**   total mass by formula minus loss of electrons' mass  */
+        float adjustedMass(int charge);  /**   total mass by formula minus loss of electrons' mass  */
         void addReaction(Reaction* r) { reactions.push_back(r); }   /**  add reaction of this compound   */
         /**
         *@brief   -  utility function to compare compound by mass

--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -426,7 +426,7 @@ double PeakGroup::getExpectedMz(int charge, map<string, bool> isotopeAtom, int n
     else if (!isIsotope() && compound && compound->mass > 0) {
         float mz = 0;
         if (!compound->formula.empty()) {
-            mz = compound->ajustedMass(charge);
+            mz = compound->adjustedMass(charge);
         } else {
             mz = compound->mass;
         }

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -297,8 +297,14 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         // TODO: Added this while merging this file
         compoundID   = sanitizeString(group->compound->id.c_str()).toStdString();
         formula = sanitizeString(group->compound->formula.c_str()).toStdString();
-        ppmDist = mzUtils::ppmDist((double) group->compound->mass,
+        if (!group->compound->formula.empty()) {
+            int charge = getMavenParameters()->getCharge(group->compound);
+            ppmDist = mzUtils::ppmDist((double) group->compound->adjustedMass(charge),
                 (double) group->meanMz);
+        }
+        else {
+            ppmDist = mzUtils::ppmDist((double) group->compound->mass, (double) group->meanMz);
+        }
         expectedRtDiff = group->expectedRtDiff;
 
         // TODO: Added this while merging this file

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1402,7 +1402,7 @@ void EicWidget::setCompound(Compound* c) {
 
 	if (!c->formula.empty()) {
 		int charge = getMainWindow()->mavenParameters->getCharge(c);
-		mz = c->ajustedMass(charge);
+		mz = c->adjustedMass(charge);
 	} else {
 		mz = c->mass;
 	}

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -341,7 +341,7 @@ void LigandWidget::showTable() {
 
         if (compound->formula.length()) {
             int charge = _mw->mavenParameters->getCharge(compound);
-            mz = compound->ajustedMass(charge);
+            mz = compound->adjustedMass(charge);
         } 
         else {
             mz = compound->mass;
@@ -583,7 +583,7 @@ QList<Compound*> LigandWidget::parseXMLRemoteCompounds()
                 if (remoteCompound !=NULL) {
 
                     if (!remoteCompound->formula.empty()) {
-                        remoteCompound->mass=remoteCompound->ajustedMass(0);
+                        remoteCompound->mass=remoteCompound->adjustedMass(0);
                     }
 
 					if (remoteCompound->name == "Unknown") {
@@ -686,7 +686,7 @@ void LigandWidget::matchFragmentation() {
 
     int charge = _mw->mavenParameters->getCharge(c); //user specified ionization mode
 	float precursorMz = c->precursorMz;
-    if (!c->formula.empty()) precursorMz = c->ajustedMass(charge);
+    if (!c->formula.empty()) precursorMz = c->adjustedMass(charge);
 
     for(int i=0; i < mzCount; i++ ) {
 			float mz = c->fragment_mzs[i];

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1306,7 +1306,7 @@ void MainWindow::setCompoundFocus(Compound*c) {
 
 	float mz = c->mass;
 	if (!c->formula.empty())
-		mz = c->ajustedMass(charge);
+		mz = c->adjustedMass(charge);
 
 	//if (pathwayWidget != NULL && pathwayWidget->isVisible() ) {
 	//  pathwayWidget->clear();
@@ -3105,7 +3105,7 @@ bool MainWindow::checkCompoundExistance(Compound* c) {
 	// if (getIonizationMode())
 	// 	charge = getIonizationMode(); //user specified ionization mode
 	charge = mavenParameters->getCharge(c);
-	float mz = c->ajustedMass(charge);
+	float mz = c->adjustedMass(charge);
 	float mzmin = mz - mz / 1e6 * 3;
 	float mzmax = mz + mz / 1e6 * 3;
 


### PR DESCRIPTION
ppmdiff was being calculated according to the compound mass every time.

Change made:
- Adjusted Mass is used if compound formula is present.
- Compound Mass is used when compound formula has not been provided
- fixed typo in function name