### PR TITLE
Fix: copy to clipboard for isotopic children shows compound name

### DIFF
--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -347,9 +347,13 @@ QString IsotopeWidget::groupIsotopeMatrixExport(PeakGroup* group, bool includeSa
 			}
 
 			_mw->setStatusText("Clipboard set to isotope summary");
-		} else {
-                isotopeInfo += tag + " | " + groupTextEport(group) + "\n";
-				_mw->setStatusText("Clipboard to group summary");
+		} 
+		else {
+			// non-isotopic group
+            if (!group->isIsotope()) isotopeInfo += tag + groupTextEport(group) + "\n";
+			// for isotopic children
+			else isotopeInfo += tag + " | " + groupTextEport(group) + "\n";
+			_mw->setStatusText("Clipboard to group summary");
 		}
         return isotopeInfo;
 

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -287,6 +287,7 @@ QString IsotopeWidget::groupIsotopeMatrixExport(PeakGroup* group, bool includeSa
     if (group == NULL ) return "";
 		//header line
 		QString tag(group->tagString.c_str());
+		if (group->isIsotope()) tag = QString(group->parent->tagString.c_str());
         if ( tag.isEmpty() && group->compound != NULL ) tag = QString(group->compound->name.c_str());
         if ( tag.isEmpty() && group->srmId.length()   ) tag = QString(group->srmId.c_str());
         if ( tag.isEmpty() && group->meanMz > 0 )       tag = QString::number(group->meanMz,'f',6) + "@" +  QString::number(group->meanRt,'f',2);
@@ -327,7 +328,7 @@ QString IsotopeWidget::groupIsotopeMatrixExport(PeakGroup* group, bool includeSa
 			MatrixXf MM = _mw->getIsotopicMatrixIsoWidget(group);
 			for (int i=0; i < isotopes.size(); i++ ) {
 				QStringList groupInfo;
-                groupInfo << tag + " " + QString(isotopes[i]->tagString.c_str());
+                groupInfo << tag + " | " + QString(isotopes[i]->tagString.c_str());
 				for( unsigned int j=0; j < vsamples.size(); j++) {
 					groupInfo << QString::number(MM(j,i), 'f', 2 );
 				}
@@ -337,7 +338,7 @@ QString IsotopeWidget::groupIsotopeMatrixExport(PeakGroup* group, bool includeSa
 				isotopeInfo += "Natural Abundance\n";
 				for (int i = 0, k = isotopes.size(); i < isotopes.size(); i++, k++) {
 					QStringList groupInfo;
-                    groupInfo << tag + " " + QString(isotopes[i]->tagString.c_str());
+                    groupInfo << tag + " | " + QString(isotopes[i]->tagString.c_str());
 					for( unsigned int j=0; j < vsamples.size(); j++) {
 						groupInfo << QString::number(MM(j,k), 'f', 2 );
 					}
@@ -347,7 +348,7 @@ QString IsotopeWidget::groupIsotopeMatrixExport(PeakGroup* group, bool includeSa
 
 			_mw->setStatusText("Clipboard set to isotope summary");
 		} else {
-                isotopeInfo += tag + groupTextEport(group) + "\n";
+                isotopeInfo += tag + " | " + groupTextEport(group) + "\n";
 				_mw->setStatusText("Clipboard to group summary");
 		}
         return isotopeInfo;


### PR DESCRIPTION
Copying isotopic information to clipboard for isotopic children copied the tagString twice instead of adding compound name.