### PR TITLE
Fix: Remove delimiter #640

### DIFF
--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -402,8 +402,7 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
                 << peak.peakAreaTopCorrected << SEP
                 << peak.noNoiseObs <<  SEP
                 << peak.signalBaselineRatio <<  SEP
-                << peak.fromBlankSample << SEP
-                << endl;
+                << peak.fromBlankSample << endl;
     }
 }
 


### PR DESCRIPTION
	Delimiter is removed from last of the line in peak export
.csv format
Issue: #640