### PR TITLE
Refactor group filtering part of automated peak detection

### DIFF
--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -877,6 +877,8 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC *> &eics,
         //grp.fillInPeaks(eics);
         //Feng note: fillInPeaks is unecessary
         grp.groupStatistics();
+        grp.computeAvgBlankArea(eics);
+
     }
 
     //now merge overlapping groups

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -885,6 +885,13 @@ void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)
             eicCount++;
             float max = 0;
 
+            if (mavenParameters->clsf->hasModel())
+            {
+                for (unsigned int k=0; k < eics[j]->peaks.size(); k++ ) {
+                    eics[j]->peaks[k].quality = mavenParameters->clsf->scorePeak(eics[j]->peaks[k]);
+                }
+            }
+
             switch ((PeakGroup::QType)mavenParameters->peakQuantitation)
             {
             case PeakGroup::AreaTop:
@@ -979,10 +986,6 @@ vector<PeakGroup*> PeakDetector::groupFiltering(vector<PeakGroup> &peakgroups, m
         group.minQuality = mavenParameters->minQuality;
         group.minIntensity = mavenParameters->minGroupIntensity;
 
-        if (mavenParameters->clsf->hasModel())
-        {
-            mavenParameters->clsf->classify(&group);
-        }
         group.groupStatistics();
 
         if (mavenParameters->clsf->hasModel() && group.goodPeakCount < mavenParameters->minGoodGroupCount)

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -879,18 +879,17 @@ void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)
                         mavenParameters->eicType,
                         mavenParameters->filterline);
 
+
+        if (mavenParameters->clsf->hasModel())
+        {
+            mavenParameters->clsf->scoreEICs(eics);
+        }
+
         float eicMaxIntensity = 0;
         for (unsigned int j = 0; j < eics.size(); j++)
         {
             eicCount++;
             float max = 0;
-
-            if (mavenParameters->clsf->hasModel())
-            {
-                for (unsigned int k=0; k < eics[j]->peaks.size(); k++ ) {
-                    eics[j]->peaks[k].quality = mavenParameters->clsf->scorePeak(eics[j]->peaks[k]);
-                }
-            }
 
             switch ((PeakGroup::QType)mavenParameters->peakQuantitation)
             {

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -826,220 +826,203 @@ bool PeakDetector::quantileFilters(PeakGroup *group) {
     return false;
 }
 
-void PeakDetector::processSlices(vector<mzSlice*>&slices, string setName) {
+void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)
+{
 
-        if (slices.size() == 0)
-                return;
-        mavenParameters->allgroups.clear();
+    if (slices.size() == 0)
+        return;
+    mavenParameters->allgroups.clear();
 
-	//TODO: All the ion counts are 0 there is no use in sorting
-        sort(slices.begin(), slices.end(), mzSlice::compIntensity);
+    sort(slices.begin(), slices.end(), mzSlice::compIntensity);
 
-	//process KNOWNS
-        QTime timer;
-        timer.start();
-        // qDebug() << "Proessing slices: setName=" << setName.c_str() << " slices="
-        //          << slices.size();
+    int converged = 0;
+    int foundGroups = 0;
 
-        int converged = 0;
-        int foundGroups = 0;
+    int eicCount = 0;
+    int groupCount = 0;
+    for (unsigned int s = 0; s < slices.size(); s++)
+    {
 
-        int eicCount = 0;
-        int groupCount = 0;
-        // int peakCount = 0; //naman: not being used anywhere TODO comment it out 
+        if (mavenParameters->stop)
+            break;
+        mzSlice *slice = slices[s];
 
-        // for all the slies, find EICs and score quality and rank ofpeaks in the EICs
-        // using the classifier
-        // #pragma omp parallel for ordered
-        for (unsigned int s = 0; s < slices.size(); s++) {
+        Compound *compound = slice->compound;
 
-                if (mavenParameters->stop) break;
-                mzSlice* slice = slices[s];
+        if (compound != NULL && compound->hasGroup())
+            compound->unlinkGroup();
 
-                Compound* compound = slice->compound;
-
-                if (compound != NULL && compound->hasGroup())
-                        compound->unlinkGroup();
-
-                //TODO: what is this for? this is not used
-                //mavenParameters->checkConvergance is not always 0
-                if (mavenParameters->checkConvergance) {
-                        mavenParameters->allgroups.size() - foundGroups > 0 ? converged =
-                                0 :
-                                converged++;
-                        if (converged > 1000) {
-                        break;
-                        }
-                        foundGroups = mavenParameters->allgroups.size();
-                }
-
-//		qDebug() << "Pulling EICs";
-
-                vector<EIC*> eics;
-                // for all the slies, find EICs
-                // #pragma omp ordered
-                //TODO: all the settings from this are not connected to the main
-                //window parameters which are not connected are they are
-                //connected from options settings
-                //mavenParameters->baseline_smoothingWindow
-                //mavenParameters->baseline_dropTopX
-                eics = pullEICs(slice, mavenParameters->samples,
-                                EicLoader::PeakDetection, mavenParameters->eic_smoothingWindow,
-                                mavenParameters->eic_smoothingAlgorithm, mavenParameters->amuQ1,
-                                mavenParameters->amuQ3,
-                                mavenParameters->baseline_smoothingWindow,
-                                mavenParameters->baseline_dropTopX,
-                                mavenParameters->minSignalBaselineDifference,
-                                mavenParameters->eicType,
-                                mavenParameters->filterline);
-
-                float eicMaxIntensity = 0;
-
-                for (unsigned int j = 0; j < eics.size(); j++) {
-                    eicCount++;
-                    float max = 0;
-
-                    switch((PeakGroup::QType) mavenParameters->peakQuantitation) {
-                        case PeakGroup::AreaTop: max = eics[j]->maxAreaTopIntensity; break;
-                        case PeakGroup::Area: max =  eics[j]->maxAreaIntensity; break;
-                        case PeakGroup::Height: max = eics[j]->maxIntensity; break;
-                        case PeakGroup::AreaNotCorrected: max = eics[j]->maxAreaNotCorrectedIntensity; break;
-                        case PeakGroup::AreaTopNotCorrected: max = eics[j]->maxAreaTopNotCorrectedIntensity; break;
-                        default: max = eics[j]->maxIntensity; break;
-                    }
-
-                    if (max > eicMaxIntensity)
-                        eicMaxIntensity = max;
-                }
-                if (eicMaxIntensity < mavenParameters->minGroupIntensity) {
-                        delete_all(eics);
-                        continue;
-                }
-
-                //for ( unsigned int j=0; j < eics.size(); j++ )	eics[j]->getPeakPositions(eic_smoothingWindow);
-                vector<PeakGroup> peakgroups = EIC::groupPeaks(eics,
-                                                                mavenParameters->eic_smoothingWindow,
-                                                                mavenParameters->grouping_maxRtWindow,
-                                                                mavenParameters->minQuality,
-                                                                mavenParameters->distXWeight,
-                                                                mavenParameters->distYWeight,
-                                                                mavenParameters->overlapWeight,
-                                                                mavenParameters->useOverlap,
-                                                                mavenParameters->minSignalBaselineDifference);
-
-
-		//score quality of each group using classifier
-                vector<PeakGroup*> groupsToAppend;
-                for (unsigned int j = 0; j < peakgroups.size(); j++) {
-
-                        PeakGroup& group = peakgroups[j];
-                        group.setQuantitationType((PeakGroup::QType) mavenParameters->peakQuantitation);
-                        group.minQuality = mavenParameters->minQuality;
-                        group.minIntensity = mavenParameters->minGroupIntensity;
-                        group.computeAvgBlankArea(eics);
-                        group.groupStatistics();
-                        groupCount++;
-                        // peakCount += group.peakCount(); //naman: not being used anywhere TODO comment it out 
-
-			if (mavenParameters->clsf->hasModel()) {
-				mavenParameters->clsf->classify(&group);
-                                group.groupStatistics();
-                        }
-                        if (mavenParameters->clsf->hasModel()
-                            && group.goodPeakCount < mavenParameters->minGoodGroupCount)
-                                continue;
-                        // if (group.blankMean*minBlankRatio > group.sampleMean ) continue;
-                        
-                        if (group.maxNoNoiseObs < mavenParameters->minNoNoiseObs)
-                                continue;
-                        if (quantileFilters(&group))
-                                continue;
-                                
-                        if (compound)
-                                group.compound = compound;
-                        if (!slice->srmId.empty())
-                                group.srmId = slice->srmId;
-
-                        
-                        float rtDiff = -1;
-
-                        if (compound != NULL && compound->expectedRt > 0)
-                        {
-                            rtDiff = abs(compound->expectedRt - (group.meanRt));
-                            group.expectedRtDiff = rtDiff;
-                        }
-
-                        // Peak Group Rank accoording to given weightage
-                        double A = (double) mavenParameters->qualityWeight/10;
-                        double B = (double) mavenParameters->intensityWeight/10;
-                        double C = (double) mavenParameters->deltaRTWeight/10;
-
-                        if (compound != NULL && compound->expectedRt > 0) {
-                            if(mavenParameters->deltaRtCheckFlag) {
-                            group.groupRank = pow(rtDiff, 2*C) * pow((1.1 - group.maxQuality), A)
-                                                  * (1 /( pow(log(group.maxIntensity + 1), B))); //TODO Formula to rank groups
-                            }
-                            if (mavenParameters->matchRtFlag && group.expectedRtDiff > mavenParameters->compoundRTWindow) continue;
-
-                        } 
-                        
-                        if (!mavenParameters->deltaRtCheckFlag || compound == NULL || compound->expectedRt <= 0) {
-                            group.groupRank = pow((1.1 - group.maxQuality), A)
-                                                  * (1 /(pow(log(group.maxIntensity + 1), B)));
-                        }
-                        groupsToAppend.push_back(&group);
-                }
-
-		//sort groups according to their rank
-                std::sort(groupsToAppend.begin(), groupsToAppend.end(),
-                          PeakGroup::compRankPtr);
-
-                for (unsigned int j = 0; j < groupsToAppend.size(); j++) {
-                        //check for duplicates	and append group
-                        if (j >= mavenParameters->eicMaxGroups)
-                                break;
-
-                        PeakGroup* group = groupsToAppend[j];
-                        // bool ok = addPeakGroup(*group); //naman: unused, maybe used below.
-                        addPeakGroup(*group); //naman: unused, maybe used below.
-
-                        //TODO: commended by sabu
-                        // //force insert when processing compounds.. even if duplicated
-                        // if (ok == false && compound != NULL)
-                        //         mavenParameters->allgroups.push_back(*group);
-                }
-
-                //cleanup
-                delete_all(eics);
-
-                if (mavenParameters->allgroups.size()
-                    > mavenParameters->limitGroupCount) {
-                        cerr << "Group limit exceeded!" << endl;
-//       #pragma omp cancel for
-                        break;
-                }
-
-                if (zeroStatus){
-					sendBoostSignal("Status", 0 , 1);
-					zeroStatus = false;
-                }
-
-                if (mavenParameters->showProgressFlag && s % 10 == 0) {
-
-                        string progressText = "Found "
-                                               + to_string(mavenParameters->allgroups.size())
-                                               + " groups";
-                sendBoostSignal(progressText,s + 1, std::min((int) slices.size(), mavenParameters->limitGroupCount));
-
-                        /*TODO: Fix Q_EMIT update progress of slices.
-                           Q_EMIT(
-                           updateProgressBar(progressText, s + 1,
-                           std::min((int) slices.size(), limitGroupCount)));
-                         */
-                }
+        //TODO: what is this for? this is not used
+        //mavenParameters->checkConvergance is not always 0
+        if (mavenParameters->checkConvergance)
+        {
+            mavenParameters->allgroups.size() - foundGroups > 0 ? converged =
+                                                                      0
+                                                                : converged++;
+            if (converged > 1000)
+            {
+                break;
+            }
+            foundGroups = mavenParameters->allgroups.size();
         }
 
-        //cleanup();
+        vector<EIC *> eics;
+        eics = pullEICs(slice,
+                        mavenParameters->samples,
+                        EicLoader::PeakDetection,
+                        mavenParameters->eic_smoothingWindow,
+                        mavenParameters->eic_smoothingAlgorithm,
+                        mavenParameters->amuQ1,
+                        mavenParameters->amuQ3,
+                        mavenParameters->baseline_smoothingWindow,
+                        mavenParameters->baseline_dropTopX,
+                        mavenParameters->minSignalBaselineDifference,
+                        mavenParameters->eicType,
+                        mavenParameters->filterline);
+
+        float eicMaxIntensity = 0;
+        for (unsigned int j = 0; j < eics.size(); j++)
+        {
+            eicCount++;
+            float max = 0;
+
+            switch ((PeakGroup::QType)mavenParameters->peakQuantitation)
+            {
+            case PeakGroup::AreaTop:
+                max = eics[j]->maxAreaTopIntensity;
+                break;
+            case PeakGroup::Area:
+                max = eics[j]->maxAreaIntensity;
+                break;
+            case PeakGroup::Height:
+                max = eics[j]->maxIntensity;
+                break;
+            case PeakGroup::AreaNotCorrected:
+                max = eics[j]->maxAreaNotCorrectedIntensity;
+                break;
+            case PeakGroup::AreaTopNotCorrected:
+                max = eics[j]->maxAreaTopNotCorrectedIntensity;
+                break;
+            default:
+                max = eics[j]->maxIntensity;
+                break;
+            }
+
+            if (max > eicMaxIntensity)
+                eicMaxIntensity = max;
+        }
+        if (eicMaxIntensity < mavenParameters->minGroupIntensity)
+        {
+            delete_all(eics);
+            continue;
+        }
+
+        vector<PeakGroup> peakgroups =
+            EIC::groupPeaks(eics,
+                            mavenParameters->eic_smoothingWindow,
+                            mavenParameters->grouping_maxRtWindow,
+                            mavenParameters->minQuality,
+                            mavenParameters->distXWeight,
+                            mavenParameters->distYWeight,
+                            mavenParameters->overlapWeight,
+                            mavenParameters->useOverlap,
+                            mavenParameters->minSignalBaselineDifference);
+
+        vector<PeakGroup *> groupsToAppend;
+        for (unsigned int j = 0; j < peakgroups.size(); j++)
+        {
+
+            PeakGroup &group = peakgroups[j];
+            group.setQuantitationType((PeakGroup::QType)mavenParameters->peakQuantitation);
+            group.minQuality = mavenParameters->minQuality;
+            group.minIntensity = mavenParameters->minGroupIntensity;
+            group.computeAvgBlankArea(eics);
+            group.groupStatistics();
+            groupCount++;
+
+            if (mavenParameters->clsf->hasModel())
+            {
+                mavenParameters->clsf->classify(&group);
+                group.groupStatistics();
+            }
+            if (mavenParameters->clsf->hasModel() && group.goodPeakCount < mavenParameters->minGoodGroupCount)
+                continue;
+
+            if (group.maxNoNoiseObs < mavenParameters->minNoNoiseObs)
+                continue;
+            if (quantileFilters(&group))
+                continue;
+
+            if (compound)
+                group.compound = compound;
+            if (!slice->srmId.empty())
+                group.srmId = slice->srmId;
+
+            float rtDiff = -1;
+
+            if (compound != NULL && compound->expectedRt > 0)
+            {
+                rtDiff = abs(compound->expectedRt - (group.meanRt));
+                group.expectedRtDiff = rtDiff;
+            }
+
+            double A = (double)mavenParameters->qualityWeight / 10;
+            double B = (double)mavenParameters->intensityWeight / 10;
+            double C = (double)mavenParameters->deltaRTWeight / 10;
+
+            if (compound != NULL && compound->expectedRt > 0)
+            {
+                if (mavenParameters->deltaRtCheckFlag)
+                {
+                    group.groupRank = pow(rtDiff, 2 * C) * pow((1.1 - group.maxQuality), A) * (1 / (pow(log(group.maxIntensity + 1), B))); //TODO Formula to rank groups
+                }
+                if (mavenParameters->matchRtFlag && group.expectedRtDiff > mavenParameters->compoundRTWindow)
+                    continue;
+            }
+
+            if (!mavenParameters->deltaRtCheckFlag || compound == NULL || compound->expectedRt <= 0)
+            {
+                group.groupRank = pow((1.1 - group.maxQuality), A) * (1 / (pow(log(group.maxIntensity + 1), B)));
+            }
+            groupsToAppend.push_back(&group);
+        }
+
+        //sort groups according to their rank
+        std::sort(groupsToAppend.begin(), groupsToAppend.end(),
+                  PeakGroup::compRankPtr);
+
+        for (unsigned int j = 0; j < groupsToAppend.size(); j++)
+        {
+            //check for duplicates	and append group
+            if (j >= mavenParameters->eicMaxGroups)
+                break;
+
+            PeakGroup *group = groupsToAppend[j];
+            addPeakGroup(*group);
+        }
+
+        //cleanup
+        delete_all(eics);
+
+        if (mavenParameters->allgroups.size() > mavenParameters->limitGroupCount)
+        {
+            cerr << "Group limit exceeded!" << endl;
+            break;
+        }
+
+        if (zeroStatus)
+        {
+            sendBoostSignal("Status", 0, 1);
+            zeroStatus = false;
+        }
+
+        if (mavenParameters->showProgressFlag && s % 10 == 0)
+        {
+
+            string progressText = "Found " + to_string(mavenParameters->allgroups.size()) + " groups";
+            sendBoostSignal(progressText, s + 1, std::min((int)slices.size(), mavenParameters->limitGroupCount));
+        }
+    }
 }
 
 bool PeakDetector::addPeakGroup(PeakGroup& grup1) {

--- a/src/core/libmaven/PeakDetector.h
+++ b/src/core/libmaven/PeakDetector.h
@@ -126,6 +126,15 @@ public:
 	void processSlices(vector<mzSlice*>&slices, string setName);
 
 	/**
+	 * @brief Filter groups on the basis of user-defined parameters
+	 * @param peakgroups vector of Peakgroup objects
+	 * @param slice mzSlice object bound to PeakGroup
+	 * @return filteredGroups Filtered PeakGroups
+	 * @see PeakGroup
+	 */
+	vector<PeakGroup*> groupFiltering(vector<PeakGroup> &peakgroups, mzSlice* slice);
+
+	/**
 	 * [apply peak selection filters to group; if x percentage of peaks in the group are above the user input threshold for a parameter, do not reject the group]
 	 * @method quantileFilters
 	 * @param  group        [pointer to PeakGroup]

--- a/src/core/libmaven/classifierNeuralNet.cpp
+++ b/src/core/libmaven/classifierNeuralNet.cpp
@@ -71,7 +71,7 @@ vector<float> ClassifierNeuralNet::getFeatures(Peak& p) {
 }
 
 void ClassifierNeuralNet::classify(PeakGroup* grp) {
-    //Merged with Maven776 - Kiran
+
 	if (brain == NULL)
 		return;
 
@@ -80,6 +80,16 @@ void ClassifierNeuralNet::classify(PeakGroup* grp) {
 	}
 }
 
+void ClassifierNeuralNet::scoreEICs(vector<EIC*> &eics)
+{
+
+	for (unsigned int i = 0; i < eics.size(); i++)
+	{
+		for (unsigned int j = 0; j < eics[i]->peaks.size(); j++ ) {
+			eics[i]->peaks[j].quality = scorePeak(eics[i]->peaks[j]);
+		}
+	}
+}
 
 float ClassifierNeuralNet::scorePeak(Peak& p) {
    //Merged with Maven776 - Kiran

--- a/src/core/libmaven/classifierNeuralNet.h
+++ b/src/core/libmaven/classifierNeuralNet.h
@@ -9,6 +9,7 @@
 #include <math.h>
 #include <vector>
 #include "classifier.h"
+#include "EIC.h"
 
 using namespace std;
 
@@ -24,6 +25,7 @@ public:
 	bool hasModel();
     vector<float> getFeatures(Peak& p);
 	float scorePeak(Peak& p);
+	void scoreEICs(vector<EIC*> &eics);
 private:
 	
 

--- a/src/core/libmaven/mavenparameters.h
+++ b/src/core/libmaven/mavenparameters.h
@@ -14,8 +14,8 @@
 #include "mzUtils.h"
 #include "Compound.h"
 #include "masscutofftype.h"
+#include "classifierNeuralNet.h"
 
-class Classifier;
 
 class MavenParameters 
 {
@@ -224,7 +224,7 @@ class MavenParameters
         vector<PeakGroup> undoAlignmentGroups;
         int alignButton;
         MassCalculator mcalc;
-        Classifier* clsf;
+        ClassifierNeuralNet* clsf;
         PeakGroup* _group;
         vector<mzSample*> samples;
         vector<Compound*> compounds;

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -188,8 +188,6 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
 	}
 
 	eicParameters->_integratedGroup.groupStatistics();
-	//setSelectedGroup (&eicParameters->_integratedGroup);
-	//getMainWindow()->isotopeWidget->integrationFlag = true;
 	getMainWindow()->isotopeWidget->updateIsotopicBarplot(&eicParameters->_integratedGroup);
 	getMainWindow()->isotopeWidget->setPeakGroupAndMore(&eicParameters->_integratedGroup, true);
 }
@@ -328,6 +326,11 @@ void EicWidget::computeEICs() {
 			baseline_quantile, minSignalBaselineDifference, eic_type,
 			filterline);
 
+	//score peak quality
+	ClassifierNeuralNet* clsf = getMainWindow()->getClassifier();
+	if (clsf != NULL) {
+		clsf->scoreEICs(eicParameters->eics);
+	}
 
 	if(_groupPeaks) groupPeaks(); //TODO: Sahil, added while merging eicwidget
 	eicParameters->associateNameWithPeakGroups();
@@ -882,15 +885,6 @@ void EicWidget::replot(PeakGroup* group) {
 
 	//qDebug << "EicWidget::replot() " << " group=" << group << " mz: " << _slice.mzmin << "-" << _slice.mzmax << " rt: " << _slice.rtmin << "-" << _slice.rtmax;
 	clearPlot();
-
-	//score peak quality
-	Classifier* clsf = getMainWindow()->getClassifier();
-	if (clsf != NULL) {
-		for (int i = 0; i < eicParameters->peakgroups.size(); i++) {
-			clsf->classify(&eicParameters->peakgroups[i]);
-			eicParameters->peakgroups[i].updateQuality();
-		}
-	}
 	
 	setSelectedGroup(group);
 	setTitle();

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -226,7 +226,7 @@ public:
 
     QList< QPointer<TableDockWidget> > getPeakTableList() { return groupTables; } //TODO: Sahil - Kiran, Added while merging mainwindow
 
-	Classifier* getClassifier() {
+	ClassifierNeuralNet* getClassifier() {
 		return clsf;
 	}
 
@@ -421,7 +421,7 @@ private Q_SLOTS:
 private:
 	int m_value;
 	QSettings* settings;
-	Classifier* clsf;
+	ClassifierNeuralNet* clsf;
 	QList<QPointer<TableDockWidget> > groupTables;
 	//Added when merging with Maven776 - Kiran
     QMap< QPointer<TableDockWidget>, QToolButton*> groupTablesButtons;


### PR DESCRIPTION
- Ref: Indentation & remove unnecessary comments in process Slices
- Ref: Separate out group filtering part out of process Slices func
- Ref: Move classification of peaks before grouping 
- Ref: Add function scoreEICs to score peaks of EICs