### PR TITLE
Fix: Update QSetting on starting #431

### DIFF
--- a/src/gui/mzroll/main.cpp
+++ b/src/gui/mzroll/main.cpp
@@ -56,6 +56,7 @@ int main(int argc, char *argv[])
     splash.finish(mainWindow);
     mainWindow->show();
     mainWindow->fileLoader->start();
+    mainWindow->settingsForm->getFormValues();
     int rv = app.exec();
     return rv;
 


### PR DESCRIPTION
QSettings instance was not updated on starting of ElMaven.

After creating instance of MainWindow, QSettings is updated from
value of GUI forms

Issue: #431