### PR TITLE
Fix: Update sorting algo for tree item #466

### DIFF
--- a/src/gui/mzroll/numeric_treewidgetitem.h
+++ b/src/gui/mzroll/numeric_treewidgetitem.h
@@ -21,31 +21,12 @@ public:
 	bool operator< ( const QTreeWidgetItem & other ) const  
 	{
 		int sortCol = treeWidget()->sortColumn();
-		bool isaFloat;
-		bool isbFloat;
-		float a = text(sortCol).toFloat(&isaFloat);
-		float b = other.text(sortCol).toFloat(&isbFloat);
-
-		if (isaFloat & isbFloat) {
-			return  a < b;
-		}
-		else if(a){
-			return true;
-		}
-		else if(b){
-			return false;
-		}
-
-
-		QString text1=text(sortCol);
-		QString text2=other.text(sortCol);
-		int length1=text1.length();
-		int length2=text2.length();
-
-		if(length1==length2) {
-			return text1<text2;
-		}
-		else return length1<length2;
+		QString thisText=text(sortCol);
+		QString otherText=other.text(sortCol);
+		
+		QCollator collator;
+		collator.setNumericMode(true);
+		return collator.compare(thisText , otherText) < 0;
 
     }
 

--- a/src/gui/mzroll/numeric_treewidgetitem.h
+++ b/src/gui/mzroll/numeric_treewidgetitem.h
@@ -21,15 +21,33 @@ public:
 	bool operator< ( const QTreeWidgetItem & other ) const  
 	{
 		int sortCol = treeWidget()->sortColumn();
-		bool isFloat;
-		float a = text(sortCol).toFloat(&isFloat);
+		bool isaFloat;
+		bool isbFloat;
+		float a = text(sortCol).toFloat(&isaFloat);
+		float b = other.text(sortCol).toFloat(&isbFloat);
 
-		if (isFloat) {
-			return  a < other.text(sortCol).toFloat();
-		} else {
-			return  text(sortCol) < other.text(sortCol);
+		if (isaFloat & isbFloat) {
+			return  a < b;
 		}
-        }
+		else if(a){
+			return true;
+		}
+		else if(b){
+			return false;
+		}
+
+
+		QString text1=text(sortCol);
+		QString text2=other.text(sortCol);
+		int length1=text1.length();
+		int length2=text2.length();
+
+		if(length1==length2) {
+			return text1<text2;
+		}
+		else return length1<length2;
+
+    }
 
 
 };

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -479,9 +479,9 @@ void ProjectDockWidget::setInfo(vector<mzSample*>&samples) {
         QTreeWidgetItem *item=NULL;
 
         if (parent) { 
-            item = new QTreeWidgetItem(parent,SampleType); 
+            item = new NumericTreeWidgetItem(parent,SampleType); 
         } else {
-            item = new QTreeWidgetItem(_treeWidget,SampleType); 
+            item = new NumericTreeWidgetItem(_treeWidget,SampleType); 
         }
 
         QColor color = QColor::fromRgbF( sample->color[0], sample->color[1], sample->color[2], sample->color[3] );


### PR DESCRIPTION
	Default tree item is sorted lexicographcal order of string
that could be number also.
	It's updated - if there are numbers, then  numbers will be
sorted otherwise string will be given larger value and sorted.

Issue: #466