### PR TITLE
[Fix] Stop mass adjustment if mass is zero #493

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -414,11 +414,12 @@ void PeakGroup::updateQuality() {
 // TODO: Remove this function as expected mz should be calculated while creating the group - Sahil
 double PeakGroup::getExpectedMz(int charge) {
 
+    float mz = 0;
+
     if (isIsotope() && childCount() == 0 && compound && !compound->formula.empty() && compound->mass > 0) { 
         return expectedMz;
     }
     else if (!isIsotope() && compound && compound->mass > 0) {
-        float mz = 0;
         if (!compound->formula.empty()) {
             mz = compound->adjustedMass(charge);
         } else {
@@ -428,8 +429,6 @@ double PeakGroup::getExpectedMz(int charge) {
         return mz;
     }
     else if (compound && compound->mass == 0 && compound->productMz > 0) {
-
-        float mz = 0;
         mz = compound->productMz;
         return mz;
     }

--- a/src/core/libmaven/mzMassCalculator.cpp
+++ b/src/core/libmaven/mzMassCalculator.cpp
@@ -70,6 +70,7 @@ double MassCalculator::computeNeutralMass(string formula) {
 }
 
 double MassCalculator::adjustMass(double mass, int charge) {
+    if (mass == 0) return 0;
     if (MassCalculator::ionizationType == EI and charge != 0) {
         return ((mass - charge * ELECTRON_MASS) /
                 charge);  // lost of electrons


### PR DESCRIPTION
Compound mass is set to zero for MS/MS fragments. It is used as a check for MS2 in multiple places.
AdjustMass was adding or removing proton mass even when mass is zero. This caused some of these checks to fail.
One prominent result: expectedMz showing "NA" in Peaks Table

Issues: #493