### PR TITLE
Fix: Update correct column for maxQuality #602

### DIFF
--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -325,7 +325,7 @@ void TableDockWidget::updateItem(QTreeWidgetItem* item) {
         clsf->classify(group);
         group->updateQuality();
         //Added when Merging to Maven776 - Kiran
-        if(viewType == groupView) item->setText(10,QString::number(group->maxQuality,'f',2));
+        if(viewType == groupView) item->setText(11,QString::number(group->maxQuality,'f',2));
         item->setText(1,QString(group->getName().c_str()));
     }
 


### PR DESCRIPTION
Max S/N column was getting updated with maxQuality value leading to the same value in both columns.

Issue: #602