### PR TITLE
[Fix] Use eic mz tolerance for EIC title #596

### DIFF
--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1188,8 +1188,8 @@ EIC *mzSample::getEIC(float precursorMz, float collisionEnergy, float productMz,
 	e->sample = this;
 	e->totalIntensity = 0;
 	e->maxIntensity = 0;
-	e->mzmin = 0;
-	e->mzmax = 0;
+	e->mzmin = productMz - amuQ3;
+	e->mzmax = productMz + amuQ3;
 
 	for (unsigned int i = 0; i < scans.size(); i++)
 	{

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -944,6 +944,10 @@ void EicWidget::setTitle() {
 	font.setPixelSize(pxSize);
 
 	QString tagString;
+	double mzmin;
+	double mzmax;
+	Compound* compound;
+	compound = eicParameters->_slice.compound;
 
 	if (eicParameters->selectedGroup != NULL) {
 		tagString = QString(eicParameters->selectedGroup->getName().c_str());
@@ -953,9 +957,20 @@ void EicWidget::setTitle() {
 		tagString = QString(eicParameters->_slice.srmId.c_str());
 	}
 
+	if (compound && compound->productMz)
+	{
+		//TODO: use slices for MS2 eics
+		mzmin = eicParameters->eics[0]->mzmin;
+		mzmax = eicParameters->eics[0]->mzmax;
+	}
+	else
+	{
+		mzmin = eicParameters->_slice.mzmin;
+		mzmax = eicParameters->_slice.mzmax;
+	}
 	QString titleText = tr("<b>%1</b> m/z: %2-%3").arg(tagString,
-			QString::number(eicParameters->_slice.mzmin, 'f', 4),
-			QString::number(eicParameters->_slice.mzmax, 'f', 4));
+			QString::number(mzmin, 'f', 4),
+			QString::number(mzmax, 'f', 4));
 
 	QGraphicsTextItem* title = scene()->addText(titleText, font);
 	title->setHtml(titleText);
@@ -963,7 +978,6 @@ void EicWidget::setTitle() {
 	title->setPos(scene()->width() / 2 - titleWith / 2, 5);
 	title->update();
 
-	//TODO: Sahil, added this whole thing while merging eicwidget
     bool hasData=false;
     for(int i=0;  i < eicParameters->eics.size(); i++ ) { if(eicParameters->eics[i]->size() > 0) { hasData=true; break; } }
     if (hasData == false ) {


### PR DESCRIPTION
EIC title for MS/MS data was displaying m/z range according to ppm value.
This has been changed to display product m/z range according to Q3 tolerance.

Issue: #596