### PR TITLE
Fix: Use expectedMz of isotope for ppmDiff calculation #235

### DIFF
--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -299,8 +299,13 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         formula = sanitizeString(group->compound->formula.c_str()).toStdString();
         if (!group->compound->formula.empty()) {
             int charge = getMavenParameters()->getCharge(group->compound);
-            ppmDist = mzUtils::ppmDist((double) group->compound->adjustedMass(charge),
+            if (group->parent != NULL) {
+                ppmDist = mzUtils::ppmDist((double) group->getExpectedMz(charge, getMavenParameters()->isotopeAtom, getMavenParameters()->noOfIsotopes), (double) group->meanMz);
+            }
+            else {
+                ppmDist = mzUtils::ppmDist((double) group->compound->adjustedMass(charge),
                 (double) group->meanMz);
+            }
         }
         else {
             ppmDist = mzUtils::ppmDist((double) group->compound->mass, (double) group->meanMz);


### PR DESCRIPTION
ppmDiff in csvreport was being calculated using the expected mz for the parent.

Issue: #235