### PR TITLE
Fix: Check for empty EIC when zooming out #553

### DIFF
--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1322,7 +1322,11 @@ void EicWidget::resetZoom() {
 	//qDebug <<"EicWidget::resetZoom() ";
 	mzSlice bounds(0, 0, 0, 0);
 
-	if (eicParameters->eics.size() > 0) {
+	bool hasData = false;
+	for (int i = 0; i < eicParameters->eics.size(); i++)
+		if (eicParameters->eics[i]->size() > 0) hasData = true;
+
+	if (hasData) {
 		bounds = eicParameters->visibleEICBounds();
 	} else if (getMainWindow()->sampleCount() > 0) {
 		vector<mzSample*> samples = getMainWindow()->getVisibleSamples();


### PR DESCRIPTION
Corner case: Calling ResetZoom for MS2 data gave a blank widget for empty EIC with no expected Rt.

The function now checks if the EIC in the widget is empty and sets the axis bounds equal to sample bounds.

Issue: #553