### PR TITLE
Fix: Remove Rt line when expectedRt is not provided #553

### DIFF
--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1436,6 +1436,13 @@ void EicWidget::setCompound(Compound* c) {
 		setFocusLine(c->expectedRt);
 		selectGroupNearRt(c->expectedRt);
 	}
+	else {
+		//remove previous focusline
+		if (_focusLine && _focusLine->scene()) {
+			scene()->removeItem(_focusLine);
+			resetZoom();
+		}
+	}
 
 //   clock_gettime(CLOCK_REALTIME, &tE);
 	// qDebug() << "Time taken" << (tE.tv_sec-tS.tv_sec)*1000 + (tE.tv_nsec - tS.tv_nsec)/1e6;

--- a/src/gui/mzroll/eicwidget.h
+++ b/src/gui/mzroll/eicwidget.h
@@ -49,6 +49,11 @@ public Q_SLOTS:
 	void setRtWindow(float rtmin, float rtmax);
 	void setSrmId(string srmId);
 	void setPeakGroup(PeakGroup* group);
+	/**
+	 * @brief updates EIC widget for the selected compound
+	 * @details sets appropriate mzSlice in the EIC widget and focusLine for expected Rt
+	 * @param selected compound object
+	 **/
 	void setCompound(Compound* c);
 	void setSelectedGroup(PeakGroup* group);
 	void updateIsotopicBarplot(PeakGroup* group);


### PR DESCRIPTION
Rt line of the last selected compound persists when a compound with no expected Rt is selected.

The old Rt line will now be removed and the complete EIC displayed.

Issue: #553