### PR TITLE
Fix: Calculate spline area for shift drag integration #496

### DIFF
--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -179,6 +179,7 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
 		}
 		if (peak.pos > 0) {
 			//qDebug << "details" << peak.pos << " " << peak.minpos << " " << peak.maxpos;
+			eic->findPeakBounds(peak);
 			eic->getPeakDetails(peak);
 			eicParameters->_integratedGroup.addPeak(peak);
 			qDebug() << eic->sampleName.c_str() << " " << peak.peakArea << " "


### PR DESCRIPTION
Peak bounds were not being calculated for peaks found out by
shift drag  integration

Issue: #496