### PR TITLE
Fix test coverage

### DIFF
--- a/3rdparty/libcdfread/libcdfread.pro
+++ b/3rdparty/libcdfread/libcdfread.pro
@@ -1,8 +1,8 @@
-include($$mzroll_pri)
+
 
 MOC_DIR=$$top_builddir/tmp/cdfread/
 OBJECTS_DIR=$$top_builddir/tmp/cdfread/
-
+include($$mzroll_pri)
 DESTDIR=$$top_builddir/libs/
 
 TEMPLATE = lib

--- a/3rdparty/libcsvparser/libcsvparser.pro
+++ b/3rdparty/libcsvparser/libcsvparser.pro
@@ -1,9 +1,9 @@
-include($$mzroll_pri)
+
 
 
 MOC_DIR=$$top_builddir/tmp/csv_parser/
 OBJECTS_DIR=$$top_builddir/tmp/csv_parser/
-
+include($$mzroll_pri)
 DESTDIR=$$top_builddir/libs/
 
 TEMPLATE = lib

--- a/3rdparty/libdate/libdate.pro
+++ b/3rdparty/libdate/libdate.pro
@@ -1,8 +1,8 @@
-include($$mzroll_pri)
+
 
 MOC_DIR=$$top_builddir/tmp/date/
 OBJECTS_DIR=$$top_builddir/tmp/date/
-
+include($$mzroll_pri)
 DESTDIR=$$top_builddir/libs/
 
 TEMPLATE = lib

--- a/3rdparty/libneural/libneural.pro
+++ b/3rdparty/libneural/libneural.pro
@@ -1,8 +1,8 @@
-include($$mzroll_pri)
+
 
 MOC_DIR=$$top_builddir/tmp/neural/
 OBJECTS_DIR=$$top_builddir/tmp/neural/
-
+include($$mzroll_pri)
 DESTDIR=$$top_builddir/libs/
 
 TEMPLATE = lib

--- a/3rdparty/libpillow/libpillow.pro
+++ b/3rdparty/libpillow/libpillow.pro
@@ -1,9 +1,9 @@
-include($$mzroll_pri)
+
 include(config.pri)
 
 MOC_DIR=$$top_builddir/tmp/pillow/
 OBJECTS_DIR=$$top_builddir/tmp/pillow/
-
+include($$mzroll_pri)
 unix {
     DESTDIR=$$top_builddir/libs/
 }

--- a/3rdparty/libplog/libplog.pro
+++ b/3rdparty/libplog/libplog.pro
@@ -1,8 +1,7 @@
-include($$mzroll_pri)
 
 MOC_DIR=$$top_builddir/tmp/plog/
 OBJECTS_DIR=$$top_builddir/tmp/plog/
-
+include($$mzroll_pri)
 DESTDIR=$$top_builddir/libs/
 
 TEMPLATE = lib

--- a/3rdparty/libpls/libpls.pro
+++ b/3rdparty/libpls/libpls.pro
@@ -1,9 +1,9 @@
-include($$mzroll_pri)
+
 DESTDIR=$$top_builddir/libs/
 
 MOC_DIR=$$top_builddir/tmp/pls/
 OBJECTS_DIR=$$top_builddir/tmp/pls/
-
+include($$mzroll_pri)
 TEMPLATE=lib
 CONFIG += staticlib warn_off console silent
 TARGET = pls

--- a/3rdparty/pugixml/src/src.pro
+++ b/3rdparty/pugixml/src/src.pro
@@ -1,7 +1,6 @@
-include($$mzroll_pri)
-
 MOC_DIR=$$top_builddir/tmp/pugixml/
 OBJECTS_DIR=$$top_builddir/tmp/pugixml/
+include($$mzroll_pri)
 
 DESTDIR=$$top_builddir/libs/
 

--- a/CrashReporter/CrashReporter.pro
+++ b/CrashReporter/CrashReporter.pro
@@ -10,6 +10,17 @@ QT       += core gui network
 MOC_DIR=$$top_builddir/tmp/crash_reporter/
 OBJECTS_DIR=$$top_builddir/tmp/crash_reporter/
 
+CONFIG(debug, debug|release){
+    message("running in debug mode  ")
+    unix:!macx {
+        QMAKE_CCFLAGS+= -fprofile-arcs -ftest-coverage
+        QMAKE_CXXFLAGS+= -fprofile-arcs -ftest-coverage
+        QMAKE_LFLAGS+= -fprofile-arcs -ftest-coverage
+        MOC_DIR=tmp/
+        OBJECTS_DIR=tmp/
+    }
+}
+
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 TARGET = CrashReporter

--- a/mzWatcher/mzWatcher.pro
+++ b/mzWatcher/mzWatcher.pro
@@ -1,9 +1,9 @@
-include(../mzroll.pri)
+
 
 TEMPLATE = app
 TARGET = mzWatcher
 DESTDIR = ../bin
-
+include(../mzroll.pri)
 CONFIG += warn_off gui network
 #CONFIG += console
 CONFIG -= opengl

--- a/mzroll.pri
+++ b/mzroll.pri
@@ -4,6 +4,8 @@ CONFIG(debug, debug|release){
         QMAKE_CCFLAGS+= -fprofile-arcs -ftest-coverage
         QMAKE_CXXFLAGS+= -fprofile-arcs -ftest-coverage
         QMAKE_LFLAGS+= -fprofile-arcs -ftest-coverage
+        MOC_DIR=tmp/
+        OBJECTS_DIR=tmp/
     }
 }
 

--- a/run.sh
+++ b/run.sh
@@ -20,10 +20,10 @@ if [ -f ./bin/MavenTests ]; then
 	./bin/MavenTests -xml
 fi
 
-type="$(uname)" 
+type="$(uname)"
 systemType="$(echo "$type"  |  tr '[:upper:]'  '[:lower:]')"
 if [ $systemType == "linux" ] && [ $flag == 10 ]; then
-    lcov --capture --directory ./ --output-file coverage.info
-    genhtml coverage.info --output-directory coverage
+    lcov --capture --directory ./ --output-file ../coverage.info --no-external
+    genhtml ../coverage.info --output-directory ../coverage
 fi
 

--- a/src/cli/peakdetector/peakdetector.pro
+++ b/src/cli/peakdetector/peakdetector.pro
@@ -1,9 +1,8 @@
-include($$mzroll_pri)
 DESTDIR = $$top_srcdir/bin
 
 MOC_DIR=$$top_builddir/tmp/peakdetector/
 OBJECTS_DIR=$$top_builddir/tmp/peakdetector/
-
+include($$mzroll_pri)
 TEMPLATE = app
 TARGET = peakdetector
 

--- a/src/core/libmaven/libmaven.pro
+++ b/src/core/libmaven/libmaven.pro
@@ -1,8 +1,6 @@
-include($$mzroll_pri)
-
 MOC_DIR=$$top_builddir/tmp/maven/
 OBJECTS_DIR=$$top_builddir/tmp/maven/
-
+include($$mzroll_pri)
 DESTDIR=$$top_builddir/libs/
 
 QT+= sql network

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -1,8 +1,6 @@
-include($$mzroll_pri)
-
 MOC_DIR=$$top_builddir/tmp/mzroll/
 OBJECTS_DIR=$$top_builddir/tmp/mzroll/
-
+include($$mzroll_pri)
 DESTDIR = $$top_srcdir/bin/
 #TEMPLATE = app
 

--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -1,9 +1,8 @@
-include($$mzroll_pri)
 DESTDIR = $$top_srcdir/bin/
 
 MOC_DIR=$$top_builddir/tmp/maven_tests/
 OBJECTS_DIR=$$top_builddir/tmp/maven_tests/
-
+include($$mzroll_pri)
 TEMPLATE = app
 TARGET = MavenTests
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,3 +3,6 @@ rm -rf build/lib/*
 make -C MavenTests/ distclean
 rm -rf bin/maven_dev* bin/El_Maven* bin/peakdetector bin/mzWatcher docs/html docs/latex 
 rm -rf $HOME/.config/mzRoll
+find . -type d | grep tmp | xargs rm -rfd
+rm -frd ../coverage
+rm -rf ../coverage.info


### PR DESCRIPTION
Step to generate test coverage (only for linux)-

1. Run **uninstall.sh**
2. Run **run.sh** in debug mode (type **n** afte running run.sh)
3. Go to parent directory of ElMaven
4. Go to **coverage** directory and click on **index.html**
    While running in debug mode, all temporary files (moc* , *.o, *.gcno and *.gcda) will be created in tmp folder of respective subdirectory not in ../build/tmp folder. Running **uninstall.sh** will delete all these tmp directories.
    While running in release mode, all temporary files will be created in ../build/tmp folder.
Debug mode is generating temporary files in respective folder to generate test-coverage.