### PR TITLE
Fix: Update user input setting

### DIFF
--- a/src/core/libmaven/masscutofftype.cpp
+++ b/src/core/libmaven/masscutofftype.cpp
@@ -1,6 +1,10 @@
 #include <assert.h>
 #include "masscutofftype.h"
 
+MassCutoff::MassCutoff(){
+    _massCutoffType="";
+    _massCutoff=0;
+}
 double MassCutoff::massCutoffValue(double mz){
     
     if(_massCutoffType=="ppm"){

--- a/src/core/libmaven/masscutofftype.h
+++ b/src/core/libmaven/masscutofftype.h
@@ -16,6 +16,7 @@ private:
 	string _massCutoffType;
 	double _massCutoff;
 public:
+	MassCutoff();
 	void setMassCutoffAndType(double massCutoff, string massCutoffType);
 	void setMassCutoffType(string massCutoffType){_massCutoffType=massCutoffType;}
 	string getMassCutoffType(){return _massCutoffType;}

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -18,11 +18,16 @@ MavenParameters::MavenParameters() {
         showProgressFlag = true;
 
         alignButton = 0;
-
+        /*
+        * Whenever we create an instance of this class, massCutoffType must be set for fragmentMatchMassCutoffTolr
+        */
         fragmentMatchMassCutoffTolr = new MassCutoff();
         fragmentMatchMassCutoffTolr->setMassCutoff(1000);
         mzBinStep = 0.01;
         rtStepSize = 20;
+        /*
+        * Whenever we create an instance of this class, massCutoffType must be set for massCutoffMerge
+        */
         massCutoffMerge = new MassCutoff();
         massCutoffMerge->setMassCutoff(30);
         avgScanTime = 0.2;
@@ -56,6 +61,9 @@ MavenParameters::MavenParameters() {
 	deltaRTWeight=10;
         deltaRtCheckFlag = false;
 
+        /*
+        * Whenever we create an instance of this class, massCutoffType must be set for compoundMassCutoffWindow
+        */
         compoundMassCutoffWindow=new MassCutoff();
         compoundMassCutoffWindow->setMassCutoff(10);
         compoundRTWindow = 2;

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -478,8 +478,7 @@ void PeakDetectionDialog::updateQSettingsWithUserInput(QSettings* settings) {
     settings->setValue("quantileIntensity", quantileIntensity->value());
     // Compound DB search
     settings->setValue("matchRtFlag", matchRt->isChecked());
-    QString massCutoffType=QString::fromStdString(mainwindow->getUserMassCutoff()->getMassCutoffType());
-    settings->setValue("massCutoffType",massCutoffType);
+    settings->setValue("massCutoffType",mainwindow->massCutoffComboBox->currentText());
     settings->setValue("compoundMassCutoffWindow", compoundPPMWindow->value());
     settings->setValue("compoundRTWindow", compoundRTWindow->value());
     settings->setValue("eicMaxGroups", eicMaxGroups->value());
@@ -546,13 +545,14 @@ void PeakDetectionDialog::setMavenParameters(QSettings* settings) {
         mavenParameters->deltaRtCheckFlag = settings->value("deltaRtCheckFlag").toBool();
 
         // Compound DB search
+        string massCutoffType=mainwindow->massCutoffComboBox->currentText().toStdString();
         mavenParameters->matchRtFlag = settings->value("matchRtFlag").toBool();
-        mavenParameters->compoundMassCutoffWindow->setMassCutoffAndType(settings->value("compoundMassCutoffWindow").toDouble(),settings->value("massCutoffType").toString().toStdString());
+        mavenParameters->compoundMassCutoffWindow->setMassCutoffAndType(settings->value("compoundMassCutoffWindow").toDouble(),massCutoffType);
         mavenParameters->compoundRTWindow = settings->value("compoundRTWindow").toDouble();
         mavenParameters->eicMaxGroups = settings->value("eicMaxGroups").toInt();
 
         // Automated Peak Detection
-        mavenParameters->massCutoffMerge->setMassCutoffAndType(settings->value("massCutoffMerge").toDouble(),settings->value("massCutoffType").toString().toStdString());
+        mavenParameters->massCutoffMerge->setMassCutoffAndType(settings->value("massCutoffMerge").toDouble(),massCutoffType);
         mavenParameters->rtStepSize = settings->value("rtStepSize").toDouble();
         mavenParameters->minRt = settings->value("minRT").toDouble();
         mavenParameters->maxRt = settings->value("maxRT").toDouble();


### PR DESCRIPTION
	ElMaven was crashing because massCutoff type was not getting
updated correctly.