### PR TITLE
Blank samples in sample widget #512 #535

### DIFF
--- a/bin/methods/test.xml
+++ b/bin/methods/test.xml
@@ -39,6 +39,6 @@
 		<outputdir type="string" value="bin/methods" />
 		<savemzroll type="int" value="1" />
 		<samples type="string" value="bin/methods/testsample_2.mzxml" />
-		<samples type="string" value="bin/methods/blan_1.mzxml" />
+		<samples type="string" value="bin/methods/blank_1.mzxml" />
 	</GeneralArguments>
 </Arguments>

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -145,7 +145,7 @@ void mzSample::checkSampleBlank(const char *filename)
 	this->isBlank = false;
 
 	makeLowerCase(filenameString);
-	if (filenameString.find("blan") != string::npos)
+	if (filenameString.find("blank") != string::npos)
 	{
 		this->isBlank = true;
 	}

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -82,7 +82,7 @@ mzSample* mzFileIO::loadSample(QString filename){
         //set file path
         sample->fileName = filename.toStdString();
 
-        if (filename.contains("blan",Qt::CaseInsensitive)) sample->isBlank = true;
+        if (filename.contains("blank",Qt::CaseInsensitive)) sample->isBlank = true;
         return sample;
     }
     return NULL;
@@ -542,7 +542,7 @@ void mzFileIO::fileImport(void) {
                     sample->calculateMzRtRange();    //set min and max values for rt
                     sample->fileName = filename.toStdString();
 
-                    if ( filename.contains("blan",Qt::CaseInsensitive))
+                    if ( filename.contains("blank",Qt::CaseInsensitive))
                             sample->isBlank = true;   //check if this is a blank sample
 
                     if (sample->scans.size()>0)
@@ -567,7 +567,7 @@ void mzFileIO::fileImport(void) {
                     sample->calculateMzRtRange();    //set min and max values for rt
                     sample->fileName = filename.toStdString();
 
-                    if ( filename.contains("blan",Qt::CaseInsensitive))
+                    if ( filename.contains("blank",Qt::CaseInsensitive))
                             sample->isBlank = true;   //check if this is a blank sample
 
                     if (sample->scans.size()>0)

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -455,15 +455,6 @@ void ProjectDockWidget::setInfo(vector<mzSample*>&samples) {
 
         sample->setSampleOrder(i);
 
-		//set blank to non transparent red
-		if (sample->isBlank) {
-			sample->color[0] = 0.9;
-			sample->color[1] = 0.0;
-			sample->color[2] = 0.0;
-			sample->color[3] = 1.0;
-			continue;
-		}
-
 		float hue = 1 - 0.6 * ((float) (i + 1) / N);
 		QColor c = QColor::fromHsvF(hue, 1.0, 1.0, 1.0);
 		//qDebug() << "SAMPLE COLOR=" << c;
@@ -512,6 +503,14 @@ void ProjectDockWidget::setInfo(vector<mzSample*>&samples) {
         item->setFlags(Qt::ItemIsEditable|Qt::ItemIsSelectable|Qt::ItemIsDragEnabled|Qt::ItemIsUserCheckable|Qt::ItemIsEnabled);
         sample->isSelected  ? item->setCheckState(0,Qt::Checked) : item->setCheckState(0,Qt::Unchecked);
         item->setExpanded(true);
+        
+        //set blank to black italics
+		if (sample->isBlank) {
+            setSampleColor(item, QColor(Qt::black));
+            QFont font;
+            font.setItalic(true); 
+            item->setFont(0,font);
+		}
     }
 
     _treeWidget->resizeColumnToContents(0);

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -360,28 +360,46 @@ void ProjectDockWidget::SetAsBlankSamples() {
               QVariant v = item->data(0,Qt::UserRole);
               mzSample*  sample =  v.value<mzSample*>();
               if ( sample == NULL) return;
-              if(!sample->isBlank){
-                        sample->isBlank = true; // To selected samples as Blank Samples
-                        QString sampleName = QString::fromStdString(sample->sampleName.c_str());
-                        usedColor = QColor::fromRgbF(sample->color[0], sample->color[1],sample->color[2], 1.0);
-                        storeColor[sampleName] = usedColor;
-                        if (item->type() == SampleType) setSampleColor(item, QColor(Qt::black));
-                        QFont font;
-                        font.setItalic(true); 
-                        item->setFont(0,font);
-              }
-              else{
-                    sample->isBlank = false; // To unselected samples as Blank Samples
-                    QString sampleName = QString::fromStdString(sample->sampleName.c_str());
-                    if (item->type() == SampleType) setSampleColor(item, storeColor[sampleName]);
-                    QFont font;
-                    font.setItalic(false); 
-                    item->setFont(0,font);
-              }
+              if(!sample->isBlank) markBlank(item);
+              else unmarkBlank(item);
            }
       }
      _treeWidget->update();
      _mainwindow->getEicWidget()->replotForced();
+}
+
+void ProjectDockWidget::unmarkBlank(QTreeWidgetItem* item) {
+    QVariant v = item->data(0,Qt::UserRole);
+    mzSample*  sample =  v.value<mzSample*>();
+    if ( sample == NULL) return;
+
+    sample->isBlank = false;
+
+    //restore sample color
+    QString sampleName = QString::fromStdString(sample->sampleName.c_str());
+    setSampleColor(item, storeColor[sampleName]);
+    
+    QFont font;
+    font.setItalic(false); 
+    item->setFont(0,font);
+}
+
+void ProjectDockWidget::markBlank(QTreeWidgetItem* item) {
+    QVariant v = item->data(0,Qt::UserRole);
+    mzSample*  sample =  v.value<mzSample*>();
+    if ( sample == NULL) return;
+    
+    sample->isBlank = true; //for manually marking blanks
+    
+    //Set sample color to black
+    QString sampleName = QString::fromStdString(sample->sampleName.c_str());
+    storeColor[sampleName] = QColor::fromRgbF(sample->color[0], sample->color[1],sample->color[2], 1.0);
+    setSampleColor(item, QColor(Qt::black));
+    
+    //Sample name in italics
+    QFont font;
+    font.setItalic(true); 
+    item->setFont(0,font);
 }
 
 void ProjectDockWidget::setSampleColor(QTreeWidgetItem* item, QColor color) {

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -524,10 +524,7 @@ void ProjectDockWidget::setInfo(vector<mzSample*>&samples) {
         
         //set blank to black italics
 		if (sample->isBlank) {
-            setSampleColor(item, QColor(Qt::black));
-            QFont font;
-            font.setItalic(true); 
-            item->setFont(0,font);
+            markBlank(item);
 		}
     }
 

--- a/src/gui/mzroll/projectdockwidget.h
+++ b/src/gui/mzroll/projectdockwidget.h
@@ -64,6 +64,8 @@ private Q_SLOTS:
 
 private:
     QTreeWidgetItem* getParentFolder(QString filename);
+    void markBlank(QTreeWidgetItem* item);
+    void unmarkBlank(QTreeWidgetItem* item);
     QMap<QString,QTreeWidgetItem*> parentMap;
     QTextEdit* _editor;
     MainWindow* _mainwindow;

--- a/tests/MavenTests/testCLI.cpp
+++ b/tests/MavenTests/testCLI.cpp
@@ -7,7 +7,7 @@ TestCLI::TestCLI() {
     clsfPath = "bin/default.model";
     dbPath = "bin/methods/KNOWNS.csv";
     normalSample = "bin/methods/testsample_1.mzxml";
-    blankSample = "bin/methods/blan_1.mzxml";
+    blankSample = "bin/methods/blank_1.mzxml";
 
 }
 
@@ -45,7 +45,7 @@ void TestCLI::testLoadSamples() {
 
     QVERIFY(peakdetectorCLI->mavenParameters->samples.size() == 2);
     QVERIFY(peakdetectorCLI->mavenParameters->samples[0]->getSampleName().compare("testsample_1.mzxml"));
-    QVERIFY(peakdetectorCLI->mavenParameters->samples[1]->getSampleName().compare("blan_1.mzxml"));
+    QVERIFY(peakdetectorCLI->mavenParameters->samples[1]->getSampleName().compare("blank_1.mzxml"));
 
 }
 
@@ -89,7 +89,7 @@ void TestCLI::testProcessXml() {
 
     peakdetectorCLI->loadSamples(peakdetectorCLI->filenames);
     QVERIFY(peakdetectorCLI->mavenParameters->samples[0]->getSampleName().compare("testsample_1.mzxml"));
-    QVERIFY(peakdetectorCLI->mavenParameters->samples[1]->getSampleName().compare("blan_1.mzxml"));
+    QVERIFY(peakdetectorCLI->mavenParameters->samples[1]->getSampleName().compare("blank_1.mzxml"));
 
 	peakdetectorCLI->loadClassificationModel(peakdetectorCLI->clsfModelFilename);
     QVERIFY(peakdetectorCLI->mavenParameters->clsf->hasModel());

--- a/tests/MavenTests/testLoadSamples.cpp
+++ b/tests/MavenTests/testLoadSamples.cpp
@@ -4,7 +4,7 @@
 
 TestLoadSamples::TestLoadSamples() {
     loadFile = "bin/methods/testsample_1.mzxml";
-    blankSample = "bin/methods/blan_1.mzxml";
+    blankSample = "bin/methods/blank_1.mzxml";
 }
 
 void TestLoadSamples::initTestCase() {


### PR DESCRIPTION
The commits in this PR will effect the following changes:
- Samples with 'blank' in their filename will be marked as blanks. Samples with just 'blan' would not.
- Automatically marked blanks will show up as black. The text will be in italics.
- User can unmark automatically detected blanks.
- Unmarking a blank will restore its color