### PR TITLE
Fix: Assign right scan no. for MS/MS #341

### DIFF
--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -392,7 +392,7 @@ void mzSample::parseMzMLChromatogromList(xml_node chromatogramList)
 	std::sort(scans.begin(), scans.end(), Scan::compRt);
 	for (unsigned int i = 0; i < scans.size(); i++)
 	{
-		scans[i]->scannum = i + 1;
+		scans[i]->scannum = i;
 	}
 }
 


### PR DESCRIPTION
scan no. was updating wrong for ms/ms- having
a increment of 1.

Issue: #341