### PR TITLE
Test isotope module

### DIFF
--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -46,6 +46,7 @@ HEADERS += \
     testCharge.h \
     testSRMList.h \
     testGroupFiltering.h \
+    testIsotopeLogic.h \
     $$top_srcdir/src/cli/peakdetector/PeakDetectorCLI.h \
     $$top_srcdir/src/core/libmaven/classifier.h \
     $$top_srcdir/src/core/libmaven/classifierNeuralNet.h \
@@ -69,6 +70,7 @@ SOURCES += \
     testCharge.cpp \
     testSRMList.cpp \
     testGroupFiltering.cpp \
+    testIsotopeLogic.cpp \
     main.cpp \
     $$top_srcdir/src/cli/peakdetector/PeakDetectorCLI.cpp  \
     $$top_srcdir/src/cli/peakdetector/options.cpp \

--- a/tests/MavenTests/main.cpp
+++ b/tests/MavenTests/main.cpp
@@ -14,6 +14,7 @@
 #include "testCLI.h"
 #include "testCharge.h"
 #include "testSRMList.h"
+#include "testIsotopeLogic.h"
 
 int readLog(QString);
 
@@ -73,6 +74,10 @@ int main(int argc, char** argv) {
     if (freopen("testSRMList.xml", "w", stdout))
         result |= QTest::qExec(new TestSRMList, argc, argv);
     result|=readLog("testSRMList.xml");
+
+    if (freopen("testIsotopeLogic.xml", "w", stdout))
+        result |= QTest::qExec(new TestIsotopeLogic, argc, argv);
+    result|=readLog("testIsotopeLogic.xml");
 
     return result;
 }

--- a/tests/MavenTests/testIsotopeLogic.cpp
+++ b/tests/MavenTests/testIsotopeLogic.cpp
@@ -1,0 +1,23 @@
+#include "testIsotopeLogic.h"
+#include "isotopelogic.h"
+
+TestIsotopeLogic::TestIsotopeLogic() {
+
+}
+
+void TestIsotopeLogic::initTestCase() {
+    // This function is being executed at the beginning of each test suite
+    // That is - before other tests from this class run
+}
+
+void TestIsotopeLogic::cleanupTestCase() {
+    // Similarly to initTestCase(), this function is executed at the end of test suite
+}
+
+void TestIsotopeLogic::init() {
+    // This function is executed before each test
+}
+
+void TestIsotopeLogic::cleanup() {
+    // This function is executed after each test
+}

--- a/tests/MavenTests/testIsotopeLogic.h
+++ b/tests/MavenTests/testIsotopeLogic.h
@@ -1,0 +1,29 @@
+#ifndef TESTISOTOPELOGIC_H
+#define TESTISOTOPELOGIC_H
+#include <iostream>
+#include <QtTest>
+#include <string>
+#include <sstream>
+
+
+class TestIsotopeLogic : public QObject {
+    Q_OBJECT
+
+    public:
+        TestIsotopeLogic();
+    private:
+
+    private Q_SLOTS:
+        // functions executed by QtTest before and after test suite
+        void initTestCase();
+        void cleanupTestCase();
+
+        // functions executed by QtTest before and after each test
+        void init();
+        void cleanup();
+
+        // test functions - all functions prefixed with "test" will be ran as tests
+        // this is automatically detected thanks to Qt's meta-information about QObjects
+};
+
+#endif // TESTISOTOPELOGIC_H

--- a/tests/MavenTests/testMassCalculator.cpp
+++ b/tests/MavenTests/testMassCalculator.cpp
@@ -77,22 +77,56 @@ void TestMassCalculator::testComputeMass() {
 }
 
 void TestMassCalculator::testComputeIsotopes() {
-    string XanthosineChe = "C10H12N4O6";
-
+    string formula = "C12H18N4O4PS";
     map <string, bool> isotopeAtom;
+
+    //test for all labels
+    isotopeAtom["ShowIsotopes"] = true;
     isotopeAtom["D2Labeled_BPE"] = true;
     isotopeAtom["C13Labeled_BPE"] = true;
     isotopeAtom["N15Labeled_BPE"] = true;
     isotopeAtom["S34Labeled_BPE"] = true;
 
-    vector<Isotope> isotopesXanthosine = MassCalculator::computeIsotopes(XanthosineChe, +1, isotopeAtom, 2);
+    vector<Isotope> isotopes = MassCalculator::computeIsotopes(formula, +1, isotopeAtom, 500);
 
-    //TODO: have to add a test case here
-    for(vector<Isotope>::iterator it = isotopesXanthosine.begin(); it != isotopesXanthosine.end(); ++it) {
-         //cerr << it->name << endl;
-    }
+    //verify number of isotopes
+    QVERIFY(isotopes.size() == 312);
+    //verify C12 parent mass
+    QVERIFY(floor(isotopes[0].mass) == 346);
+    //verify C13 mass
+    QVERIFY(floor(isotopes[277].mass) == 347);
+    //verify N15 mass
+    QVERIFY(floor(isotopes[290].mass) == 348);
+    //verify D2 mass
+    QVERIFY(floor(isotopes[294].mass) == 347);
+    //verify S34 mass
+    QVERIFY(floor(isotopes[293].mass) == 348);
+    //verify C13N15 dual label mass
+    QVERIFY(floor(isotopes[1].mass) == 348);
+    //verify C13D2 dual label mass
+    QVERIFY(floor(isotopes[61].mass) == 348);
+    //verify C13S34 dual label mass
+    QVERIFY(floor(isotopes[49].mass) == 349);
+    //verify abundance calculation
+    QVERIFY(isotopes[294].abundance > 0.00169 && isotopes[294].abundance < 0.0017);
 
-    QVERIFY(true);
+    //test for isotopeAtom condition statements
+    isotopeAtom["C13Labeled_BPE"] = true;
+    isotopeAtom["N15Labeled_BPE"] = false;
+    isotopeAtom["D2Labeled_BPE"] = false;
+
+    vector<Isotope> isotopes1 = MassCalculator::computeIsotopes(formula, +1, isotopeAtom, 200);
+
+    //verify number of isotopes
+    QVERIFY(isotopes1.size() == 26);
+
+    //test for isotope detection off
+    isotopeAtom["ShowIsotopes"] = false;
+
+    vector<Isotope> isotopes2 = MassCalculator::computeIsotopes(formula, +1, isotopeAtom, 200);
+
+    //verify number of isotopes. Only C12 parent should be present
+    QVERIFY(isotopes2.size() == 1);
 }
 
 void TestMassCalculator::testenumerateMasses() {

--- a/tests/MavenTests/testPeakDetection.cpp
+++ b/tests/MavenTests/testPeakDetection.cpp
@@ -159,6 +159,7 @@ void TestPeakDetection::testpullIsotopes() {
     {
         PeakGroup& child = parent.children[i];
         Peak* childPeak = child.getPeak(sample);
+        if (!childPeak) continue;
         float rtDiff = abs(parentRt - childPeak->rt);
         if (rtDiff > maxRtDiff) outlier++;
     }

--- a/tests/MavenTests/testPeakDetection.cpp
+++ b/tests/MavenTests/testPeakDetection.cpp
@@ -94,8 +94,7 @@ void TestPeakDetection::testprocessSlices() {
 
 void TestPeakDetection::testpullIsotopes() {
     DBS.loadCompoundCSVFile(loadCompoundDB);
-    vector<Compound*> compounds =
-        DBS.getCopoundsSubset("qe3_v11_2016_04_29");
+    vector<Compound*> compounds = DBS.getCopoundsSubset("qe3_v11_2016_04_29");
     vector<mzSample*> samplesToLoad;
 
     for (int i = 0; i < files.size(); ++i) {
@@ -107,8 +106,7 @@ void TestPeakDetection::testpullIsotopes() {
     MavenParameters* mavenparameters = new MavenParameters();
     mavenparameters->compoundMassCutoffWindow->setMassCutoffAndType(10,"ppm");
     ClassifierNeuralNet* clsf = new ClassifierNeuralNet();
-    string loadmodel = "bin/default.model";
-    clsf->loadModel(loadmodel);
+    clsf->loadModel("bin/default.model");
     mavenparameters->clsf = clsf;
     mavenparameters->ionizationMode = +1;
     mavenparameters->matchRtFlag = true;
@@ -116,17 +114,21 @@ void TestPeakDetection::testpullIsotopes() {
     mavenparameters->samples = samplesToLoad;
     mavenparameters->eic_smoothingWindow = 10;
     mavenparameters->eic_smoothingAlgorithm = 1;
-    mavenparameters->amuQ1 = 0.25;
-    mavenparameters->amuQ3 = 0.30;
     mavenparameters->baseline_smoothingWindow = 5;
     mavenparameters->baseline_dropTopX = 80;
+    mavenparameters->isotopeAtom["ShowIsotopes"] = true;
+    mavenparameters->isotopeAtom["C13Labeled_BPE"] = true;
+    mavenparameters->isotopeAtom["N15Labeled_BPE"] = true;
+    mavenparameters->isotopeAtom["D2Labeled_BPE"] = true;
+    mavenparameters->isotopeAtom["S34Labeled_BPE"] = true;
 
     PeakDetector peakDetector;
     peakDetector.setMavenParameters(mavenparameters);
-    vector<mzSlice*> slices = 
-	    peakDetector.processCompounds(compounds, "compounds");
+    vector<mzSlice*> slices = peakDetector.processCompounds(compounds, "compounds");
     peakDetector.processSlices(slices, "compounds");
+    
     PeakGroup& parent = mavenparameters->allgroups[0];
     peakDetector.pullIsotopes(&parent);
-    QVERIFY(parent.childCount() > 0);
+    
+    QVERIFY(parent.childCount() == 12);
 }

--- a/tests/MavenTests/testPeakDetection.cpp
+++ b/tests/MavenTests/testPeakDetection.cpp
@@ -155,7 +155,7 @@ void TestPeakDetection::testpullIsotopes() {
     peakDetector.pullIsotopes(&parent);
     
     int outlier = 0;
-    for(int i = 0; i < parent.children.size(); i++) 
+    for (int i = 0; i < parent.children.size(); i++) 
     {
         PeakGroup& child = parent.children[i];
         Peak* childPeak = child.getPeak(sample);
@@ -163,4 +163,34 @@ void TestPeakDetection::testpullIsotopes() {
         if (rtDiff > maxRtDiff) outlier++;
     }
     QVERIFY(outlier == 0);
+    
+    //test for different labels
+    mavenparameters->C13Labeled_BPE = true;
+    mavenparameters->N15Labeled_BPE = false;
+    mavenparameters->D2Labeled_BPE = false;
+    mavenparameters->S34Labeled_BPE = true;
+    mavenparameters->minIsotopicCorrelation = 0.2;
+    mavenparameters->maxIsotopeScanDiff = 5;
+    mavenparameters->avgScanTime = 0.2;
+    parent = mavenparameters->allgroups[4];
+
+    peakDetector.pullIsotopes(&parent);
+
+    int N15_BPE = 0;
+    int D2_BPE = 0;
+    int C13_BPE = 0;
+    for (int i = 0; i < parent.children.size(); i++)
+    {
+        PeakGroup& child = parent.children[i];
+        string isotopeName = child.tagString;
+        if (isotopeName.find(N15_LABEL) != string::npos || isotopeName.find(C13N15_LABEL) != string::npos)
+            N15_BPE++;
+        if (isotopeName.find(H2_LABEL) != string::npos || isotopeName.find(C13H2_LABEL) != string::npos)
+            D2_BPE++;
+        if (isotopeName.find(C13_LABEL) != string::npos)
+            C13_BPE++;
+    }
+    QVERIFY(N15_BPE == 0);
+    QVERIFY(D2_BPE == 0);
+    QVERIFY(C13_BPE > 0);
 }

--- a/tests/MavenTests/testPeakDetection.h
+++ b/tests/MavenTests/testPeakDetection.h
@@ -18,6 +18,7 @@ class TestPeakDetection : public QObject {
         TestPeakDetection();
     private:
         const char* loadCompoundDB;
+        const char* loadCompoundDB1;
         QStringList files;
 
     private Q_SLOTS:


### PR DESCRIPTION
This PR has tests for:

mzMassCalculator::computeIsotopes()

- Add test cases for mass calculation of all labels
- Add test case for abundance calculation
- Add test case for turning on/off isotope detection
- Add test case for certain labels turning on/off

PeakDetector::pullIsotopes()

- Add test case for isotopicCorrelation filter
- Add test case for Isotopes within Rt limits
- Add test case for certain labels turning on/off