### PR TITLE
Init exception

### DIFF
--- a/3rdparty/3rdparty.pro
+++ b/3rdparty/3rdparty.pro
@@ -2,7 +2,7 @@ TEMPLATE = subdirs
 CONFIG += ordered qt thread
 
 
-SUBDIRS += libneural libcdfread  libcsvparser pugixml/src  libpillow libpls
+SUBDIRS += libneural libcdfread  libcsvparser pugixml/src  libpillow libpls ErrorHandling
 !macx {
     SUBDIRS += libplog
 }

--- a/3rdparty/ErrorHandling/ErrorHandling.pro
+++ b/3rdparty/ErrorHandling/ErrorHandling.pro
@@ -2,8 +2,11 @@ TEMPLATE = lib
 
 DESTDIR=$$top_builddir/libs/
 OBJECTS_DIR=$$top_buildir/tmp/error_handling
+MOC_DIR=$$top_builddir/tmp/error_handling
 
 CONFIG += staticlib
+
+INCLUDEPATH += $$top_srcdir/3rdparty/libplog
 
 SOURCES += MavenException.cpp
 HEADERS += MavenException.h

--- a/3rdparty/ErrorHandling/ErrorHandling.pro
+++ b/3rdparty/ErrorHandling/ErrorHandling.pro
@@ -1,0 +1,8 @@
+TEMPLATE = lib
+
+DESTDIR=$$top_builddir/libs/
+
+CONFIG += staticlib
+
+SOURCES += MavenException.cpp
+HEADERS += MavenException.h

--- a/3rdparty/ErrorHandling/ErrorHandling.pro
+++ b/3rdparty/ErrorHandling/ErrorHandling.pro
@@ -1,6 +1,7 @@
 TEMPLATE = lib
 
 DESTDIR=$$top_builddir/libs/
+OBJECTS_DIR=$$top_buildir/tmp/error_handling
 
 CONFIG += staticlib
 

--- a/3rdparty/ErrorHandling/ErrorHandling.pro
+++ b/3rdparty/ErrorHandling/ErrorHandling.pro
@@ -4,6 +4,7 @@ DESTDIR=$$top_builddir/libs/
 OBJECTS_DIR=$$top_buildir/tmp/error_handling
 MOC_DIR=$$top_builddir/tmp/error_handling
 
+QMAKE_CXXFLAGS += -std=c++11
 CONFIG += staticlib
 
 INCLUDEPATH += $$top_srcdir/3rdparty/libplog

--- a/3rdparty/ErrorHandling/MavenException.cpp
+++ b/3rdparty/ErrorHandling/MavenException.cpp
@@ -1,0 +1,42 @@
+#include "MavenException.h"
+#include <Log.h>
+
+ErrorMsg* ErrorMsg::errMsg = nullptr;
+
+
+ErrorMsg::ErrorMsg()
+{
+    errMessages[ErrorCodes::FileNotFound] = "File not found";
+    errMessages[ErrorCodes::Blank] =  "Blank file";
+    errMessages[ErrorCodes::UnsupportedFormat] = "File format not supported";
+    errMessages[ErrorCodes::ParseCsv] = "Unable to parse Csv file";
+    errMessages[ErrorCodes::ParsemzData] = "Unable to parse mzData file";
+    errMessages[ErrorCodes::ParsemzMl] = "Unable to parse mzMl file";
+    errMessages[ErrorCodes::ParsemzXml]= "Unable to parse mzXml file";
+}
+
+ErrorMsg* ErrorMsg::getInstance() {
+
+    if(errMsg == nullptr) {
+        errMsg = new ErrorMsg;
+    }
+    return errMsg;
+}
+
+std::map<ErrorCodes::Errors, std::string> ErrorMsg::getErrmessages()
+{
+    return errMessages;
+}
+
+
+MavenException::MavenException(ErrorCodes::Errors errCd, const std::string& details)
+{
+    message = ErrorMsg::getInstance()->getErrmessages().at(errCd);
+    message += " : ";
+    message += details;
+    message += "\n";
+
+    LOGD << message;
+}
+
+

--- a/3rdparty/ErrorHandling/MavenException.h
+++ b/3rdparty/ErrorHandling/MavenException.h
@@ -1,0 +1,22 @@
+#include <exception>
+
+using namespace std;
+
+class MavenException: public exception
+{
+    public:
+        MavenException(const string& msg): message(msg)
+        {
+        }
+
+        virtual ~MavenException() throw()
+        {}
+
+        virtual const char* what() const  throw()
+        {
+                return message.c_str();
+        }
+
+    private:
+        string message;
+};

--- a/3rdparty/ErrorHandling/MavenException.h
+++ b/3rdparty/ErrorHandling/MavenException.h
@@ -6,19 +6,20 @@ class MavenException: public exception
 {
     public:
         enum Error {
-            FileNotFound,
-            UnsupportedFileFormat,
+            FileError,
+            FormatError,
             ParseError,
         };
+
         MavenException(const Error& err)
         {
             switch (err) {
 
-                case FileNotFound:  {
-                    message = "File not found";
+                case FileError:  {
+                    message = "File Error";
                     break;
                 }
-                case UnsupportedFileFormat: {
+                case FormatError: {
                     message = "File format not supported";
                     break;
                 }
@@ -40,4 +41,91 @@ class MavenException: public exception
 
     private:
         string message;
+};
+
+class FileException: public MavenException
+{
+public:
+    enum FileError {
+        notFound,
+        blank
+    };
+    FileException(const FileError& ferr):MavenException(Error::FileError)
+    {
+        switch(ferr) {
+            case notFound: {
+                message = "File not found";
+                break;
+            }
+            case blank: {
+                message = "uploaded blank file";
+                break;
+            }
+        }
+    }
+
+    virtual ~FileException() throw() {}
+
+    virtual const char* what() throw()
+    {
+        return message.c_str();
+    }
+
+private:
+    string  message;
+};
+
+class ParseException: public MavenException
+{
+public:
+    enum ParseError{
+        mzXml,
+        mzMl,
+        mzData,
+        csv,
+        mzroll,
+        peaksList,
+        spectralHits
+    };
+    ParseException(const ParseError& err):MavenException(Error::ParseError) {
+        switch(err) {
+            case mzXml: {
+                message = "Unable to parse mzXml file";
+                break;
+            }
+            case mzMl: {
+                message = "Unable to parse mzMl file";
+                break;
+            }
+            case csv: {
+                message = "Unable to parse csv file";
+                break;
+            }
+            case mzroll: {
+                message = "Unable to parse mzroll file";
+                break;
+            }
+            case peaksList: {
+                message = "Unable to parse peaksList file";
+                break;
+            }
+            case spectralHits: {
+                message = "Unable to parse spectralHits file";
+                break;
+            }
+            case mzData: {
+                message = "Unable to parse mzData ";
+                break;
+            }
+
+        }
+    }
+    virtual ~ParseException() throw() {}
+    virtual const char* what() throw()
+    {
+        return message.c_str();
+    }
+
+private:
+   string message;
 };

--- a/3rdparty/ErrorHandling/MavenException.h
+++ b/3rdparty/ErrorHandling/MavenException.h
@@ -1,35 +1,42 @@
 #include <exception>
+#include <map>
 
-using namespace std;
+struct ErrorCodes
+{
+    enum Errors {
+        UnsupportedFormat,
+        FileNotFound,
+        Blank,
+        ParsemzXml,
+        ParsemzMl,
+        ParsemzData,
+        ParseCsv
+    };
 
-class MavenException: public exception
+};
+
+//singleton
+class ErrorMsg
 {
     public:
-        enum Error {
-            FileError,
-            FormatError,
-            ParseError,
-        };
+        ErrorMsg();
 
-        MavenException(const Error& err)
-        {
-            switch (err) {
+        static ErrorMsg* getInstance();
 
-                case FileError:  {
-                    message = "File Error";
-                    break;
-                }
-                case FormatError: {
-                    message = "File format not supported";
-                    break;
-                }
+        std::map<ErrorCodes::Errors, std::string> getErrmessages();
 
-                case ParseError: {
-                    message = "Parisng the file failed";
-                    break;
-                }
-            }
-        }
+    private:
+        static ErrorMsg* errMsg;
+        std::map<ErrorCodes::Errors, std::string> errMessages;
+};
+
+
+
+class MavenException: public std::exception
+{
+    public:
+
+        MavenException(ErrorCodes::Errors, const std::string& details = "");
 
         virtual ~MavenException() throw()
         {}
@@ -40,92 +47,5 @@ class MavenException: public exception
         }
 
     private:
-        string message;
-};
-
-class FileException: public MavenException
-{
-public:
-    enum FileError {
-        notFound,
-        blank
-    };
-    FileException(const FileError& ferr):MavenException(Error::FileError)
-    {
-        switch(ferr) {
-            case notFound: {
-                message = "File not found";
-                break;
-            }
-            case blank: {
-                message = "uploaded blank file";
-                break;
-            }
-        }
-    }
-
-    virtual ~FileException() throw() {}
-
-    virtual const char* what() throw()
-    {
-        return message.c_str();
-    }
-
-private:
-    string  message;
-};
-
-class ParseException: public MavenException
-{
-public:
-    enum ParseError{
-        mzXml,
-        mzMl,
-        mzData,
-        csv,
-        mzroll,
-        peaksList,
-        spectralHits
-    };
-    ParseException(const ParseError& err):MavenException(Error::ParseError) {
-        switch(err) {
-            case mzXml: {
-                message = "Unable to parse mzXml file";
-                break;
-            }
-            case mzMl: {
-                message = "Unable to parse mzMl file";
-                break;
-            }
-            case csv: {
-                message = "Unable to parse csv file";
-                break;
-            }
-            case mzroll: {
-                message = "Unable to parse mzroll file";
-                break;
-            }
-            case peaksList: {
-                message = "Unable to parse peaksList file";
-                break;
-            }
-            case spectralHits: {
-                message = "Unable to parse spectralHits file";
-                break;
-            }
-            case mzData: {
-                message = "Unable to parse mzData ";
-                break;
-            }
-
-        }
-    }
-    virtual ~ParseException() throw() {}
-    virtual const char* what() throw()
-    {
-        return message.c_str();
-    }
-
-private:
-   string message;
+        std::string message;
 };

--- a/3rdparty/ErrorHandling/MavenException.h
+++ b/3rdparty/ErrorHandling/MavenException.h
@@ -5,8 +5,29 @@ using namespace std;
 class MavenException: public exception
 {
     public:
-        MavenException(const string& msg): message(msg)
+        enum Error {
+            FileNotFound,
+            UnsupportedFileFormat,
+            ParseError,
+        };
+        MavenException(const Error& err)
         {
+            switch (err) {
+
+                case FileNotFound:  {
+                    message = "File not found";
+                    break;
+                }
+                case UnsupportedFileFormat: {
+                    message = "File format not supported";
+                    break;
+                }
+
+                case ParseError: {
+                    message = "Parisng the file failed";
+                    break;
+                }
+            }
         }
 
         virtual ~MavenException() throw()

--- a/3rdparty/ErrorHandling/MavenException.h
+++ b/3rdparty/ErrorHandling/MavenException.h
@@ -1,5 +1,6 @@
 #include <exception>
 #include <map>
+#include <string>
 
 struct ErrorCodes
 {

--- a/mzroll.pri
+++ b/mzroll.pri
@@ -23,7 +23,7 @@ win32 {
 unix: {
     INCLUDEPATH += /usr/local/include/
     QMAKE_LFLAGS += -L/usr/local/lib/
-    LIBS +=  -lboost_signals
+    LIBS +=  -lboost_signals -lErrorHandling
 }
 
 #INSTALL_LIBDIR = $$(INSTALL_LIBDIR)

--- a/src/cli/peakdetector/peakdetector.pro
+++ b/src/cli/peakdetector/peakdetector.pro
@@ -17,7 +17,7 @@ INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  $$top_srcdir/3rdparty/pugixml/sr
 
 QMAKE_LFLAGS  +=  -L$$top_builddir/libs/
 
-LIBS +=  -lmaven -lpugixml -lneural -lcsvparser -lpls
+LIBS +=  -lmaven -lpugixml -lneural -lcsvparser -lpls -lErrorHandling
 
 SOURCES	= 	PeakDetectorCLI.cpp  \
 		 	options.cpp \

--- a/src/core/libmaven/libmaven.pro
+++ b/src/core/libmaven/libmaven.pro
@@ -20,7 +20,8 @@ TARGET = maven
 LIBS += -L. -lcsvparser -ldate
 
 INCLUDEPATH +=  $$top_srcdir/3rdparty/pugixml/src/ $$top_srcdir/3rdparty/libcdfread/  $$top_srcdir/src/gui/mzroll/ $$top_srcdir/3rdparty/libneural/ \
-                $$top_srcdir/3rdparty/libcsvparser $$top_srcdir/3rdparty/libdate/ $$top_srcdir/3rdparty/ErrorHandling
+                $$top_srcdir/3rdparty/libcsvparser $$top_srcdir/3rdparty/libdate/ $$top_srcdir/3rdparty/ErrorHandling \
+                $$top_srcdir/3rdparty/libplog
 
 
 macx{

--- a/src/core/libmaven/libmaven.pro
+++ b/src/core/libmaven/libmaven.pro
@@ -17,7 +17,7 @@ QMAKE_CXXFLAGS += -DOMP_PARALLEL
 
 TARGET = maven
 
-LIBS += -L. -lcsvparser -ldate
+LIBS += -L. -lcsvparser -ldate -lErrorHandling
 
 INCLUDEPATH +=  $$top_srcdir/3rdparty/pugixml/src/ $$top_srcdir/3rdparty/libcdfread/  $$top_srcdir/src/gui/mzroll/ $$top_srcdir/3rdparty/libneural/ \
                 $$top_srcdir/3rdparty/libcsvparser $$top_srcdir/3rdparty/libdate/ $$top_srcdir/3rdparty/ErrorHandling \

--- a/src/core/libmaven/libmaven.pro
+++ b/src/core/libmaven/libmaven.pro
@@ -20,7 +20,7 @@ TARGET = maven
 LIBS += -L. -lcsvparser -ldate
 
 INCLUDEPATH +=  $$top_srcdir/3rdparty/pugixml/src/ $$top_srcdir/3rdparty/libcdfread/  $$top_srcdir/src/gui/mzroll/ $$top_srcdir/3rdparty/libneural/ \
-                $$top_srcdir/3rdparty/libcsvparser $$top_srcdir/3rdparty/libdate/
+                $$top_srcdir/3rdparty/libcsvparser $$top_srcdir/3rdparty/libdate/ $$top_srcdir/3rdparty/ErrorHandling
 
 
 macx{

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1,5 +1,6 @@
 #include "mzSample.h"
 #include "Compound.h"
+#include <MavenException.h>
 
 //global options
 int mzSample::filter_minIntensity = -1;
@@ -101,6 +102,7 @@ string mzSample::getFileName(const string &filename)
 
 void mzSample::loadAnySample(const char *filename)
 {
+    LOGD << " loading sample " << filename;
 
 	if (mystrcasestr(filename, "mzCSV") != NULL)
 	{
@@ -116,7 +118,7 @@ void mzSample::loadAnySample(const char *filename)
 	}
 	else if (mystrcasestr(filename, "mzml") != NULL)
 	{
-		parseMzML(filename);
+        parseMzML(filename);
 	}
 	else if (mystrcasestr(filename, "cdf") != NULL)
 	{
@@ -155,7 +157,15 @@ void mzSample::loadSample(const char *filename)
 {
 
 	//Loading and Decoding the file
-	loadAnySample(filename);
+    //catch any error while parsing
+    try {
+
+        loadAnySample(filename);
+    }
+    catch(MavenException& excp) {
+        LOGD << excp.what();
+    }
+
 
 	//getting the SRM scan type
 	enumerateSRMScans();
@@ -172,15 +182,14 @@ void mzSample::loadSample(const char *filename)
 
 void mzSample::parseMzCSV(const char *filename)
 {
+    LOGD << "parsing mzCSV: " << filename;
 	// file structure: scannum,rt,mz,intensity,mslevel,precursorMz,polarity,srmid
 	int lineNum = 0;
-	cerr << "Loading " << filename << endl;
+
 	ifstream myfile(filename);
 	if (!myfile.is_open())
-	{
-		cerr << "Can't open file " << filename;
-		return;
-	}
+        throw (MavenException::FileNotFound);
+
 
 	std::stringstream ss;
 	std::string line;
@@ -284,15 +293,16 @@ int mzSample::getPolarity()
 }
 void mzSample::parseMzML(const char *filename)
 {
+    LOGD << "parsing mzMl file: " << filename;
 	xml_document doc;
 
 	const unsigned int parse_options = parse_minimal;
 
-	bool loadok = doc.load_file(filename, parse_options);
-	if (!loadok)
+    pugi::xml_parse_result parseResult = doc.load_file(filename, parse_options);
+    if (parseResult.status != pugi::xml_parse_status::status_ok)
 	{
-		cerr << "Failed to load " << filename << endl;
-		return;
+        throw MavenException(MavenException::ParseError);
+//		return;
 	}
 
 	//Get injection time stamp
@@ -534,15 +544,17 @@ map<string, string> mzSample::mzML_cvParams(xml_node node)
 
 void mzSample::parseMzData(const char *filename)
 {
+    LOGD << "parsing mzData: " << filename;
 	xml_document doc;
 
 	const unsigned int parse_options = parse_minimal;
 
-	bool loadok = doc.load_file(filename, parse_options);
-	if (!loadok)
+    pugi::xml_parse_result parseResult = doc.load_file(filename, parse_options);
+    if (parseResult.status != pugi::xml_parse_status::status_ok)
 	{
-		cerr << "Failed to load " << filename << endl;
-		return;
+        throw (MavenException(MavenException::ParseError));
+//		cerr << "Failed to load " << filename << endl;
+//		return;
 	}
 
 	//Get a spectrumstore node
@@ -684,7 +696,7 @@ void mzSample::setInstrumentSettigs(xml_document &doc, xml_node spectrumstore)
 
 void mzSample::parseMzXMLData(xml_document &doc, xml_node spectrumstore)
 {
-
+    LOGD << "parsing mzXML data" ;
 	//Iterate through spectrums
 	int scannum = 0;
 
@@ -709,29 +721,20 @@ void mzSample::parseMzXMLData(xml_document &doc, xml_node spectrumstore)
 
 void mzSample::parseMzXML(const char *filename)
 {
+    LOGD << "parsing mzXML: " << filename;
 	xml_document doc;
-	try
-	{
 
-		xml_node spectrumstore = getmzXMLSpectrumData(doc, filename);
+    xml_node spectrumstore = getmzXMLSpectrumData(doc, filename);
 
-		if (!spectrumstore.empty())
-		{
-			//Setting the instrument related information
-			setInstrumentSettigs(doc, spectrumstore);
-			//parse mzXML information from the scan
-			parseMzXMLData(doc, spectrumstore);
-		}
-		else
-		{
-			return;
-		}
-	}
-	catch (char *err)
-	{
-
-		cerr << "Failed to load file: " << filename << " " << err << endl;
-	}
+    if (!spectrumstore.empty())
+    {
+        //Setting the instrument related information
+        setInstrumentSettigs(doc, spectrumstore);
+        //parse mzXML information from the scan
+        parseMzXMLData(doc, spectrumstore);
+    }
+    else
+        throw (MavenException::ParseError);
 }
 
 /**
@@ -890,7 +893,7 @@ void mzSample::populateFilterline(string filterLine, Scan *_scan)
 void mzSample::parseMzXMLScan(const xml_node &scan, int scannum)
 {
 
-	float rt = 0.0, precursorMz = 0.0, productMz = 0, collisionEnergy = 0;
+    float rt = 0.0, precursorMz = 0.0, productMz = 0, collisionEnergy = 0;
 	int scanpolarity = 0, msLevel = 1;
 	string filterLine, scanType;
 	vector<float> mzint;
@@ -950,8 +953,12 @@ void mzSample::parseMzXMLScan(const xml_node &scan, int scannum)
 
 	//no m/z intensity values
 	mzint = parsePeaksFromMzXML(scan);
-	if (mzint.empty())
-		return;
+    if (mzint.empty()) {
+        LOGD << " parsing scan number: " << scannum << "failed ";
+        LOGD << " failed to get m/z intensity values";
+
+        return;
+    }
 
 	Scan *_scan = new Scan(this, scannum, msLevel, rt, precursorMz, scanpolarity);
 

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -165,18 +165,9 @@ void mzSample::loadSample(const char *filename)
 
         loadAnySample(filename);
     }
-    catch (FileException& fexcp) {
-
-        LOGD << static_cast<MavenException*>(&fexcp)->what() << " : " <<  fexcp.what();
-    }
-
-    catch (ParseException& pexcp) {
-
-        LOGD << static_cast<MavenException*>(&pexcp)->what() << " : " << pexcp.what();
-    }
 
     catch(MavenException& excp) {
-        LOGD << excp.what();
+        cerr << endl << "Error: " << excp.what() << endl;
     }
 
 
@@ -201,7 +192,7 @@ void mzSample::parseMzCSV(const char *filename)
 
 	ifstream myfile(filename);
 	if (!myfile.is_open())
-        throw (FileException(FileException::notFound));
+        throw (MavenException(ErrorCodes::FileNotFound, filename));
 
 
 	std::stringstream ss;
@@ -314,8 +305,7 @@ void mzSample::parseMzML(const char *filename)
     pugi::xml_parse_result parseResult = doc.load_file(filename, parse_options);
     if (parseResult.status != pugi::xml_parse_status::status_ok)
 	{
-        throw ParseException(ParseException::mzMl);
-//		return;
+        throw MavenException(ErrorCodes::ParsemzMl, filename);
 	}
 
 	//Get injection time stamp
@@ -568,9 +558,7 @@ void mzSample::parseMzData(const char *filename)
     pugi::xml_parse_result parseResult = doc.load_file(filename, parse_options);
     if (parseResult.status != pugi::xml_parse_status::status_ok)
 	{
-        throw (ParseException(ParseException::mzData));
-//		cerr << "Failed to load " << filename << endl;
-//		return;
+        throw (MavenException(ErrorCodes::ParsemzData, filename));
 	}
 
 	//Get a spectrumstore node
@@ -750,7 +738,7 @@ void mzSample::parseMzXML(const char *filename)
         parseMzXMLData(doc, spectrumstore);
     }
     else
-        throw (ParseException(ParseException::mzXml));
+        throw MavenException(ErrorCodes::ParsemzXml, filename);
 }
 
 /**

--- a/src/gui/mzroll/main.cpp
+++ b/src/gui/mzroll/main.cpp
@@ -37,7 +37,7 @@ plog::MyAppender<plog::TxtFormatter> myAppender; // Create our custom appender.
 
 int main(int argc, char *argv[])
 {
-    plog::init(plog::debug, &myAppender); // Initialize the logger with our appender.
+    plog::init(plog::verbose, "/home/rishabh/logging.txt"); // Initialize the logger with our appender.
 
     QApplication app(argc, argv);
     QPixmap pixmap(":/images/splash.png","PNG",Qt::ColorOnly);

--- a/src/gui/mzroll/main.cpp
+++ b/src/gui/mzroll/main.cpp
@@ -37,7 +37,7 @@ plog::MyAppender<plog::TxtFormatter> myAppender; // Create our custom appender.
 
 int main(int argc, char *argv[])
 {
-    plog::init(plog::verbose, "/home/rishabh/logging.txt"); // Initialize the logger with our appender.
+    plog::init(plog::verbose, &myAppender); // Initialize the logger with our appender.
 
     QApplication app(argc, argv);
     QPixmap pixmap(":/images/splash.png","PNG",Qt::ColorOnly);

--- a/src/gui/mzroll/main.cpp
+++ b/src/gui/mzroll/main.cpp
@@ -37,9 +37,12 @@ plog::MyAppender<plog::TxtFormatter> myAppender; // Create our custom appender.
 
 int main(int argc, char *argv[])
 {
-    plog::init(plog::verbose, &myAppender); // Initialize the logger with our appender.
 
     QApplication app(argc, argv);
+
+    std::string loggerFile = QString(QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + QDir::separator() + "ElMavenLogger.txt").toStdString();
+    plog::init(plog::verbose, loggerFile.c_str()); // Initialize the logger with our appender.
+
     QPixmap pixmap(":/images/splash.png","PNG",Qt::ColorOnly);
     QSplashScreen splash(pixmap);
     splash.setMask(pixmap.mask());

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -6,6 +6,8 @@
 #include <omp.h>
 #endif
 
+#include <MavenException.h>
+
 mzFileIO::mzFileIO(QWidget*) {
     _mainwindow = NULL;
     _stopped = true;
@@ -68,7 +70,7 @@ mzSample* mzFileIO::loadSample(QString filename){
             sample->loadSample( filename.toLatin1().data() );
             if ( sample->scans.size() == 0 ) { delete(sample); sample=NULL; }
         }
-    } catch(...) {
+    } catch(MavenException& excp) {
         qDebug() << "mzFileIO::loadSample() " << filename << " failed..";
     }
 
@@ -478,7 +480,13 @@ mzSample* mzFileIO::parseMzData(QString fileName) {
 }
 
 void mzFileIO::run(void) {
-    fileImport();
+    try {
+        fileImport();
+    }
+    catch (MavenException& excp) {
+        qDebug () << excp.what() ;
+    }
+
     quit();
 }
 
@@ -505,6 +513,8 @@ void mzFileIO::fileImport(void) {
         } else if (isSpectralHitType(filename)) {
             spectralhits << filename;
         }
+        else
+            throw MavenException("Incorrect file format");
     }
 
     Q_FOREACH(QString filename, projects ) {

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -510,7 +510,7 @@ void mzFileIO::fileImport(void) {
         try {
             QFileInfo fileInfo(filename);
             if (!fileInfo.exists())
-                throw (FileException(FileException::notFound));
+                throw MavenException(ErrorCodes::FileNotFound, filename.toStdString());
 
             if (isSampleFileType(filename)) {
                 samples << filename;
@@ -522,15 +522,11 @@ void mzFileIO::fileImport(void) {
                 spectralhits << filename;
             }
             else
-                throw (MavenException(MavenException::FormatError));
-        }
-
-        catch (FileException& fexcp) {
-            LOGD << filename << " : " << fexcp.what();
+                throw (MavenException(ErrorCodes::UnsupportedFormat, filename.toStdString()));
         }
 
         catch (MavenException& excp) {
-            LOGD << filename << " : " << excp.what();
+            qDebug() << "Error: " << excp.what();
         }
     }
 

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -48,7 +48,7 @@ win32 {
 }
 
 
-LIBS +=  -lmaven -lpugixml -lneural -lcsvparser -lpls -lplog                  #64bit
+LIBS +=  -lmaven -lpugixml -lneural -lcsvparser -lpls -lplog -lErrorHandling                 #64bit
 macx {
     LIBS -= -lplog
 }

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -37,7 +37,7 @@ INCLUDEPATH +=  /usr/include/x86_64-linux-gnu/qt5/QtXml/ /usr/include/x86_64-lin
 
 INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  $$top_srcdir/3rdparty/pugixml/src $$top_srcdir/3rdparty/libneural  $$top_srcdir/3rdparty/Eigen/ \
                 $$top_srcdir/3rdparty/libpls $$top_srcdir/3rdparty/libcsvparser $$top_srcdir/3rdparty/ $$top_srcdir/3rdparty/libplog/ $$top_srcdir/3rdparty/libpillow \
-                $$top_srcdir/3rdparty/libdate/
+                $$top_srcdir/3rdparty/libdate/ $$top_srcdir/3rdparty/ErrorHandling
 
 QMAKE_LFLAGS += -L$$top_builddir/libs/
 

--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -23,7 +23,7 @@ INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  $$top_srcdir/3rdparty/pugixml/sr
 
 QMAKE_LFLAGS += -L$$top_builddir/libs/
 
-LIBS += -lmaven -lpugixml -lneural -lcsvparser -lpls
+LIBS += -lmaven -lpugixml -lneural -lcsvparser -lpls -lErrorHandling
 !macx: LIBS += -fopenmp
 
 


### PR DESCRIPTION
The change introduced in the four commits  are the following:

commit 42157ef (first commit)
- new Error handling library 
- new exception class
- introduce exception while importing files


commit 5e147d4
- introduce exceptions in mzSample class
- handle error while parsing different sample formats

commit 48a9f9d
- introduce two new exception classes.
- Don't bother about this commit. We decided to have only one exception class and hence
  these classes were removed 

commit c2d351b
- use a single exception class
- do all the logging in exception class
- store logs in generic config location

commit ce8762d
- link Error handling library with Cli and Tests