### PR TITLE
Fix: Update access to group compound

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -629,8 +629,8 @@ void PeakGroup::reorderSamples() {
 string PeakGroup::getName() {
     string tag;
     if (compound) tag = compound->name;
-    if (tagString.empty()) tag += " | " + tagString;
-    if (srmId.empty()) tag +=  " | " + srmId;
+    if (!tagString.empty()) tag += " | " + tagString;
+    if (!srmId.empty()) tag +=  " | " + srmId;
     if (tag.empty()) tag = integer2string(groupId);
     return tag;
 }

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -299,8 +299,13 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         formula = sanitizeString(group->compound->formula.c_str()).toStdString();
         if (!group->compound->formula.empty()) {
             int charge = getMavenParameters()->getCharge(group->compound);
-            ppmDist = mzUtils::ppmDist((double) group->compound->adjustedMass(charge),
+            if (group->parent != NULL) {
+                ppmDist = mzUtils::ppmDist((double) group->getExpectedMz(charge, getMavenParameters()->isotopeAtom, getMavenParameters()->noOfIsotopes), (double) group->meanMz);
+            }
+            else {
+                ppmDist = mzUtils::ppmDist((double) group->compound->adjustedMass(charge),
                 (double) group->meanMz);
+            }
         }
         else {
             ppmDist = mzUtils::ppmDist((double) group->compound->mass, (double) group->meanMz);

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -979,7 +979,7 @@ void TableDockWidget::deleteGroup(PeakGroup *groupX) {
             int intMz=group->meanMz*1e5;
             int intRt=group->meanRt*1e5;
             QPair<int,int> sameMzRtGroupIndexHash(intMz,intRt);
-            QString compoundName=QString::fromStdString(groupX->compound->name);
+            QString compoundName=QString::fromStdString(groupX->getName());
             if( sameMzRtGroups[sameMzRtGroupIndexHash].contains(compoundName)){
                 for(int i=0;i<sameMzRtGroups[sameMzRtGroupIndexHash].size();++i){
                     if(sameMzRtGroups[sameMzRtGroupIndexHash][i]==compoundName){

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -547,7 +547,7 @@ bool TableDockWidget::hasPeakGroup(PeakGroup* group) {
     int intMz=group->meanMz*1e5;
     int intRt=group->meanRt*1e5;
     QPair<int,int> sameMzRtGroupIndexHash(intMz,intRt);
-    QString compoundName=QString::fromStdString(group->compound->name);//
+    QString compoundName=QString::fromStdString(group->getName());//
     
     if(allgroups.size()==0 || sameMzRtGroups[sameMzRtGroupIndexHash].size()==0){
         /**


### PR DESCRIPTION
El-Maven was crashing because compound name was accessed but
there wasn't any compound