### PR TITLE
CSV export

### DIFF
--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -675,16 +675,13 @@ void PeakDetectorCLI::saveCSV(string setName) {
     }
 
     if(fileName.empty()) return;
-
-	csvreports->flag = 0;
     
     if (mavenParameters->samples.size() == 0) return;
 
     csvreports->setUserQuantType(quantitationType);
 
     //Added to pass into csvreports file when merged with Maven776 - Kiran
-    bool includeSetNamesLines=true;
-	csvreports->openGroupReport(fileName, includeSetNamesLines);
+	csvreports->openGroupReport(fileName);
 
     for(int i=0; i<mavenParameters->allgroups.size(); i++ ) {
 		PeakGroup& group = mavenParameters->allgroups[i];

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -681,7 +681,8 @@ void PeakDetectorCLI::saveCSV(string setName) {
     csvreports->setUserQuantType(quantitationType);
 
     //Added to pass into csvreports file when merged with Maven776 - Kiran
-	csvreports->openGroupReport(fileName);
+    //CLI exports the default Group Summary Matrix Format (without set Names)
+    csvreports->openGroupReport(fileName);
 
     for(int i=0; i<mavenParameters->allgroups.size(); i++ ) {
 		PeakGroup& group = mavenParameters->allgroups[i];

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -35,7 +35,7 @@ QString CSVReports::sanitizeString(const char* s) {
     return out;
 }
 
-void CSVReports::openGroupReport(string outputfile,bool includeSetNamesLine = false) {
+void CSVReports::openGroupReport(string outputfile,bool includeSetNamesLine) {
 
     initialCheck(outputfile);                                                                                               /**@brief-  if number of sample is zero, output file will not open*/
     openGroupReportCSVFile(outputfile);                                                                        /**@brief-  after checking initial check, open output file*/
@@ -82,8 +82,7 @@ void CSVReports::insertGroupReportColumnNamesintoCSVFile(string outputfile,bool 
         }
         groupReport << endl;
         //TODO: Remove this to remove row in csv reports --@Giridhari
-        if (includeSetNamesLine && flag){
-            cerr <<"setname: ";
+        if (includeSetNamesLine){
              for(unsigned int i=0; i < 12; i++) { groupReport << SEP; }
              for(unsigned int i=0; i< samples.size(); i++) { groupReport << SEP << sanitizeString(samples[i]->getSetName().c_str()).toStdString(); }
              groupReport << endl;

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -75,6 +75,7 @@ void CSVReports::insertGroupReportColumnNamesintoCSVFile(string outputfile,bool 
         groupReportcolnames << "label" << "metaGroupId" << "groupId" << "goodPeakCount"
                 << "medMz" << "medRt" << "maxQuality" << "isotopeLabel" << "compound"
                 << "compoundId" << "formula" << "expectedRtDiff" << "ppmDiff" << "parent";
+        int cohort_offset = groupReportcolnames.size() - 1;
         QString header = groupReportcolnames.join(SEP.c_str());
         groupReport << header.toStdString();
         for (unsigned int i = 0; i < samples.size(); i++) {
@@ -83,7 +84,7 @@ void CSVReports::insertGroupReportColumnNamesintoCSVFile(string outputfile,bool 
         groupReport << endl;
         //TODO: Remove this to remove row in csv reports --@Giridhari
         if (includeSetNamesLine){
-             for(unsigned int i = 0; i < 13; i++) { groupReport << SEP; }
+             for(unsigned int i = 0; i < cohort_offset; i++) { groupReport << SEP; }
              for(unsigned int i = 0; i < samples.size(); i++) { groupReport << SEP << sanitizeString(samples[i]->getSetName().c_str()).toStdString(); }
              groupReport << endl;
          }

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -83,8 +83,8 @@ void CSVReports::insertGroupReportColumnNamesintoCSVFile(string outputfile,bool 
         groupReport << endl;
         //TODO: Remove this to remove row in csv reports --@Giridhari
         if (includeSetNamesLine){
-             for(unsigned int i=0; i < 12; i++) { groupReport << SEP; }
-             for(unsigned int i=0; i< samples.size(); i++) { groupReport << SEP << sanitizeString(samples[i]->getSetName().c_str()).toStdString(); }
+             for(unsigned int i = 0; i < 13; i++) { groupReport << SEP; }
+             for(unsigned int i = 0; i < samples.size(); i++) { groupReport << SEP << sanitizeString(samples[i]->getSetName().c_str()).toStdString(); }
              groupReport << endl;
          }
     }

--- a/src/core/libmaven/csvreports.h
+++ b/src/core/libmaven/csvreports.h
@@ -38,7 +38,7 @@ public:
     /**
     * @brief-   open output file in which group info will be written
     */
-    void openGroupReport(string filename,bool includeSetNamesLine);
+    void openGroupReport(string filename,bool includeSetNamesLine = false);
     /**
     * @brief-   open output file in which peak info will be written
     */
@@ -108,7 +108,6 @@ public:
     QString sanitizeString(const char* s);
     ofstream groupReport;       /**@param-  output file for groups report*/
     ofstream peakReport;         /**@param-  output file for peaks report*/
-    int flag=1;                           /**@param-    TODO, not sure what this flag for*/
 private:
     void writeGroupInfo(PeakGroup* group);      /**@brief-  helper function to write group info*/
     void writePeakInfo(PeakGroup* group);           /**@brief-  helper function to write peak info*/

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -704,11 +704,11 @@ void TableDockWidget::exportGroupsToSpreadsheet() {
 
     if ( settings->contains("lastDir") ) dir = settings->value("lastDir").value<QString>();
 
-    QString groupsTAB = "Groups Summary Matrix Format (*.tab)";
-    QString groupsSTAB = "Groups Summary Matrix Format Without Set Name (*.tab)";    
+    QString groupsSTAB = "Groups Summary Matrix Format With Set Names (*.tab)";
+    QString groupsTAB = "Groups Summary Matrix Format (*.tab)";    
     QString peaksTAB =  "Peaks Detailed Format (*.tab)";
+    QString groupsSCSV = "Groups Summary Matrix Format Comma Delimited With Set Names (*.csv)";
     QString groupsCSV = "Groups Summary Matrix Format Comma Delimited (*.csv)";
-    QString groupsSCSV = "Groups Summary Matrix Format Comma Delimited Without Set Name (*.csv)";
     QString peaksCSV =  "Peaks Detailed Format Comma Delimited (*.csv)";
     //Added when Merging to Maven776 - Kiran
     QString peaksListQE= "Inclusion List QE (*.csv)";
@@ -722,19 +722,19 @@ void TableDockWidget::exportGroupsToSpreadsheet() {
 
     if(fileName.isEmpty()) return;
 
-    if ( sFilterSel == groupsCSV || sFilterSel == peaksCSV) {
+    if ( sFilterSel == groupsSCSV || sFilterSel == peaksCSV) {
         if(!fileName.endsWith(".csv",Qt::CaseInsensitive)) fileName = fileName + ".csv";
     }
-    if ( sFilterSel == groupsSCSV) {
+    if ( sFilterSel == groupsCSV) {
         if(!fileName.endsWith(".csv",Qt::CaseInsensitive)) fileName = fileName + ".csv";
         cerr <<"csv without:";
         csvreports->flag = 0;
         cerr <<"csv without:1";
     }
-    if ( sFilterSel == groupsTAB || sFilterSel == peaksTAB) {
+    if ( sFilterSel == groupsSTAB || sFilterSel == peaksTAB) {
         if(!fileName.endsWith(".tab",Qt::CaseInsensitive)) fileName = fileName + ".tab";
     }
-    if ( sFilterSel == groupsSTAB) {
+    if ( sFilterSel == groupsTAB) {
         cerr <<"tab without:";
         if(!fileName.endsWith(".tab",Qt::CaseInsensitive)) fileName = fileName + ".tab";
         csvreports->flag = 0;
@@ -758,9 +758,9 @@ void TableDockWidget::exportGroupsToSpreadsheet() {
     //Added to pass into csvreports file when merged with Maven776 - Kiran
     bool includeSetNamesLines=true;
 
-    if (sFilterSel == groupsCSV) {
+    if (sFilterSel == groupsSCSV) {
         csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
-    } else if (sFilterSel == groupsTAB )  {
+    } else if (sFilterSel == groupsSTAB )  {
         csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
     } else if (sFilterSel == peaksCSV )  {
         csvreports->openPeakReport(fileName.toStdString());

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -717,7 +717,7 @@ void TableDockWidget::exportGroupsToSpreadsheet() {
     QString sFilterSel;
     QString fileName = QFileDialog::getSaveFileName(this, 
             tr("Export Groups"), dir, 
-            groupsTAB + ";;" + groupsSTAB + ";;" + peaksTAB + ";;" + groupsCSV + ";;" + groupsSCSV + ";;" + peaksCSV + ";;" + peaksListQE + ";;" + mascotMGF,
+            groupsCSV + ";;" + groupsSCSV + ";;" + groupsTAB + ";;" + groupsSTAB + ";;" + peaksCSV + ";;" + peaksTAB + ";;" + peaksListQE + ";;" + mascotMGF,
             &sFilterSel);
 
     if(fileName.isEmpty()) return;

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -722,23 +722,12 @@ void TableDockWidget::exportGroupsToSpreadsheet() {
 
     if(fileName.isEmpty()) return;
 
-    if ( sFilterSel == groupsSCSV || sFilterSel == peaksCSV) {
+    if ( sFilterSel == groupsSCSV || sFilterSel == peaksCSV || sFilterSel == groupsCSV) {
         if(!fileName.endsWith(".csv",Qt::CaseInsensitive)) fileName = fileName + ".csv";
     }
-    if ( sFilterSel == groupsCSV) {
-        if(!fileName.endsWith(".csv",Qt::CaseInsensitive)) fileName = fileName + ".csv";
-        cerr <<"csv without:";
-        csvreports->flag = 0;
-        cerr <<"csv without:1";
-    }
-    if ( sFilterSel == groupsSTAB || sFilterSel == peaksTAB) {
+    
+    if ( sFilterSel == groupsSTAB || sFilterSel == peaksTAB || sFilterSel == groupsTAB) {
         if(!fileName.endsWith(".tab",Qt::CaseInsensitive)) fileName = fileName + ".tab";
-    }
-    if ( sFilterSel == groupsTAB) {
-        cerr <<"tab without:";
-        if(!fileName.endsWith(".tab",Qt::CaseInsensitive)) fileName = fileName + ".tab";
-        csvreports->flag = 0;
-        cerr <<"tab without:1";
     }
     
     if ( samples.size() == 0) return;
@@ -768,7 +757,7 @@ void TableDockWidget::exportGroupsToSpreadsheet() {
         csvreports->openPeakReport(fileName.toStdString());
     } else { 	//default to group summary
         //Updated when csvreports file was merged with Maven776 - Kiran
-        csvreports->openGroupReport(fileName.toStdString(),includeSetNamesLines);
+        csvreports->openGroupReport(fileName.toStdString());
     }
 
     QList<PeakGroup*> selectedGroups = getSelectedGroups();

--- a/tests/MavenTests/testCSVReports.cpp
+++ b/tests/MavenTests/testCSVReports.cpp
@@ -60,7 +60,7 @@ void TestCSVReports::testopenGroupReport() {
     colnames.clear();
     getline(ifile, temp);
     remove(outputfile.c_str());
-    for(unsigned int i=0; i < 14; i++) { colnames << ","; }
+    for(unsigned int i=0; i < 15; i++) { colnames << ","; }
     header = colnames.join("");
     QVERIFY(header.toStdString()==temp);
 }


### PR DESCRIPTION
This PR includes the following fixes:

- The export format names (in the export CSV dialog box) have been modified. 'Group Summary Matrix format' and 'Group Summary Matrix Format Without Set Names' have been changed to 'Group Summary Matrix Format with Set Names' and 'Group Matrix Summary Format' respectively. This has been done to make the default format without set names as it is more popular. (#555 )
- Bug in Set Names export: Cohort names were shifted to the left
- Minor refactoring to prevent such bugs in the future
- Updated test