### PR TITLE
Fix peaks not identified

### DIFF
--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -8,33 +8,33 @@ void PeakDetectorCLI::processOptions(int argc, char* argv[]) {
 
 	//command line options
 	const char * optv[] = {
-							"a?alignSamples <int>",
-							"b?minGoodGroupCount <int>",
-							"c?matchRtFlag <int>",
-							"C?compoundPPMWindow <float>",							
-							"d?db <string>",
-							"e?processAllSlices <int>",
-							"f?pullIsotopes <int>",				//C13(1st bit), S34i(2nd bit), N15i(3rd bit), D2(4th bit)
-							"g?grouping_maxRtWindow <float>",
+							"a?alignSamples: Enter non-zero integer to run alignment <int>",
+							"b?minGoodGroupCount: Enter minimum number of good peaks per group <int>",
+							"c?matchRtFlag: Enter non-zero integer to match retention time to the database values <int>",
+							"C?compoundPPMWindow: Enter ppm window for m/z <float>",							
+							"d?db: Enter full path to database file <string>",
+							"e?processAllSlices: Enter non-zero integer to run untargeted peak detection <int>",
+							"f?pullIsotopes: Enter 1111 to pull all isotopic labels, 0000 for no isotopes. Refer the GitHub wiki document for more details <int>",				//C13(1st bit), S34i(2nd bit), N15i(3rd bit), D2(4th bit)
+							"g?grouping_maxRtWindow: Enter the maximum Rt difference between peaks in a group <float>",
 							"h?help",
-							"i?minGroupIntensity <float>",
-							"I?quantileIntensity <float>",
-                            "j?saveEicJson <int>",
-							"k?charge <int>",
-							"m?model <string>",
-							"n?eicMaxGroups <int>",
-							"o?outputdir <string>",
-							"p?ppmMerge <float>",
-							"q?minQuality <float>",
-							"Q?quantileQuality <float>",
-							"r?rtStepSize <float>",
-                            "s?savemzroll <int>",
-                            "v?ionizationMode <int>",
-							"w?minPeakWidth <int>",
-							"x?xml <string>",
-							"X|defaultXml",
-							"y?eicSmoothingWindow <int>",
-							"z?minSignalBaseLineRatio <float>",
+							"i?minGroupIntensity: Enter min group intensity threshold for a group <float>",
+							"I?quantileIntensity: Specify required percentage of peaks above the intensity threshold <float>",
+                            "j?saveEicJson: Enter non-zero integer to save EIC JSON in the output folder <int>",
+							"k?charge: Enter the magnitude of charge on each compound <int>",
+							"m?model: Enter full path to the model file <string>",
+							"n?eicMaxGroups: Enter maximum number of groups reported per compound <int>",
+							"o?outputdir: Enter full path to output folder <string>",
+							"p?ppmMerge: Enter ppm window for untargeted peak detection and removing duplicate groups <float>",
+							"q?minQuality: Enter min peak quality threshold for a group <float>",
+							"Q?quantileQuality: Specify required percentage of peaks above quality threshold <float>",
+							"r?rtStepSize: Enter retention time window for untargeted peak detection <float>",
+                            "s?savemzroll: Enter non-zero integer to save mzroll in the output folder <int>",
+                            "v?ionizationMode: Enter 0, -1 or 1 ionization mode <int>",
+							"w?minPeakWidth: Enter min peak width threshold in a group <int>",
+							"x?xml: Enter full path to the config file <string>",
+							"X?defaultXml: Create a template config file",
+							"y?eicSmoothingWindow: Enter number of scans used for smoothing at a time <int>",
+							"z?minSignalBaseLineRatio: Enter min signal to baseline ratio threshold for a group <float>",
 							NULL 
 	};
 
@@ -95,7 +95,7 @@ void PeakDetectorCLI::processOptions(int argc, char* argv[]) {
 			break;
 
 		case 'h':
-			opts.usage(cerr, "files ...");
+			opts.usage(cerr, "files --Enter full path to each sample file");
 			exit(0);
 			break;
 

--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -737,21 +737,21 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC *> &eics,
     vector<PeakGroup> pgroups;
 
     //case there is only a single EIC, there is nothing to group
-    if (eics.size() == 1 && eics[0] != NULL)
-    {
-        EIC *m = eics[0];
-        for (unsigned int i = 0; i < m->peaks.size(); i++)
-        {
-            PeakGroup grp;
-            grp.minQuality = minQuality;
-            grp.groupId = i;
-            grp.addPeak(m->peaks[i]);
-            grp.groupStatistics();
-            grp.setSelectedSamples(samples);
-            pgroups.push_back(grp);
-        }
-        return pgroups;
-    }
+    // if (eics.size() == 1 && eics[0] != NULL)
+    // {
+    //     EIC *m = eics[0];
+    //     for (unsigned int i = 0; i < m->peaks.size(); i++)
+    //     {
+    //         PeakGroup grp;
+    //         grp.minQuality = minQuality;
+    //         grp.groupId = i;
+    //         grp.addPeak(m->peaks[i]);
+    //         grp.groupStatistics();
+    //         grp.setSelectedSamples(samples);
+    //         pgroups.push_back(grp);
+    //     }
+    //     return pgroups;
+    // }
 
     //create EIC compose from all sample eics
     EIC *m = EIC::eicMerge(eics);

--- a/src/core/libmaven/EIC.h
+++ b/src/core/libmaven/EIC.h
@@ -217,6 +217,19 @@ class EIC
     */
     inline mzSample *getSample() { return sample; }
 
+    /**
+     * @brief return list of groups given a set of EICs
+     * @details assigns every peak to a group based on the best matching merged EIC
+     * @param smoothingWindow number of scans read at a time for smoothing
+     * @param maxRtDiff maximum retention time difference between peaks in a group
+     * @param minQuality minimum peak quality for every group. used for calculation of good peaks
+     * @param distXWeight weight of rt difference between a peak and merged EIC
+     * @param distYWeight weight of intensity difference between a peak and merged EIC
+     * @param overlapWeight weight of peak overlap between a peak and merged EIC
+     * @param userOverlap flag to determine which group score formula is used
+     * @param minSignalBaselineDifference minimum difference between peak and baseline for peak to be marked
+     * @return vector of peak groups found
+    **/
     static vector<PeakGroup> groupPeaks(vector<EIC *> &eics,
                                         int smoothingWindow,
                                         float maxRtDiff,

--- a/src/core/libmaven/constants.h
+++ b/src/core/libmaven/constants.h
@@ -52,6 +52,7 @@ const string S34_LABEL = "S34-label-";
 const string H2_LABEL = "D2-label-";
 const string C13N15_LABEL = "C13N15-label-";
 const string C13S34_LABEL = "C13S34-label-";
+const string C13H2_LABEL = "C13D2-label-";
 const string H_STRING_ID = "H";
 const string H2_STRING_ID = "D";
 const string C_STRING_ID = "C";

--- a/src/core/libmaven/mzMassCalculator.cpp
+++ b/src/core/libmaven/mzMassCalculator.cpp
@@ -10,7 +10,7 @@ ElementMass MassCalculator::elementMass;
 
 double MassCalculator::getElementMass(string elmnt) {
     double val_atome(0);
-    if (elementMass.elementMassMap.count(elmnt)  == 1) { 
+    if (elementMass.elementMassMap.count(elmnt)  == 1) {
         val_atome = elementMass.elementMassMap[elmnt];
     }
     return val_atome;
@@ -127,6 +127,20 @@ vector<Isotope> MassCalculator::computeIsotopes(string formula, int charge, map<
                     string name = C13S34_LABEL + integer2string(i) + "-" + integer2string(j);
                     double mass = parentMass + (j * S_MASS_DELTA) + (i * C_MASS_DELTA);
                     Isotope x(name, mass, i, 0, j, 0);
+                    isotopes.push_back(x);
+                    count2++;
+                    if(count2 >= noOfIsotopes) break;
+                }
+                if(count2 >= noOfIsotopes) break;
+            }
+        }
+
+        if(isotopeAtom["C13Labeled_BPE"] && isotopeAtom["D2Labeled_BPE"]) {
+            for (int i = 1; i <= CatomCount; i++) {
+                for (int j = 1; j <= HatomCount; j++) {
+                    string name = C13H2_LABEL + integer2string(i) + "-" + integer2string(j);
+                    double mass = parentMass + (j * D_MASS_DELTA) + (i * C_MASS_DELTA);
+                    Isotope x(name, mass, i, 0, 0, j);
                     isotopes.push_back(x);
                     count2++;
                     if(count2 >= noOfIsotopes) break;

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -699,9 +699,6 @@ void EicWidget::addMergedEIC() {
 	int eic_smoothingWindow = settings->value("eic_smoothingWindow").toInt();
 	int eic_smoothingAlgorithm =
 			settings->value("eic_smoothingAlgorithm").toInt();
-	int baseline_smoothing = getMainWindow()->mavenParameters->baseline_smoothingWindow;
-	int baseline_quantile = getMainWindow()->mavenParameters->baseline_dropTopX;
-	int minSignalBaselineDifference = getMainWindow()->mavenParameters->minSignalBaselineDifference;
 
 	EicLine* line = new EicLine(0, scene());
 

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -707,10 +707,8 @@ void EicWidget::addMergedEIC() {
 
 	EIC* eic = EIC::eicMerge(eicParameters->eics);
 	eic->setSmootherType((EIC::SmootherType) eic_smoothingAlgorithm);
-	eic->setBaselineSmoothingWindow(baseline_smoothing);
-	eic->setBaselineDropTopX(baseline_quantile);
-	eic->setFilterSignalBaselineDiff(minSignalBaselineDifference);
-	eic->getPeakPositions(eic_smoothingWindow);
+	eic->computeSpline(eic_smoothingWindow);
+
 
 	for (int j = 0; j < eic->size(); j++) {
 		if (eic->rt[j] < eicParameters->_slice.rtmin)

--- a/tests/MavenTests/testEIC.cpp
+++ b/tests/MavenTests/testEIC.cpp
@@ -228,13 +228,9 @@ void TestEIC:: testgroupPeaks() {
     QVERIFY(14.8468 < peakgroups[2].meanRt < 14.847);
     QVERIFY(744.0849 < peakgroups[2].meanMz < 744.0851);
 
-    unsigned int maxPeakNum = 0;
-    for(unsigned int j = 0; j < peakgroups.size(); j++) {   
-        if (maxPeakNum < peakgroups[j].peaks.size())
-            maxPeakNum = peakgroups[j].peaks.size();
-    }
-
-    QVERIFY(maxPeakNum == 2);    
+    QVERIFY(peakgroups[0].peaks.size() == 2);
+    QVERIFY(peakgroups[1].peaks.size() == 1);
+    QVERIFY(peakgroups[2].peaks.size() == 1);
 }
 
 
@@ -292,7 +288,7 @@ void TestEIC:: testeicMerge() {
     QVERIFY(maxEICsize == m->rt.size());
     QVERIFY(maxEICsize == m->scannum.size());
     QVERIFY(maxEICsize == m->mz.size());
-    QVERIFY(m->rtmin > 0);
-    QVERIFY(m->rtmax > 0);
+    QVERIFY(13.041 < m->rtmin < 13.042);
+    QVERIFY(17.039 < m->rtmax < 17.040);
 }
 


### PR DESCRIPTION
ElMaven no longer handles the case of a single EIC explicitly.
Merged EIC for a single sample is created using eicMerge. Same as for multiple samples.

To test whether this change would cause any issues with multiple samples:
- group Rt and intensity values were compared with those obtained from develop version. No change was observed
- Fewer groups are reported for a single sample as expected