### PR TITLE
UI: Correct misleading quantile slider value #267

### DIFF
--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -392,7 +392,7 @@ void mzSample::parseMzMLChromatogromList(xml_node chromatogramList)
 	std::sort(scans.begin(), scans.end(), Scan::compRt);
 	for (unsigned int i = 0; i < scans.size(); i++)
 	{
-		scans[i]->scannum = i + 1;
+		scans[i]->scannum = i;
 	}
 }
 

--- a/src/gui/mzroll/forms/alignmentdialog.ui
+++ b/src/gui/mzroll/forms/alignmentdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>520</width>
-    <height>663</height>
+    <height>667</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -354,6 +354,24 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>minGoodPeakCount</tabstop>
+  <tabstop>limitGroupCount</tabstop>
+  <tabstop>groupingWindow</tabstop>
+  <tabstop>minGroupIntensity</tabstop>
+  <tabstop>minSN</tabstop>
+  <tabstop>minPeakWidth</tabstop>
+  <tabstop>peakDetectionAlgo</tabstop>
+  <tabstop>selectDatabaseComboBox</tabstop>
+  <tabstop>minIntensity</tabstop>
+  <tabstop>maxIntensity</tabstop>
+  <tabstop>alignAlgo</tabstop>
+  <tabstop>maxItterations</tabstop>
+  <tabstop>polynomialDegree</tabstop>
+  <tabstop>UndoAlignment</tabstop>
+  <tabstop>alignButton</tabstop>
+  <tabstop>cancelButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/mzroll/forms/peakdetectiondialog.ui
+++ b/src/gui/mzroll/forms/peakdetectiondialog.ui
@@ -998,6 +998,56 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tabwidget</tabstop>
+  <tabstop>featureOptions</tabstop>
+  <tabstop>ppmStep</tabstop>
+  <tabstop>mzMin</tabstop>
+  <tabstop>mzMax</tabstop>
+  <tabstop>rtStep</tabstop>
+  <tabstop>rtMin</tabstop>
+  <tabstop>rtMax</tabstop>
+  <tabstop>ignoreIsotopes</tabstop>
+  <tabstop>minIntensity</tabstop>
+  <tabstop>maxIntensity</tabstop>
+  <tabstop>chargeMin</tabstop>
+  <tabstop>chargeMax</tabstop>
+  <tabstop>dbOptions</tabstop>
+  <tabstop>compoundDatabase</tabstop>
+  <tabstop>compoundPPMWindow</tabstop>
+  <tabstop>matchRt</tabstop>
+  <tabstop>compoundRTWindow</tabstop>
+  <tabstop>eicMaxGroups</tabstop>
+  <tabstop>matchFragmentatioOptions</tabstop>
+  <tabstop>doubleSpinBox_2</tabstop>
+  <tabstop>doubleSpinBox</tabstop>
+  <tabstop>minFragMatchScore</tabstop>
+  <tabstop>reportIsotopesOptions</tabstop>
+  <tabstop>changeIsotopeOptions</tabstop>
+  <tabstop>minGroupIntensity</tabstop>
+  <tabstop>peakQuantitation</tabstop>
+  <tabstop>quantileIntensity</tabstop>
+  <tabstop>doubleSpinBoxMinQuality</tabstop>
+  <tabstop>quantileQuality</tabstop>
+  <tabstop>sigBlankRatio</tabstop>
+  <tabstop>quantileSignalBlankRatio</tabstop>
+  <tabstop>sigBaselineRatio</tabstop>
+  <tabstop>quantileSignalBaselineRatio</tabstop>
+  <tabstop>minNoNoiseObs</tabstop>
+  <tabstop>minGoodGroupCount</tabstop>
+  <tabstop>classificationModelFilename</tabstop>
+  <tabstop>loadModelButton</tabstop>
+  <tabstop>computeButton</tabstop>
+  <tabstop>cancelButton</tabstop>
+  <tabstop>saveMethodButton</tabstop>
+  <tabstop>loadMethodButton</tabstop>
+  <tabstop>methodSummary</tabstop>
+  <tabstop>groupBox</tabstop>
+  <tabstop>outputTableComboBox</tabstop>
+  <tabstop>groupBox_3</tabstop>
+  <tabstop>outputDirName</tabstop>
+  <tabstop>setOutputDirButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/mzroll/forms/settingsform.ui
+++ b/src/gui/mzroll/forms/settingsform.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1305</width>
+    <width>1341</width>
     <height>318</height>
    </rect>
   </property>
@@ -851,14 +851,14 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Droid Sans Mono,Courier New,monospace,Droid Sans Fallback'; font-size:11pt; color:#000000;&quot;&gt;score = 1.0/((distX*A)+0.01)/((distY*B)+0.01)*(C*overlap)&lt;/span&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;where&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	distX = Rt difference of peaks being compared&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	A = Weight of distX&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	distY = Difference between peak Intensities&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	B = Weight of distY&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	overlap = Overlap of peaks (between 0 to 1)&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	C = Overlap weight&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p align=&quot;center&quot; style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Droid Sans Mono,Courier New,monospace,Droid Sans Fallback'; color:#000000;&quot;&gt;score = 1.0/((distX*A)+0.01)/((distY*B)+0.01)*(C*overlap)&lt;/span&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;where&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	distX = Rt difference of peaks being compared&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	A = Weight of distX&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	distY = Difference between peak Intensities&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	B = Weight of distY&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	overlap = Overlap of peaks (between 0 to 1)&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	C = Overlap weight&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
@@ -869,12 +869,12 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Droid Sans Mono,Courier New,monospace,Droid Sans Fallback'; font-size:11pt; color:#000000;&quot;&gt;score = 1.0/((distX*A)+0.01)/((distY*B)+0.01)&lt;/span&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;where&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	distX = Rt difference of peaks being compared&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	A = Weight of distX&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	distY = Difference between peak Intensities&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;	B = Weight of distY&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Droid Sans Mono,Courier New,monospace,Droid Sans Fallback'; color:#000000;&quot;&gt;score = 1.0/((distX*A)+0.01)/((distY*B)+0.01)&lt;/span&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;where&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	distX = Rt difference of peaks being compared&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	A = Weight of distX&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	distY = Difference between peak Intensities&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;	B = Weight of distY&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
@@ -1032,21 +1032,21 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;Group Rank = ((1.1 - Q)^A) * (1 /( log(I + 1))^B) * (dRT)^(2*C)&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;Where   &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                Q =  Quality of a group &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                A =  Quality Weightage&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                I  =  Intensity of a group   &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;               B =  Intensity Weightage&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;               dRT = Difference between compound retention time and group mean retention time&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;               C =  dRT Weightage&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Group Rank = ((1.1 - Q)^A) * (1 /( log(I + 1))^B) * (dRT)^(2*C)&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Where   &lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                Q =  Quality of a group &lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                A =  Quality Weightage&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                I  =  Intensity of a group   &lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;               B =  Intensity Weightage&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;               dRT = Difference between compound retention time and group mean retention time&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;               C =  dRT Weightage&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
        <widget class="QTextBrowser" name="formulaWithoutRt">
@@ -1063,17 +1063,17 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;Group Rank = ((1.1 - Q)^A) * (1 /( log(I + 1))^B) &lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;Where   &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                Q =  Quality of a group &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                A =  Quality Weightage&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;                I  =  Intensity of a group   &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:11pt;&quot;&gt;               B =  Intensity Weightage&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Group Rank = ((1.1 - Q)^A) * (1 /( log(I + 1))^B) &lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Where   &lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                Q =  Quality of a group &lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                A =  Quality Weightage&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;                I  =  Intensity of a group   &lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;               B =  Intensity Weightage&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </widget>
@@ -1348,6 +1348,71 @@ p, li { white-space: pre-wrap; }
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>ionizationMode</tabstop>
+  <tabstop>amuQ1</tabstop>
+  <tabstop>ionizationType</tabstop>
+  <tabstop>amuQ3</tabstop>
+  <tabstop>instrumentType</tabstop>
+  <tabstop>filterlineComboBox</tabstop>
+  <tabstop>centroid_scan_flag</tabstop>
+  <tabstop>scan_filter_polarity</tabstop>
+  <tabstop>scan_filter_mslevel</tabstop>
+  <tabstop>scan_filter_min_quantile</tabstop>
+  <tabstop>scan_filter_min_intensity</tabstop>
+  <tabstop>checkBoxMultiprocessing</tabstop>
+  <tabstop>eic_smoothingAlgorithm</tabstop>
+  <tabstop>eic_smoothingWindow</tabstop>
+  <tabstop>grouping_maxRtWindow</tabstop>
+  <tabstop>baseline_quantile</tabstop>
+  <tabstop>baseline_smoothing</tabstop>
+  <tabstop>minSignalBaselineDifference</tabstop>
+  <tabstop>D2Labeled_BPE</tabstop>
+  <tabstop>C13Labeled_BPE</tabstop>
+  <tabstop>N15Labeled_BPE</tabstop>
+  <tabstop>S34Labeled_BPE</tabstop>
+  <tabstop>D2Labeled_Barplot</tabstop>
+  <tabstop>C13Labeled_Barplot</tabstop>
+  <tabstop>N15Labeled_Barplot</tabstop>
+  <tabstop>S34Labeled_Barplot</tabstop>
+  <tabstop>D2Labeled_IsoWidget</tabstop>
+  <tabstop>C13Labeled_IsoWidget</tabstop>
+  <tabstop>N15Labeled_IsoWidget</tabstop>
+  <tabstop>S34Labeled_IsoWidget</tabstop>
+  <tabstop>noOfIsotopes</tabstop>
+  <tabstop>doubleSpinBoxAbThresh</tabstop>
+  <tabstop>minIsotopicCorrelation</tabstop>
+  <tabstop>maxIsotopeScanDiff</tabstop>
+  <tabstop>maxNaturalAbundanceErr</tabstop>
+  <tabstop>isotopicMinSignalBaselineDifference</tabstop>
+  <tabstop>isotopeC13Correction</tabstop>
+  <tabstop>eicTypeComboBox</tabstop>
+  <tabstop>formulaWithOverlap</tabstop>
+  <tabstop>formulaWithoutOverlap</tabstop>
+  <tabstop>useOverlap</tabstop>
+  <tabstop>distXSlider</tabstop>
+  <tabstop>distYSlider</tabstop>
+  <tabstop>overlapSlider</tabstop>
+  <tabstop>formulaWithRt</tabstop>
+  <tabstop>formulaWithoutRt</tabstop>
+  <tabstop>deltaRTCheck</tabstop>
+  <tabstop>qualityWeight</tabstop>
+  <tabstop>intensityWeight</tabstop>
+  <tabstop>deltaRTWeight</tabstop>
+  <tabstop>data_server_url</tabstop>
+  <tabstop>fetchCompounds</tabstop>
+  <tabstop>methodsFolderSelect</tabstop>
+  <tabstop>methodsFolder</tabstop>
+  <tabstop>pathwaysFolderSelect</tabstop>
+  <tabstop>pathwaysFolder</tabstop>
+  <tabstop>scriptsFolderSelect</tabstop>
+  <tabstop>scriptsFolder</tabstop>
+  <tabstop>rawExtractSelect</tabstop>
+  <tabstop>RawExtractProgram</tabstop>
+  <tabstop>RProgramSelect</tabstop>
+  <tabstop>Rprogram</tabstop>
+ </tabstops>
  <resources>
   <include location="../mzroll.qrc"/>
  </resources>

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1262,14 +1262,15 @@ PeakGroup* MainWindow::bookmarkPeakGroup(PeakGroup* group) {
 void MainWindow::setFormulaFocus(QString formula) {
 	int charge = 0;
 	mavenParameters->formulaFlag = true;
-	//if (getIonizationMode())
-	charge = mavenParameters->getCharge(); //user specified ionization mode
+	charge = mavenParameters->getCharge();
 	mavenParameters->formulaFlag = false;
-	// MassCalculator mcalc;
-	double parentMass = MassCalculator::computeMass(formula.toStdString(), charge);
-	if (eicWidget->isVisible())
-		eicWidget->setMzSlice(parentMass);
-	isotopeWidget->setFormula(formula);
+
+	if (eicWidget->isVisible()) {
+		string compoundName = "Compound-" + formula.toStdString();
+		string compoundId = compoundName;
+		Compound* c = new Compound(compoundId, compoundName, formula.toStdString(), charge);
+		setCompoundFocus(c);
+	}		
 }
 
 void MainWindow::setPathwayFocus(Pathway* p) {

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -402,32 +402,60 @@ void PeakDetectionDialog::findPeaks() {
 void PeakDetectionDialog::showIntensityQuantileStatus(int value) {
     mainwindow->mavenParameters->quantileIntensity= value;
     settings->setValue("quantileIntensity", (quantileIntensity->value()));
-    std::string stat(std::to_string(value) + "% peaks above minimum intensity");
-    QString qstat = QString::fromStdString(stat);
+    QString qstat;
+    if (value) {
+        std::string stat(std::to_string(value) + "% peaks above minimum intensity");
+        qstat = QString::fromStdString(stat);
+    }
+    else {
+        std::string stat("1 peak above minimum intensity");
+        qstat = QString::fromStdString(stat);
+    }
     intensityQuantileStatus->setText(qstat);
 }
 
 void PeakDetectionDialog::showQualityQuantileStatus(int value) {
     mainwindow->mavenParameters->quantileQuality= value;
     settings->setValue("quantileQuality", (quantileQuality->value()));
-    std::string stat(std::to_string(value) + "% peaks above minimum quality");
-    QString qstat = QString::fromStdString(stat);
+    QString qstat;
+    if (value) {
+        std::string stat(std::to_string(value) + "% peaks above minimum quality");
+        qstat = QString::fromStdString(stat);
+    }
+    else {
+        std::string stat("1 peak above minimum quality");
+        qstat = QString::fromStdString(stat);
+    }
     qualityQuantileStatus->setText(qstat);
 }
 
 void PeakDetectionDialog::showBaselineQuantileStatus(int value) {
     mainwindow->mavenParameters->quantileSignalBaselineRatio= value;
     settings->setValue("quantileSignalBaselineRatio", (quantileSignalBaselineRatio->value()));
-    std::string stat(std::to_string(value) + "% peaks above minimum signal/baseline ratio");
-    QString qstat = QString::fromStdString(stat);
+    QString qstat;
+    if (value) {
+        std::string stat(std::to_string(value) + "% peaks above minimum signal/baseline ratio");        
+        qstat = QString::fromStdString(stat);
+    }
+    else {
+        std::string stat("1 peak above minimum signal/baseline ratio");
+        qstat = QString::fromStdString(stat);
+    }
     baselineQuantileStatus->setText(qstat);
 }
 
 void PeakDetectionDialog::showBlankQuantileStatus(int value) {
     mainwindow->mavenParameters->quantileSignalBlankRatio= value;
     settings->setValue("quantileSignalBlankRatio", (quantileSignalBlankRatio->value()));
-    std::string stat(std::to_string(value) + "% peaks above minimum signal/blank ratio");
-    QString qstat = QString::fromStdString(stat);
+    QString qstat;
+    if (value) {
+        std::string stat(std::to_string(value) + "% peaks above minimum signal/blank ratio");
+        qstat = QString::fromStdString(stat);
+    }
+    else {
+        std::string stat("1 peak above minimum signal/blank ratio");
+        qstat = QString::fromStdString(stat);
+    }
     blankQuantileStatus->setText(qstat);
 }
 


### PR DESCRIPTION
Even when the quantile filters in peak detection dialog are set to 0%, at least 1 peak has to qualify the parameters set.

This was not intuitive. Slider status now shows "1 peak above minimum" when the value is 0%.

Issue: #267