### PR TITLE
Fix: Disable NA correction in clipboard #468

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3803,14 +3803,14 @@ MatrixXf MainWindow::getIsotopicMatrixIsoWidget(PeakGroup* group) {
 			MM(j, i) = values[j];  //rows=samples, columns=isotopes
 	}
 
-	int numberofCarbons = 0;
-	if (group->compound && !group->compound->formula.empty()) {
-		map<string, int> composition = MassCalculator::getComposition(
-				group->compound->formula);
-		numberofCarbons = composition["C"];
-	}
+	// int numberofCarbons = 0;
+	// if (group->compound && !group->compound->formula.empty()) {
+	// 	map<string, int> composition = MassCalculator::getComposition(
+	// 			group->compound->formula);
+	// 	numberofCarbons = composition["C"];
+	// }
 
-	isotopeC13Correct(MM, numberofCarbons, carbonIsotopeSpecies);
+	// isotopeC13Correct(MM, numberofCarbons, carbonIsotopeSpecies);
 	return MM;
 }
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2238,7 +2238,7 @@ void MainWindow::readSettings() {
 
     //Pull Isotopes in options
     if (!settings->contains("isotopeC13Correction"))
-        settings->setValue("isotopeC13Correction", 2);
+        settings->setValue("isotopeC13Correction", 0);
 
 	if (!settings->contains("maxNaturalAbundanceErr"))
 		settings->setValue("maxNaturalAbundanceErr", 100);


### PR DESCRIPTION
NA correction is returning fractions instead of corrected PeakArea values.
The fractions are useful for Isotope plot (needs validation) but not for clipboard functionality.
This commit will:
- retain the same isotope plot behaviour
- disable NA correction for clipboard functionality i.e. show uncorrected PeakArea values

Issue: #468