### PR TITLE
Move isotope Plot functions out of eicwidget

### DIFF
--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -455,6 +455,14 @@ class PeakGroup{
         static bool compMz(const PeakGroup& a, const PeakGroup& b ) { return(a.meanMz > b.meanMz); }
 
         /**
+         * @brief sort isotopes in natural order
+         * @param a reference to PeakGroup object
+         * @param b reference to PeakGroup object
+         * @return True if tagString of a is lesser than b
+         **/
+        static bool compTagString(const PeakGroup& a, const PeakGroup& b ) { return mzUtils::strcasecmp_withNumbers(a.tagString, b.tagString); }
+        
+        /**
          * [compIntensity ]
          * @method compIntensity
          * @param  a             []

--- a/src/core/libmaven/default_settings.xml
+++ b/src/core/libmaven/default_settings.xml
@@ -48,10 +48,6 @@
         <C13Labeled_BPE>1</C13Labeled_BPE>
         <N15Labeled_BPE>1</N15Labeled_BPE>
         <S34Labeled_BPE>1</S34Labeled_BPE>
-        <D2Labeled_Barplot>1</D2Labeled_Barplot>
-        <C13Labeled_Barplot>1</C13Labeled_Barplot>
-        <N15Labeled_Barplot>1</N15Labeled_Barplot>
-        <S34Labeled_Barplot>1</S34Labeled_Barplot>
         <D2Labeled_IsoWidget>1</D2Labeled_IsoWidget>
         <C13Labeled_IsoWidget>1</C13Labeled_IsoWidget>
         <N15Labeled_IsoWidget>1</N15Labeled_IsoWidget>

--- a/src/core/libmaven/isotopeDetection.cpp
+++ b/src/core/libmaven/isotopeDetection.cpp
@@ -45,6 +45,8 @@ void IsotopeDetection::pullIsotopes(PeakGroup* parentgroup)
 
     addIsotopes(parentgroup, isotopes);
 
+    sortIsotopes(parentgroup);
+
 }
 
 map<string, PeakGroup> IsotopeDetection::getIsotopes(PeakGroup* parentgroup, vector<Isotope> masslist)
@@ -344,4 +346,17 @@ bool IsotopeDetection::filterLabel(string isotopeName)
 
     return true;
 
+}
+
+void IsotopeDetection::sortIsotopes(PeakGroup *group)
+{
+    if (group->children.size())
+        sort(group->children.begin(), group->children.end(), PeakGroup::compTagString);
+    
+    if (group->childrenBarPlot.size())
+        sort(group->childrenBarPlot.begin(), group->childrenBarPlot.end(), PeakGroup::compTagString);
+    
+    if (group->childrenIsoWidget.size())
+        sort(group->childrenIsoWidget.begin(), group->childrenIsoWidget.end(), PeakGroup::compTagString);
+    
 }

--- a/src/core/libmaven/isotopeDetection.h
+++ b/src/core/libmaven/isotopeDetection.h
@@ -55,6 +55,7 @@ class IsotopeDetection
 	bool filterLabel(string isotopeName);
 	void addChild(PeakGroup *parentgroup, PeakGroup &child, string isotopeName);
 	bool checkChildExist(vector<PeakGroup> &children, string isotopeName);
+	void sortIsotopes(PeakGroup *group);
 
 };
 

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -98,7 +98,7 @@ MavenParameters::MavenParameters(string settingsPath):lastUsedSettingsPath(setti
 	S34Labeled_BPE = false;
 	D2Labeled_BPE = false;
 	
-	C13Labeled_Barplot = false;
+	C13Labeled_Barplot = true;
 	N15Labeled_Barplot = false;
 	S34Labeled_Barplot = false;
 	D2Labeled_Barplot = false;

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -355,18 +355,6 @@ void MavenParameters::setOptionsDialogSettings(const char* key, const char* valu
     if(strcmp(key, "S34Labeled_BPE") == 0)
         S34Labeled_BPE = atof(value);
 
-    if(strcmp(key, "D2Labeled_Barplot") == 0)
-        D2Labeled_Barplot = atof(value);
-
-    if(strcmp(key, "C13Labeled_Barplot") == 0)
-        C13Labeled_Barplot = atof(value);
-
-    if(strcmp(key, "N15Labeled_Barplot") == 0)
-        N15Labeled_Barplot = atof(value);
-
-    if(strcmp(key, "S34Labeled_Barplot") == 0)
-        S34Labeled_Barplot = atof(value);
-
     if(strcmp(key, "D2Labeled_IsoWidget") == 0)
         D2Labeled_IsoWidget = atof(value);
 

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -557,6 +557,14 @@ class mzSample
                           */
     static bool compSampleOrder(const mzSample *a, const mzSample *b) { return a->_sampleOrder < b->_sampleOrder; }
 
+    /**
+     * @brief Compare sample order of two samples
+     * @param a object of class mzSample
+     * @param b object of class mzSample
+     * @return True if sample order of 'a' is higher than 'b' else false
+     **/
+    static bool compRevSampleOrder(const mzSample *a, const mzSample *b) { return a->_sampleOrder > b->_sampleOrder; }
+
     static bool compSampleSort(const mzSample *a, const mzSample *b) { return mzUtils::strcasecmp_withNumbers(a->sampleName, b->sampleName); }
 
     /**

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1142,7 +1142,7 @@ void EicWidget::addIsotopicPlot(PeakGroup* group) {
 	if (group == NULL)
 		return;
 	if (_isotopeplot == NULL)
-		_isotopeplot = new IsotopePlot(0, scene());
+		_isotopeplot = new IsotopePlot();
 	if (_isotopeplot->scene() != scene())
 		scene()->addItem(_isotopeplot);
 	_isotopeplot->hide();

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1137,31 +1137,6 @@ void EicWidget::addBarPlot(PeakGroup* group) {
 	return;
 }
 
-void EicWidget::addIsotopicPlot(PeakGroup* group) {
-	//qDebug <<" EicWidget::addIsotopicPlot(PeakGroup* group)";
-	if (group == NULL)
-		return;
-	if (_isotopeplot == NULL)
-		_isotopeplot = new IsotopePlot();
-	if (_isotopeplot->scene() != scene())
-		scene()->addItem(_isotopeplot);
-	_isotopeplot->hide();
-
-	if (group->childCountBarPlot() == 0)
-		return;
-
-	vector<mzSample*> samples = getMainWindow()->getVisibleSamples();
-	if (samples.size() == 0)
-		return;
-
-	_isotopeplot->setPos(scene()->width() * 0.10, scene()->height() * 0.10);
-	_isotopeplot->setZValue(1000);
-	_isotopeplot->setMainWindow(getMainWindow());
-	_isotopeplot->setPeakGroup(group);
-	_isotopeplot->show();
-	return;
-}
-
 void EicWidget::addBoxPlot(PeakGroup* group) {
 	//qDebug <<" EicWidget::addBoxPlot(PeakGroup* group)";
 	if (group == NULL)
@@ -1896,7 +1871,7 @@ void EicWidget::updateIsotopicBarplot(PeakGroup* group) {
 	if (_showIsotopePlot) {
 		getMainWindow()->isotopePlotDockWidget->show();
 		getMainWindow()->isotopePlotDockWidget->raise();
-		addIsotopicPlot(group);
+		getMainWindow()->addIsotopicPlot(group);
 	} else {
 		getMainWindow()->isotopePlotDockWidget->hide();
 	}

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1855,19 +1855,6 @@ void EicWidget::selectGroupNearRt(float rt) {
 	getMainWindow()->mavenParameters->setPeakGroup(selGroup);
 }
 
-void EicWidget::updateIsotopicBarplot(PeakGroup* group) {
-	if (_frozen || group == NULL)
-		return;
-
-	if (_showIsotopePlot) {
-		getMainWindow()->isotopePlotDockWidget->show();
-		getMainWindow()->isotopePlotDockWidget->raise();
-		getMainWindow()->isotopePlot->setPeakGroup(group);
-	} else {
-		getMainWindow()->isotopePlotDockWidget->hide();
-	}
-}
-
 void EicWidget::setSelectedGroup(PeakGroup* group) {
 	//qDebug <<"EicWidget::setSelectedGroup(PeakGroup* group ) ";
 	if (_frozen || group == NULL)

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1871,7 +1871,7 @@ void EicWidget::updateIsotopicBarplot(PeakGroup* group) {
 	if (_showIsotopePlot) {
 		getMainWindow()->isotopePlotDockWidget->show();
 		getMainWindow()->isotopePlotDockWidget->raise();
-		getMainWindow()->addIsotopicPlot(group);
+		getMainWindow()->isotopePlot->setPeakGroup(group);
 	} else {
 		getMainWindow()->isotopePlotDockWidget->hide();
 	}

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1855,15 +1855,6 @@ void EicWidget::selectGroupNearRt(float rt) {
 	getMainWindow()->mavenParameters->setPeakGroup(selGroup);
 }
 
-void EicWidget::showIsotopicBarPlot(bool _showIsotopicBarPlot) {
-	if (_showIsotopicBarPlot) {
-		getMainWindow()->isotopePlotDockWidget->show();
-		//addIsotopicPlot(group);
-	} else {
-		getMainWindow()->isotopePlotDockWidget->hide();
-	}
-}
-
 void EicWidget::updateIsotopicBarplot(PeakGroup* group) {
 	if (_frozen || group == NULL)
 		return;

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -18,7 +18,6 @@ EicWidget::EicWidget(QWidget *p) {
 
 	_barplot = NULL;
 	_boxplot = NULL;
-	_isotopeplot = NULL;
 	_focusLine = NULL;
 	_selectionLine = NULL;
 	_statusText = NULL;
@@ -32,7 +31,6 @@ EicWidget::EicWidget(QWidget *p) {
 	showTicLine(false);
 	showBicLine(false); //TODO: Sahil, added while merging eicwidget
     showNotes(false); //TODO: Sahil, added while merging eicwidget
-	showIsotopePlot(true);
 	showBarPlot(true);
 	showBoxPlot(false);
     automaticPeakGrouping(true); //TODO: Sahil, added while merging eicwidget
@@ -859,11 +857,7 @@ void EicWidget::setupColors() {
 }
 
 void EicWidget::clearPlot() {
-	//qDebug <<" EicWidget::clearPlot()";
-	if (_isotopeplot && _isotopeplot->scene()) {
-		_isotopeplot->clear();
-		scene()->removeItem(_isotopeplot);
-	}
+
 	if (_barplot && _barplot->scene()) {
 		_barplot->clear();
 		scene()->removeItem(_barplot);
@@ -1773,12 +1767,6 @@ void EicWidget::contextMenuEvent(QContextMenuEvent * event) {
     o34->setChecked(_showEICLines);
     connect(o34, SIGNAL(toggled(bool)), SLOT(showEICLines(bool)));
     connect(o34, SIGNAL(toggled(bool)), SLOT(replot()));
-
-	QAction* o6 = options.addAction("Show Isotope Plot");
-	o6->setCheckable(true);
-	o6->setChecked(_showIsotopePlot);
-	connect(o6, SIGNAL(toggled(bool)), SLOT(showIsotopePlot(bool)));
-	connect(o6, SIGNAL(toggled(bool)), SLOT(replot()));
 
 	QAction* o7 = options.addAction("Show Box Plot");
 	o7->setCheckable(true);

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1882,10 +1882,10 @@ void EicWidget::selectGroupNearRt(float rt) {
 
 void EicWidget::showIsotopicBarPlot(bool _showIsotopicBarPlot) {
 	if (_showIsotopicBarPlot) {
-		getMainWindow()->isotopePlotsDockWidget->show();
+		getMainWindow()->isotopePlotDockWidget->show();
 		//addIsotopicPlot(group);
 	} else {
-		getMainWindow()->isotopePlotsDockWidget->hide();
+		getMainWindow()->isotopePlotDockWidget->hide();
 	}
 }
 
@@ -1894,11 +1894,11 @@ void EicWidget::updateIsotopicBarplot(PeakGroup* group) {
 		return;
 
 	if (_showIsotopePlot) {
-		getMainWindow()->isotopePlotsDockWidget->show();
-		getMainWindow()->isotopePlotsDockWidget->raise();
+		getMainWindow()->isotopePlotDockWidget->show();
+		getMainWindow()->isotopePlotDockWidget->raise();
 		addIsotopicPlot(group);
 	} else {
-		getMainWindow()->isotopePlotsDockWidget->hide();
+		getMainWindow()->isotopePlotDockWidget->hide();
 	}
 }
 

--- a/src/gui/mzroll/eicwidget.h
+++ b/src/gui/mzroll/eicwidget.h
@@ -64,7 +64,6 @@ public Q_SLOTS:
 	void addFocusLine(PeakGroup*);
 	void addBarPlot(PeakGroup*);
 	void addBoxPlot(PeakGroup*);
-	void addIsotopicPlot(PeakGroup*);
 	void addFitLine(PeakGroup*);
     void addMS2Events(float mzmin, float mzmax); //TODO: Sahil Added while merging eicWidget
 	void integrateRegion(float rtmin, float rtmax);

--- a/src/gui/mzroll/eicwidget.h
+++ b/src/gui/mzroll/eicwidget.h
@@ -9,7 +9,6 @@
 #include "eiclogic.h"
 #include "plot_axes.h"
 #include "mainwindow.h"
-#include "isotopeplot.h"
 #include "peakFiltering.h"
 
 class EIC;
@@ -18,7 +17,6 @@ class BoxPlot;
 class BarPlot;
 class PeakGroup;
 class MainWindow;
-class IsotopePlot;
 
 class EicWidget: public QGraphicsView {
 Q_OBJECT
@@ -135,9 +133,6 @@ public Q_SLOTS:
 		f ? setCursor(Qt::SizeHorCursor) : setCursor(Qt::ArrowCursor);
 	}
 
-	void showIsotopePlot(bool f) {
-		_showIsotopePlot = f;
-	}
 	void showBarPlot(bool f) {
 		_showBarPlot = f;
 	}
@@ -203,7 +198,6 @@ private:
 
 	BarPlot* _barplot;
 	BoxPlot* _boxplot;
-	IsotopePlot* _isotopeplot;
 	Note* _statusText;
 
 	bool _showEIC;
@@ -223,7 +217,6 @@ private:
 	bool _areaIntegration;
 	bool _spectraAveraging;
 
-	bool _showIsotopePlot;
 	bool _showBarPlot;
 	bool _showBoxPlot;
 

--- a/src/gui/mzroll/eicwidget.h
+++ b/src/gui/mzroll/eicwidget.h
@@ -152,7 +152,6 @@ public Q_SLOTS:
 	}
 
 	void markGroupGood();
-	void showIsotopicBarPlot(bool);
 	void markGroupBad();
 	void copyToClipboard();
 	void selectionChangedAction();

--- a/src/gui/mzroll/eicwidget.h
+++ b/src/gui/mzroll/eicwidget.h
@@ -52,7 +52,6 @@ public Q_SLOTS:
 	 **/
 	PeakGroup* setCompound(Compound* c);
 	void setSelectedGroup(PeakGroup* group);
-	void updateIsotopicBarplot(PeakGroup* group);
 	void addEICLines(bool showSpline, bool showEIC);
     void addCubicSpline(); //TODO: Sahil Added while merging eicWidget
 	void addBaseLine();

--- a/src/gui/mzroll/forms/isotopeplotdockwidget.ui
+++ b/src/gui/mzroll/forms/isotopeplotdockwidget.ui
@@ -1,0 +1,16 @@
+<ui version="4.0">
+ <class>IsotopePlotDockWidget</class>
+ <widget class="QDockWidget" name="IsotopePlotDockWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>DockWidget</string>
+  </property>
+ </widget>
+</ui>

--- a/src/gui/mzroll/forms/isotopeplotdockwidget.ui
+++ b/src/gui/mzroll/forms/isotopeplotdockwidget.ui
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>IsotopePlotDockWidget</class>
  <widget class="QDockWidget" name="IsotopePlotDockWidget">
@@ -5,12 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>595</width>
     <height>300</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>DockWidget</string>
   </property>
+  <widget class="QWidget" name="isotopePlot"/>
  </widget>
+ <resources/>
+ <connections/>
 </ui>

--- a/src/gui/mzroll/forms/isotopeplotdockwidget.ui
+++ b/src/gui/mzroll/forms/isotopeplotdockwidget.ui
@@ -1,4 +1,7 @@
+<<<<<<< c9b211be62274ef911e081ba108599510c814283
 <?xml version="1.0" encoding="UTF-8"?>
+=======
+>>>>>>> [UI] Move isotope plot to a dockwidget
 <ui version="4.0">
  <class>IsotopePlotDockWidget</class>
  <widget class="QDockWidget" name="IsotopePlotDockWidget">

--- a/src/gui/mzroll/forms/isotopeplotdockwidget.ui
+++ b/src/gui/mzroll/forms/isotopeplotdockwidget.ui
@@ -1,7 +1,4 @@
-<<<<<<< c9b211be62274ef911e081ba108599510c814283
 <?xml version="1.0" encoding="UTF-8"?>
-=======
->>>>>>> [UI] Move isotope plot to a dockwidget
 <ui version="4.0">
  <class>IsotopePlotDockWidget</class>
  <widget class="QDockWidget" name="IsotopePlotDockWidget">

--- a/src/gui/mzroll/forms/settingsform.ui
+++ b/src/gui/mzroll/forms/settingsform.ui
@@ -608,24 +608,10 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="2" column="4">
-           <widget class="QCheckBox" name="S34Labeled_Barplot">
-            <property name="text">
-             <string>S34</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
+          <item row="2" column="1">
            <widget class="QCheckBox" name="D2Labeled_IsoWidget">
             <property name="text">
              <string>D2</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_Barplot">
-            <property name="text">
-             <string>Isotopic barplot </string>
             </property>
            </widget>
           </item>
@@ -636,35 +622,14 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="3">
-           <widget class="QCheckBox" name="N15Labeled_Barplot">
-            <property name="text">
-             <string>N15</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="D2Labeled_Barplot">
-            <property name="text">
-             <string>D2</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QCheckBox" name="C13Labeled_Barplot">
-            <property name="text">
-             <string>C13</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="label_IsoWidget">
             <property name="text">
              <string>Isotopic widget</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="4">
+          <item row="2" column="4">
            <widget class="QCheckBox" name="S34Labeled_IsoWidget">
             <property name="text">
              <string>S34</string>
@@ -678,7 +643,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="2">
+          <item row="2" column="2">
            <widget class="QCheckBox" name="C13Labeled_IsoWidget">
             <property name="text">
              <string>C13</string>
@@ -702,7 +667,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="3">
+          <item row="2" column="3">
            <widget class="QCheckBox" name="N15Labeled_IsoWidget">
             <property name="text">
              <string>N15</string>
@@ -1440,10 +1405,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>C13Labeled_BPE</tabstop>
   <tabstop>N15Labeled_BPE</tabstop>
   <tabstop>S34Labeled_BPE</tabstop>
-  <tabstop>D2Labeled_Barplot</tabstop>
-  <tabstop>C13Labeled_Barplot</tabstop>
-  <tabstop>N15Labeled_Barplot</tabstop>
-  <tabstop>S34Labeled_Barplot</tabstop>
   <tabstop>D2Labeled_IsoWidget</tabstop>
   <tabstop>C13Labeled_IsoWidget</tabstop>
   <tabstop>N15Labeled_IsoWidget</tabstop>
@@ -1481,7 +1442,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>formulaWithoutOverlap</tabstop>
  </tabstops>
  <resources>
-  <include location="../mzroll.qrc"/>
   <include location="../mzroll.qrc"/>
  </resources>
  <connections>

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -5,11 +5,11 @@
 using namespace Eigen;
 
 
-IsotopePlot::IsotopePlot()
+IsotopePlot::IsotopePlot(MainWindow *mw)
     :QGraphicsItem() {
 	// Initialised existing values - Kiran
 	_barwidth=10;
-	_mw=NULL;
+	_mw=mw;
 	_group=NULL;
     mpMouseText = NULL;
     title = NULL;
@@ -46,7 +46,9 @@ void IsotopePlot::clear() {
 void IsotopePlot::setPeakGroup(PeakGroup* group) {
     //cerr << "IsotopePlot::setPeakGroup()" << group << endl;
 
+    clear();
     if ( group == NULL ) return;
+    if (group->childCountBarPlot() == 0) return;
 
     if (group->isIsotope() && group->getParent() ) {
         setPeakGroup(group->getParent());
@@ -57,6 +59,7 @@ void IsotopePlot::setPeakGroup(PeakGroup* group) {
 
 	_samples.clear();
 	_samples = _mw->getVisibleSamples();
+    if (_samples.size() == 0) return;
 	 sort(_samples.begin(), _samples.end(), mzSample::compSampleOrder);
 
     _isotopes.clear();
@@ -66,12 +69,6 @@ void IsotopePlot::setPeakGroup(PeakGroup* group) {
             _isotopes.push_back(isotope);
         }
     }
-    //std::sort(_isotopes.begin(), _isotopes.end(), PeakGroup::compC13);
-	/*
-	for(int i=0; i < _isotopes.size(); i++ )  {
-		cerr << _isotopes[i]->tagString <<  " " << _isotopes[i]->isotopeC13count << endl; 
-	}
-	*/
 
     showBars();
 }

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -5,8 +5,8 @@
 using namespace Eigen;
 
 
-IsotopePlot::IsotopePlot(QGraphicsItem* parent, QGraphicsScene *scene)
-    :QGraphicsItem(parent) {
+IsotopePlot::IsotopePlot()
+    :QGraphicsItem() {
 	// Initialised existing values - Kiran
 	_barwidth=10;
 	_mw=NULL;
@@ -14,8 +14,8 @@ IsotopePlot::IsotopePlot(QGraphicsItem* parent, QGraphicsScene *scene)
     mpMouseText = NULL;
     title = NULL;
     bottomAxisRect = NULL;
-    if ( scene != NULL ) {
-        _width = scene->width()*0.25;
+    if (scene()) {
+        _width = scene()->width()*0.25;
         _height = 10;
     }
 }

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -45,8 +45,6 @@ void IsotopePlot::clear() {
 
 void IsotopePlot::setPeakGroup(PeakGroup* group) {
     //cerr << "IsotopePlot::setPeakGroup()" << group << endl;
-
-    clear();
     if ( group == NULL ) return;
     if (group->childCountBarPlot() == 0) return;
 
@@ -56,6 +54,8 @@ void IsotopePlot::setPeakGroup(PeakGroup* group) {
 
     if ( isVisible() == true && group == _group) return;
     _group = group;
+    //clear plot if new group is selected 
+    clear();
 
 	_samples.clear();
 	_samples = _mw->getVisibleSamples();

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -52,10 +52,9 @@ void IsotopePlot::setPeakGroup(PeakGroup* group) {
         setPeakGroup(group->getParent());
     }
 
-    if ( isVisible() == true && group == _group) return;
-    _group = group;
-    //clear plot if new group is selected 
     clear();
+
+    _group = group;
 
 	_samples.clear();
 	_samples = _mw->getVisibleSamples();

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -148,13 +148,15 @@ void IsotopePlot::showBars() {
 
     _mw->customPlot->plotLayout()->addElement(1, 0, bottomAxisRect);
     isotopesType.resize(MM.cols());
+    QPen barPen(Qt::black);
+    barPen.setWidthF(0.5);
 
     for(int j=0; j < MM.cols(); j++ ) {
         isotopesType[j] = new QCPBars(_mw->customPlot->yAxis, _mw->customPlot->xAxis);
         isotopesType[j]->setAntialiased(true); // gives more crisp, pixel aligned bar borders
         isotopesType[j]->setStackingGap(0);
         int h = j % 20;
-        isotopesType[j]->setPen(QPen(QColor::fromHsvF(h/20.0,1.0,1.0,1.0)));
+        isotopesType[j]->setPen(barPen);
 	    isotopesType[j]->setBrush(QColor::fromHsvF(h/20.0,1.0,1.0,1.0));
         if (j != 0 ){
             isotopesType[j]->moveAbove(isotopesType[j - 1]);
@@ -170,6 +172,7 @@ void IsotopePlot::showBars() {
         }
         isotopesType[j]->setData(sampleData, isotopeData);
         isotopesType[j]->rescaleKeyAxis(false);
+        isotopesType[j]->rescaleValueAxis(true);
     }
 
     if(mpMouseText) {

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -182,7 +182,7 @@ void IsotopePlot::showBars() {
     if(!mpMouseText) return;
 
     mpMouseText->setFont(QFont("Helvetica", 12)); // make font a bit larger
-    mpMouseText->position->setType(QCPItemPosition::ptAxisRectRatio);
+    mpMouseText->position->setType(QCPItemPosition::ptPlotCoords);
     mpMouseText->setPositionAlignment(Qt::AlignLeft);
     mpMouseText->position->setCoords(QPointF(0, 0));
     mpMouseText->setText("");
@@ -228,6 +228,9 @@ void IsotopePlot::showPointToolTip(QMouseEvent *event) {
             mpMouseText->setText(name);
         }
 
+        double xPos = _mw->customPlot->xAxis->pixelToCoord(event->pos().x());
+        double yPos = _mw->customPlot->yAxis->pixelToCoord(event->pos().y());
+        mpMouseText->position->setCoords(xPos, yPos);
         mpMouseText->setFont(QFont("Helvetica", 9, QFont::Bold));
     }
     _mw->customPlot->replot();

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -187,6 +187,7 @@ void IsotopePlot::showBars() {
     mpMouseText->position->setCoords(QPointF(0, 0));
     mpMouseText->setText("");
     mpMouseText->setPen(QPen(Qt::black)); // show black border around text
+    mpMouseText->setBrush(QColor::fromRgb(255,255,255));
 
     _mw->setIsotopicPlotStyling();
     _mw->customPlot->yAxis->setRange(-0.5, MM.rows());

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -249,35 +249,3 @@ void IsotopePlot::contextMenuEvent(QContextMenuEvent * event) {
 }
 
 void IsotopePlot::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) { return; }
-
-/*
-void IsotopeBar::mouseDoubleClickEvent (QGraphicsSceneMouseEvent*event) {
-	QVariant v = data(1);
-   	PeakGroup*  x = v.value<PeakGroup*>();
-}
-
-void IsotopeBar::mousePressEvent (QGraphicsSceneMouseEvent*event) {}
-*/
-
-
-void IsotopeBar::hoverEnterEvent (QGraphicsSceneHoverEvent*event) {
-    QVariant v = data(0);
-    QString note = v.value<QString>();
-    if (note.length() == 0 ) return;
-
-    QString htmlNote = note;
-    setToolTip(note);
-    QPointF posG = mapToScene(event->pos());
-    Q_EMIT(showInfo(htmlNote, posG.x(), posG.y()+5));
-}
-
-void IsotopeBar::keyPressEvent(QKeyEvent *e) {
-    if (e->key() == Qt::Key_Delete || e->key() == Qt::Key_Backspace ) {
-        QVariant v = data(1);
-    	PeakGroup*  g = v.value<PeakGroup*>();
-        if (g && g->parent && g->parent != g) { g->parent->deleteChild(g); Q_EMIT(groupUpdated(g->parent)); }
-        IsotopePlot* parent = (IsotopePlot*) parentItem();
-        if (parent) parent->showBars();
-    }
-}
-

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -218,10 +218,11 @@ void IsotopePlot::showPointToolTip(QMouseEvent *event) {
             if (MMDuplicate(y,j)*100 > _mw->getSettings()->value("AbthresholdBarplot").toDouble()) 
             {
                 name += tr("\n %1 : %2\%").arg(_isotopes[j]->tagString.c_str(),
-                                                    QString::number(MMDuplicate(y,j)*100));
+                            QString::number(MMDuplicate(y,j)*100, 'f', 2));
             }
         }
         if(!mpMouseText) return;
+        mpMouseText->setTextAlignment(Qt::AlignLeft);
         int g = QString::compare(name, labels.at(y), Qt::CaseInsensitive);
         if(g == 0) {
             mpMouseText->setText("");

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -59,7 +59,7 @@ void IsotopePlot::setPeakGroup(PeakGroup* group) {
 	_samples.clear();
 	_samples = _mw->getVisibleSamples();
     if (_samples.size() == 0) return;
-	 sort(_samples.begin(), _samples.end(), mzSample::compSampleOrder);
+	    sort(_samples.begin(), _samples.end(), mzSample::compRevSampleOrder);
 
     _isotopes.clear();
     for(int i=0; i < group->childCountBarPlot(); i++ ) {
@@ -106,7 +106,7 @@ void IsotopePlot::showBars() {
     if (_samples.size() == 0 ) return;
 
     int visibleSamplesCount = _samples.size();
-    sort(_samples.begin(), _samples.end(), mzSample::compSampleOrder);
+    sort(_samples.begin(), _samples.end(), mzSample::compRevSampleOrder);
 
     PeakGroup::QType qtype = PeakGroup::AreaTop;
     if ( _mw ) qtype = _mw->getUserQuantType();
@@ -124,7 +124,7 @@ void IsotopePlot::showBars() {
     }
 
     labels.resize(0);
-    for(int i=0; i<MM.rows(); i++ ) {		//samples
+    for(int i=0; i<MM.rows(); i++ ) {		//samples 
         //float sum= MM.row(i).sum();
         labels << QString::fromStdString(_samples[i]->sampleName.c_str());
         //if (sum == 0) continue;

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -15,9 +15,9 @@ IsotopePlot::IsotopePlot(MainWindow *mw)
     title = NULL;
     bottomAxisRect = NULL;
     if (scene()) {
-        _width = scene()->width()*0.25;
-        _height = 10;
-    }
+         _width = scene()->width()*0.25;
+         _height = 10;
+     }
 }
 
 void IsotopePlot::setMainWindow(MainWindow* mw) { _mw = mw; }
@@ -150,7 +150,7 @@ void IsotopePlot::showBars() {
     isotopesType.resize(MM.cols());
 
     for(int j=0; j < MM.cols(); j++ ) {
-        isotopesType[j] = new QCPBars(_mw->customPlot->xAxis, _mw->customPlot->yAxis);
+        isotopesType[j] = new QCPBars(_mw->customPlot->yAxis, _mw->customPlot->xAxis);
         isotopesType[j]->setAntialiased(true); // gives more crisp, pixel aligned bar borders
         isotopesType[j]->setStackingGap(0);
         int h = j % 20;
@@ -169,7 +169,7 @@ void IsotopePlot::showBars() {
             sampleData << i;
         }
         isotopesType[j]->setData(sampleData, isotopeData);
-
+        isotopesType[j]->rescaleKeyAxis(false);
     }
 
     if(mpMouseText) {
@@ -179,7 +179,6 @@ void IsotopePlot::showBars() {
 
     if(!mpMouseText) return;
 
-    //_mw->customPlot->addItem(mpMouseText); 
     mpMouseText->setFont(QFont("Helvetica", 12)); // make font a bit larger
     mpMouseText->position->setType(QCPItemPosition::ptAxisRectRatio);
     mpMouseText->setPositionAlignment(Qt::AlignLeft);
@@ -188,8 +187,7 @@ void IsotopePlot::showBars() {
     mpMouseText->setPen(QPen(Qt::black)); // show black border around text
 
     _mw->setIsotopicPlotStyling();
-    //_mw->customPlot->rescaleAxes();
-    _mw->customPlot->xAxis->setRange(-0.5, MM.rows());
+    _mw->customPlot->yAxis->setRange(-0.5, MM.rows());
 
     disconnect(_mw->customPlot, SIGNAL(mouseMove(QMouseEvent*)));
     connect(_mw->customPlot, SIGNAL(mouseMove(QMouseEvent*)), this, SLOT(showPointToolTip(QMouseEvent*)));

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -202,26 +202,26 @@ void IsotopePlot::showPointToolTip(QMouseEvent *event) {
     if (!event) return;
     if (_mw->customPlot->plotLayout()->elementCount() <= 0) return;
 
-    int x = _mw->customPlot->xAxis->pixelToCoord(event->pos().x());
-    double keyPixel =  _mw->customPlot->xAxis->coordToPixel(x);
-    double shiftRight =  _mw->customPlot->xAxis->coordToPixel(x + .75 * 0.5) - keyPixel;
-    x = _mw->customPlot->xAxis->pixelToCoord(event->pos().x() + shiftRight);
     int y = _mw->customPlot->yAxis->pixelToCoord(event->pos().y());
+    double keyPixel =  _mw->customPlot->yAxis->coordToPixel(y);
+    double shiftAbove =  _mw->customPlot->yAxis->coordToPixel(y + .75 * 0.5) - keyPixel;
+    y = _mw->customPlot->yAxis->pixelToCoord(event->pos().y() + shiftAbove);
+    int x = _mw->customPlot->xAxis->pixelToCoord(event->pos().x());
 
-    if (x < labels.count() && x >= 0) {
-        QString name = labels.at(x);
+    if (y < labels.count() && y >= 0) {
+        QString name = labels.at(y);
         if (MMDuplicate.cols() != _isotopes.size()) return;
 
         for(int j=0; j < MMDuplicate.cols(); j++ ) {
-            if (x  >= MMDuplicate.rows()) return;
-            if (MMDuplicate(x,j)*100 > _mw->getSettings()->value("AbthresholdBarplot").toDouble()) 
+            if (y  >= MMDuplicate.rows()) return;
+            if (MMDuplicate(y,j)*100 > _mw->getSettings()->value("AbthresholdBarplot").toDouble()) 
             {
                 name += tr("\n %1 : %2\%").arg(_isotopes[j]->tagString.c_str(),
-                                                    QString::number(MMDuplicate(x,j)*100));
+                                                    QString::number(MMDuplicate(y,j)*100));
             }
         }
         if(!mpMouseText) return;
-        int g = QString::compare(name, labels.at(x), Qt::CaseInsensitive);
+        int g = QString::compare(name, labels.at(y), Qt::CaseInsensitive);
         if(g == 0) {
             mpMouseText->setText("");
         } else {

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -154,9 +154,9 @@ void IsotopePlot::showBars() {
         isotopesType[j] = new QCPBars(_mw->customPlot->yAxis, _mw->customPlot->xAxis);
         isotopesType[j]->setAntialiased(true); // gives more crisp, pixel aligned bar borders
         isotopesType[j]->setStackingGap(0);
-        int h = j % 20;
+        int h = j % 10;
         isotopesType[j]->setPen(barPen);
-	    isotopesType[j]->setBrush(QColor::fromHsvF(h/20.0,1.0,1.0,1.0));
+	    isotopesType[j]->setBrush(QColor::fromHsvF(h/10.0,1.0,1.0,1.0));
         if (j != 0 ){
             isotopesType[j]->moveAbove(isotopesType[j - 1]);
         }

--- a/src/gui/mzroll/isotopeplot.h
+++ b/src/gui/mzroll/isotopeplot.h
@@ -56,7 +56,7 @@ class IsotopePlot : public QObject, public QGraphicsItem
 #endif
 
 public:
-    IsotopePlot(QGraphicsItem *parent, QGraphicsScene *scene);
+    IsotopePlot();
     ~IsotopePlot();
 
     void setPeakGroup(PeakGroup* group);

--- a/src/gui/mzroll/isotopeplot.h
+++ b/src/gui/mzroll/isotopeplot.h
@@ -56,7 +56,7 @@ class IsotopePlot : public QObject, public QGraphicsItem
 #endif
 
 public:
-    IsotopePlot();
+    IsotopePlot(MainWindow *mw);
     ~IsotopePlot();
 
     void setPeakGroup(PeakGroup* group);

--- a/src/gui/mzroll/isotopeplot.h
+++ b/src/gui/mzroll/isotopeplot.h
@@ -11,42 +11,6 @@ class PeakGroup;
 class QGraphicsItem;
 class QGraphicsScene;
 
-class IsotopeBar : public QObject, public QGraphicsRectItem
-{
-    Q_OBJECT
-#if QT_VERSION >= 0x040600
-    Q_INTERFACES( QGraphicsItem )
-#endif
-
-	public:
-	IsotopeBar(QGraphicsItem *parent, QGraphicsScene *scene):QGraphicsRectItem(parent){
-			setFlag(ItemIsSelectable);
-			setFlag(ItemIsFocusable);
-			setAcceptHoverEvents(true);
-	}
-
-        QRectF boundingRect() {
-              return QGraphicsRectItem::boundingRect();
-        }
-
-	Q_SIGNALS:
-		void groupSelected(PeakGroup* g);
-		void groupUpdated(PeakGroup*  g);
-		void showInfo(QString,int xpos=0, int ypos=0);
-		void showMiniEICPlot(PeakGroup*g);
-
-	protected:        
-                void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) {
-                    QGraphicsRectItem::paint(painter,option,widget);
-                }
-
-	void hoverEnterEvent (QGraphicsSceneHoverEvent*event);
-//	void mouseDoubleClickEvent (QGraphicsSceneMouseEvent*event);
-//	void mousePressEvent (QGraphicsSceneMouseEvent*event);
-	void keyPressEvent(QKeyEvent *e);
-};
-
-
 class IsotopePlot : public QObject, public QGraphicsItem
 {
     Q_OBJECT

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -1,0 +1,17 @@
+#include "isotopeplotdockwidget.h"
+#include "ui_isotopeplotdockwidget.h"
+
+IsotopePlotDockWidget::IsotopePlotDockWidget(MainWindow *mw) :
+    QDockWidget(mw),
+    ui(new Ui::IsotopePlotDockWidget)
+{
+    this->_mw = mw;
+    ui->setupUi(this);
+    setObjectName("IsotopePlotDockWidget");
+    setWindowTitle("Isotope Plot: ");
+}
+
+IsotopePlotDockWidget::~IsotopePlotDockWidget()
+{
+    delete ui;
+}

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -8,10 +8,56 @@ IsotopePlotDockWidget::IsotopePlotDockWidget(MainWindow *mw) :
     this->_mw = mw;
     ui->setupUi(this);
     setObjectName("IsotopePlotDockWidget");
-    setWindowTitle("Isotope Plot: ");
+
+    setToolBar();
+
 }
 
 IsotopePlotDockWidget::~IsotopePlotDockWidget()
 {
     delete ui;
+}
+
+void IsotopePlotDockWidget::setToolBar()
+{
+    QToolBar *toolBar = new QToolBar(this);
+    toolBar->setFloatable(false);
+    toolBar->setMovable(false);
+
+    QLabel *title = new QLabel("Isotope Plot: ");
+    toolBar->addWidget(title);
+
+    QWidget* spacer1 = new QWidget();
+    spacer1->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar->addWidget(spacer1);
+
+    QCheckBox *C13 = new QCheckBox("C13");
+    C13->setChecked(true);
+    toolBar->addWidget(C13);
+
+    QWidget *spacer2 = new QWidget();
+    spacer2->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar->addWidget(spacer2);
+
+    QCheckBox *N15 = new QCheckBox("N15");
+    N15->setChecked(true);
+    toolBar->addWidget(N15);
+
+    QWidget *spacer3 = new QWidget();
+    spacer3->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar->addWidget(spacer3);
+
+    QCheckBox *D2 = new QCheckBox("D2");
+    D2->setChecked(true);
+    toolBar->addWidget(D2);
+
+    QWidget *spacer4 = new QWidget();
+    spacer4->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar->addWidget(spacer4);
+
+    QCheckBox *S34 = new QCheckBox("S34");
+    S34->setChecked(true);
+    toolBar->addWidget(S34);
+
+    setTitleBarWidget(toolBar);
 }

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -62,11 +62,32 @@ void IsotopePlotDockWidget::setToolBar()
     setTitleBarWidget(toolBar);
 
     connect(C13, SIGNAL(toggled(bool)), this, SLOT(updateC13Flag(bool)));
+    connect(N15, SIGNAL(toggled(bool)), this, SLOT(updateN15Flag(bool)));
+    connect(D2, SIGNAL(toggled(bool)), this, SLOT(updateD2Flag(bool)));
+    connect(S34, SIGNAL(toggled(bool)), this, SLOT(updateS34Flag(bool)));
 }
 
 void IsotopePlotDockWidget::updateC13Flag(bool setState)
 {
     _mw->mavenParameters->C13Labeled_Barplot = setState;
+    recompute();
+}
+
+void IsotopePlotDockWidget::updateN15Flag(bool setState)
+{
+    _mw->mavenParameters->N15Labeled_Barplot = setState;
+    recompute();
+}
+
+void IsotopePlotDockWidget::updateD2Flag(bool setState)
+{
+    _mw->mavenParameters->D2Labeled_Barplot = setState;
+    recompute();
+}
+
+void IsotopePlotDockWidget::updateS34Flag(bool setState)
+{
+    _mw->mavenParameters->S34Labeled_Barplot = setState;
     recompute();
 }
 

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -60,4 +60,24 @@ void IsotopePlotDockWidget::setToolBar()
     toolBar->addWidget(S34);
 
     setTitleBarWidget(toolBar);
+
+    connect(C13, SIGNAL(toggled(bool)), this, SLOT(updateC13Flag(bool)));
+}
+
+void IsotopePlotDockWidget::updateC13Flag(bool setState)
+{
+    _mw->mavenParameters->C13Labeled_Barplot = setState;
+    recompute();
+}
+
+void IsotopePlotDockWidget::recompute()
+{
+    if (_mw->getEicWidget()->isVisible()) {
+        PeakGroup* group = _mw->getEicWidget()->getParameters()->getSelectedGroup();
+        if (group)
+        {
+            group->childrenBarPlot.clear();
+            _mw->isotopeWidget->updateIsotopicBarplot(group);
+        }
+    }
 }

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -11,6 +11,7 @@ IsotopePlotDockWidget::IsotopePlotDockWidget(MainWindow *mw) :
 
     setToolBar();
 
+    setWindowTitle("Isotope Plot: ");
 }
 
 IsotopePlotDockWidget::~IsotopePlotDockWidget()

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -40,7 +40,7 @@ void IsotopePlotDockWidget::setToolBar()
     toolBar->addWidget(spacer2);
 
     QCheckBox *N15 = new QCheckBox("N15");
-    N15->setChecked(true);
+    N15->setChecked(false);
     toolBar->addWidget(N15);
 
     QWidget *spacer3 = new QWidget();
@@ -48,7 +48,7 @@ void IsotopePlotDockWidget::setToolBar()
     toolBar->addWidget(spacer3);
 
     QCheckBox *D2 = new QCheckBox("D2");
-    D2->setChecked(true);
+    D2->setChecked(false);
     toolBar->addWidget(D2);
 
     QWidget *spacer4 = new QWidget();
@@ -56,7 +56,7 @@ void IsotopePlotDockWidget::setToolBar()
     toolBar->addWidget(spacer4);
 
     QCheckBox *S34 = new QCheckBox("S34");
-    S34->setChecked(true);
+    S34->setChecked(false);
     toolBar->addWidget(S34);
 
     setTitleBarWidget(toolBar);

--- a/src/gui/mzroll/isotopeplotdockwidget.h
+++ b/src/gui/mzroll/isotopeplotdockwidget.h
@@ -1,0 +1,24 @@
+#ifndef ISOTOPEPLOTDOCKWIDGET_H
+#define ISOTOPEPLOTDOCKWIDGET_H
+
+#include "mainwindow.h"
+#include <QDockWidget>
+
+namespace Ui {
+class IsotopePlotDockWidget;
+}
+
+class IsotopePlotDockWidget : public QDockWidget
+{
+    Q_OBJECT
+
+public:
+    explicit IsotopePlotDockWidget(MainWindow *mw = 0);
+    ~IsotopePlotDockWidget();
+
+private:
+    Ui::IsotopePlotDockWidget *ui;
+    MainWindow *_mw;
+};
+
+#endif // ISOTOPEPLOTDOCKWIDGET_H

--- a/src/gui/mzroll/isotopeplotdockwidget.h
+++ b/src/gui/mzroll/isotopeplotdockwidget.h
@@ -19,6 +19,7 @@ public:
 private:
     Ui::IsotopePlotDockWidget *ui;
     MainWindow *_mw;
+    void setToolBar();
 };
 
 #endif // ISOTOPEPLOTDOCKWIDGET_H

--- a/src/gui/mzroll/isotopeplotdockwidget.h
+++ b/src/gui/mzroll/isotopeplotdockwidget.h
@@ -18,6 +18,9 @@ public:
 
 private Q_SLOTS:
     void updateC13Flag(bool setState);
+    void updateN15Flag(bool setState);
+    void updateD2Flag(bool setState);
+    void updateS34Flag(bool setState);
 
 private:
     Ui::IsotopePlotDockWidget *ui;

--- a/src/gui/mzroll/isotopeplotdockwidget.h
+++ b/src/gui/mzroll/isotopeplotdockwidget.h
@@ -16,10 +16,14 @@ public:
     explicit IsotopePlotDockWidget(MainWindow *mw = 0);
     ~IsotopePlotDockWidget();
 
+private Q_SLOTS:
+    void updateC13Flag(bool setState);
+
 private:
     Ui::IsotopePlotDockWidget *ui;
     MainWindow *_mw;
     void setToolBar();
+    void recompute();
 };
 
 #endif // ISOTOPEPLOTDOCKWIDGET_H

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -403,9 +403,11 @@ void IsotopeWidget::setClipboard()
 
 void IsotopeWidget::updateIsotopicBarplot()
 {
+	_mw->isotopePlotDockWidget->show();
+	_mw->isotopePlotDockWidget->raise();
 	if (isotopeParametersBarPlot->_group)
 	{
-		_mw->getEicWidget()->updateIsotopicBarplot(isotopeParametersBarPlot->_group);
+		_mw->isotopePlot->setPeakGroup(isotopeParametersBarPlot->_group);
 	}
 	workerThreadBarplot->stop();
 

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -403,8 +403,10 @@ void IsotopeWidget::setClipboard()
 
 void IsotopeWidget::updateIsotopicBarplot()
 {
-	_mw->isotopePlotDockWidget->show();
-	_mw->isotopePlotDockWidget->raise();
+	if (!_mw->isotopePlotDockWidget->isVisible()) 
+		return;
+	else
+		_mw->isotopePlotDockWidget->raise();
 	if (isotopeParametersBarPlot->_group)
 	{
 		_mw->isotopePlot->setPeakGroup(isotopeParametersBarPlot->_group);

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -403,10 +403,8 @@ void IsotopeWidget::setClipboard()
 
 void IsotopeWidget::updateIsotopicBarplot()
 {
-	if (!_mw->isotopePlotDockWidget->isVisible()) 
-		return;
-	else
-		_mw->isotopePlotDockWidget->raise();
+	_mw->isotopePlotDockWidget->show();
+	_mw->isotopePlotDockWidget->raise();
 	if (isotopeParametersBarPlot->_group)
 	{
 		_mw->isotopePlot->setPeakGroup(isotopeParametersBarPlot->_group);

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -403,8 +403,6 @@ void IsotopeWidget::setClipboard()
 
 void IsotopeWidget::updateIsotopicBarplot()
 {
-	_mw->isotopePlotDockWidget->show();
-	_mw->isotopePlotDockWidget->raise();
 	if (isotopeParametersBarPlot->_group)
 	{
 		_mw->isotopePlot->setPeakGroup(isotopeParametersBarPlot->_group);

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -967,14 +967,13 @@ void MainWindow::setIsotopicPlotStyling() {
 	customPlot->xAxis->setTickLabels( false );
 	customPlot->xAxis->setTicks( false );
 	customPlot->xAxis->setBasePen(QPen(Qt::white));
-	customPlot->xAxis->grid()->setVisible(false);	
+	customPlot->xAxis->grid()->setVisible(false);
+	customPlot->xAxis->setRange(0, 1);	
 	// prepare y axis:
 	customPlot->yAxis->grid()->setVisible(false);
 	customPlot->yAxis->setTickLabels( false );
 	customPlot->yAxis->setTicks( false );
-	customPlot->yAxis->setBasePen(QPen(Qt::white));
-	customPlot->yAxis->setRange(0, 1);
-	
+	customPlot->yAxis->setBasePen(QPen(Qt::white));	
 }
 
 void MainWindow::mzrollLoadDB(QString dbname) {

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3353,8 +3353,7 @@ QWidget* MainWindowWidgetAction::createWidget(QWidget *parent) {
 		btnShowIsotopeplot->setToolTip(tr("Show Isotope Plot"));
 		btnShowIsotopeplot->setCheckable(true);
 
-		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)),  mw->getEicWidget(), SLOT(showIsotopePlot(bool)));
-		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), SLOT(showIsotopicBarPlot(bool)));
+		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw, SLOT(toggleIsotopicBarPlot()));
 		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw->isotopeWidget, SLOT(updateIsotopicBarplot()));
 
 		btnShowIsotopeplot->setChecked(mw->isotopePlotDockWidget->isVisible());
@@ -3593,12 +3592,14 @@ int MainWindow::versionCheck() {
 	return 0;
 }
 
-void MainWindow::showIsotopicBarPlot(bool showIsotopicBarPlot)
+void MainWindow::toggleIsotopicBarPlot()
 {
-	if (showIsotopicBarPlot)
-		isotopePlotDockWidget->show();
-	else
+	if (isotopePlotDockWidget->isVisible()) {
 		isotopePlotDockWidget->hide();
+	}
+	else {
+		isotopePlotDockWidget->show();
+	}
 }
 
 void MainWindow::normalizeIsotopicMatrix(MatrixXf &MM) {

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -366,7 +366,6 @@ using namespace mzUtils;
 	alignmentVizDockWidget->setVisible(false);
 	alignmentPolyVizDockWidget->setVisible(false);
 	alignmentVizAllGroupsDockWidget->setVisible(false);
-	isotopePlotDockWidget->show();
 	scatterDockWidget->setVisible(false);
 	notesDockWidget->setVisible(false);
 	heatMapDockWidget->setVisible(false);
@@ -3352,12 +3351,8 @@ QWidget* MainWindowWidgetAction::createWidget(QWidget *parent) {
 		btnShowIsotopeplot->setToolTip(tr("Show Isotope Plot"));
 		btnShowIsotopeplot->setCheckable(true);
 
-		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw, SLOT(toggleIsotopicBarPlot()));
+		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw, SLOT(toggleIsotopicBarPlot(bool)));
 		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw->isotopeWidget, SLOT(updateIsotopicBarplot()));
-
-		btnShowIsotopeplot->setChecked(mw->isotopePlotDockWidget->isVisible());
-		connect(mw->isotopePlotDockWidget, SIGNAL(visibilityChanged(bool)), btnShowIsotopeplot,
-				SLOT(setChecked(bool)));
 
 		return btnShowIsotopeplot;
 
@@ -3591,13 +3586,14 @@ int MainWindow::versionCheck() {
 	return 0;
 }
 
-void MainWindow::toggleIsotopicBarPlot()
+void MainWindow::toggleIsotopicBarPlot(bool show)
 {
-	if (isotopePlotDockWidget->isVisible()) {
-		isotopePlotDockWidget->hide();
+	if (show) {
+		isotopePlotDockWidget->show();
+		isotopePlotDockWidget->raise();
 	}
 	else {
-		isotopePlotDockWidget->show();
+		isotopePlotDockWidget->hide();
 	}
 }
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -303,12 +303,14 @@ using namespace mzUtils;
 	alignmentPolyVizDockWidget = new AlignmentPolyVizDockWidget(this);
 	alignmentPolyVizDockWidget->setWidget(alignmentPolyVizPlot);
 
+	isotopePlotDockWidget = new IsotopePlotDockWidget(this);
+	isotopePlotDockWidget->setWidget(customPlot);
+
 	//treemap	 = 	  new TreeMap(this);
 	//peaksPanel	= new TreeDockWidget(this,"Group Information", 1);
 	spectraDockWidget = createDockWidget("Spectra", spectraWidget);
 	alignmentVizDockWidget = createDockWidget("AlignmentVisualization", alignmentVizPlot);
 	alignmentVizAllGroupsDockWidget = createDockWidget("AlignmentVisualizationForAllGroups", alignmentVizAllGroupsPlot);
-	isotopePlotsDockWidget = createDockWidget("IsotopePlots", customPlot);
 	pathwayDockWidget = createDockWidget("PathwayViewer", pathwayWidget);
 	heatMapDockWidget = createDockWidget("HeatMap", heatmap);
 	galleryDockWidget = createDockWidget("Gallery", galleryWidget);
@@ -363,7 +365,7 @@ using namespace mzUtils;
 	alignmentVizDockWidget->setVisible(false);
 	alignmentPolyVizDockWidget->setVisible(false);
 	alignmentVizAllGroupsDockWidget->setVisible(false);
-	isotopePlotsDockWidget->show();
+	isotopePlotDockWidget->show();
 	scatterDockWidget->setVisible(false);
 	notesDockWidget->setVisible(false);
 	heatMapDockWidget->setVisible(false);
@@ -420,7 +422,7 @@ using namespace mzUtils;
 	addDockWidget(Qt::BottomDockWidgetArea, alignmentVizDockWidget, Qt::Horizontal);
 	addDockWidget(Qt::BottomDockWidgetArea, alignmentPolyVizDockWidget, Qt::Horizontal);
 	addDockWidget(Qt::BottomDockWidgetArea, alignmentVizAllGroupsDockWidget, Qt::Horizontal);
-	addDockWidget(Qt::BottomDockWidgetArea, isotopePlotsDockWidget, Qt::Horizontal);
+	addDockWidget(Qt::BottomDockWidgetArea, isotopePlotDockWidget, Qt::Horizontal);
 	addDockWidget(Qt::BottomDockWidgetArea, pathwayDockWidget, Qt::Horizontal);
 	addDockWidget(Qt::BottomDockWidgetArea, adductWidget, Qt::Horizontal);
 	addDockWidget(Qt::BottomDockWidgetArea, covariantsPanel, Qt::Horizontal);
@@ -449,7 +451,7 @@ using namespace mzUtils;
 	tabifyDockWidget(spectraDockWidget, alignmentVizDockWidget);
 	tabifyDockWidget(spectraDockWidget, alignmentPolyVizDockWidget);
 	tabifyDockWidget(spectraDockWidget, alignmentVizAllGroupsDockWidget);
-	tabifyDockWidget(spectraDockWidget, isotopePlotsDockWidget);
+	tabifyDockWidget(spectraDockWidget, isotopePlotDockWidget);
 	tabifyDockWidget(spectraDockWidget, pathwayDockWidget);
 	tabifyDockWidget(spectraDockWidget, fragPanel);
 	tabifyDockWidget(spectraDockWidget, covariantsPanel);
@@ -3354,8 +3356,8 @@ QWidget* MainWindowWidgetAction::createWidget(QWidget *parent) {
 		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)),  mw->getEicWidget(), SLOT(showIsotopicBarPlot(bool)));
 		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw->isotopeWidget, SLOT(updateIsotopicBarplot()));
 
-		btnShowIsotopeplot->setChecked(mw->isotopePlotsDockWidget->isVisible());
-		connect(mw->isotopePlotsDockWidget, SIGNAL(visibilityChanged(bool)), btnShowIsotopeplot,
+		btnShowIsotopeplot->setChecked(mw->isotopePlotDockWidget->isVisible());
+		connect(mw->isotopePlotDockWidget, SIGNAL(visibilityChanged(bool)), btnShowIsotopeplot,
 				SLOT(setChecked(bool)));
 
 		return btnShowIsotopeplot;

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -287,6 +287,7 @@ using namespace mzUtils;
 	pathwayWidget = new PathwayWidget(this);
 	adductWidget = new AdductWidget(this);
 	isotopeWidget = new IsotopeWidget(this);
+	isotopePlot = new IsotopePlot(this);
 
 
 	massCalcWidget = new MassCalcWidget(this);
@@ -3590,30 +3591,6 @@ int MainWindow::versionCheck() {
 			SLOT(append(QString)));
 
 	return 0;
-}
-
-void MainWindow::addIsotopicPlot(PeakGroup* group) {
-	if (!group)
-		return;
-	if (!isotopePlot)
-		isotopePlot = new IsotopePlot();
-	//if (!isotopeplot->scene())
-	//	scene()->addItem(isotopeplot);
-	//isotopeplot->hide();
-
-	if (group->childCountBarPlot() == 0)
-		return;
-
-	vector<mzSample*> samples = getVisibleSamples();
-	if (samples.size() == 0)
-		return;
-
-	//isotopePlot->setPos(scene()->width() * 0.10, scene()->height() * 0.10);
-	isotopePlot->setZValue(1000);
-	isotopePlot->setMainWindow(this);
-	isotopePlot->setPeakGroup(group);
-	isotopePlot->show();
-	return;
 }
 
 void MainWindow::normalizeIsotopicMatrix(MatrixXf &MM) {

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3354,7 +3354,7 @@ QWidget* MainWindowWidgetAction::createWidget(QWidget *parent) {
 		btnShowIsotopeplot->setCheckable(true);
 
 		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)),  mw->getEicWidget(), SLOT(showIsotopePlot(bool)));
-		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)),  mw->getEicWidget(), SLOT(showIsotopicBarPlot(bool)));
+		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), SLOT(showIsotopicBarPlot(bool)));
 		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw->isotopeWidget, SLOT(updateIsotopicBarplot()));
 
 		btnShowIsotopeplot->setChecked(mw->isotopePlotDockWidget->isVisible());
@@ -3591,6 +3591,14 @@ int MainWindow::versionCheck() {
 			SLOT(append(QString)));
 
 	return 0;
+}
+
+void MainWindow::showIsotopicBarPlot(bool showIsotopicBarPlot)
+{
+	if (showIsotopicBarPlot)
+		isotopePlotDockWidget->show();
+	else
+		isotopePlotDockWidget->hide();
 }
 
 void MainWindow::normalizeIsotopicMatrix(MatrixXf &MM) {

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3592,6 +3592,30 @@ int MainWindow::versionCheck() {
 	return 0;
 }
 
+void MainWindow::addIsotopicPlot(PeakGroup* group) {
+	if (!group)
+		return;
+	if (!isotopePlot)
+		isotopePlot = new IsotopePlot();
+	//if (!isotopeplot->scene())
+	//	scene()->addItem(isotopeplot);
+	//isotopeplot->hide();
+
+	if (group->childCountBarPlot() == 0)
+		return;
+
+	vector<mzSample*> samples = getVisibleSamples();
+	if (samples.size() == 0)
+		return;
+
+	//isotopePlot->setPos(scene()->width() * 0.10, scene()->height() * 0.10);
+	isotopePlot->setZValue(1000);
+	isotopePlot->setMainWindow(this);
+	isotopePlot->setPeakGroup(group);
+	isotopePlot->show();
+	return;
+}
+
 void MainWindow::normalizeIsotopicMatrix(MatrixXf &MM) {
 	for(int i = 0; i < MM.rows(); i++) {
 		float sum = 0;

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3615,7 +3615,7 @@ MatrixXf MainWindow::getIsotopicMatrix(PeakGroup* group) {
 	PeakGroup::QType qtype = getUserQuantType();
 	//get visiable samples
 	vector<mzSample*> vsamples = getVisibleSamples();
-	sort(vsamples.begin(), vsamples.end(), mzSample::compSampleOrder);
+	sort(vsamples.begin(), vsamples.end(), mzSample::compRevSampleOrder);
 	map<unsigned int, string> carbonIsotopeSpecies;
 
 	//get isotopic groups

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -262,7 +262,6 @@ public:
 		Q_EMIT(reBoot());
 	}
 	vector<mzSample*> getVisibleSamples();
-	void addIsotopicPlot(PeakGroup* group);
 
 	PeakGroup::QType getUserQuantType();
 

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -405,6 +405,7 @@ private Q_SLOTS:
 	void checkSRMList();
 	void readSettings();
 	void writeSettings();
+	void showIsotopicBarPlot(bool);
 	inline void slotReboot() {
  		qDebug() << "Performing application reboot...";
 		QString rep = QDir::cleanPath(QCoreApplication::applicationFilePath());

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -406,7 +406,7 @@ private Q_SLOTS:
 	void checkSRMList();
 	void readSettings();
 	void writeSettings();
-	void toggleIsotopicBarPlot();
+	void toggleIsotopicBarPlot(bool show);
 	inline void slotReboot() {
  		qDebug() << "Performing application reboot...";
 		QString rep = QDir::cleanPath(QCoreApplication::applicationFilePath());

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -23,6 +23,7 @@
 #include "tabledockwidget.h"
 #include "alignmentpolyvizdockwidget.h"
 #include "isotopeplotdockwidget.h"
+#include "isotopeplot.h"
 #include "peakdetectiondialog.h"
 #include "pollyelmaveninterface.h"
 #include "alignmentdialog.h"
@@ -161,6 +162,7 @@ public:
 	AlignmentPolyVizDockWidget *alignmentPolyVizDockWidget;
 	AlignmentVizAllGroupsWidget * alignmentVizAllGroupsWidget;
 	IsotopePlotDockWidget *isotopePlotDockWidget;
+	IsotopePlot *isotopePlot;
 	QCustomPlot *customPlot;
 	QCustomPlot *alignmentVizPlot;
 	QCustomPlot *alignmentPolyVizPlot;
@@ -260,6 +262,7 @@ public:
 		Q_EMIT(reBoot());
 	}
 	vector<mzSample*> getVisibleSamples();
+	void addIsotopicPlot(PeakGroup* group);
 
 	PeakGroup::QType getUserQuantType();
 

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -22,6 +22,7 @@
 #include "treedockwidget.h"
 #include "tabledockwidget.h"
 #include "alignmentpolyvizdockwidget.h"
+#include "isotopeplotdockwidget.h"
 #include "peakdetectiondialog.h"
 #include "pollyelmaveninterface.h"
 #include "alignmentdialog.h"
@@ -75,6 +76,7 @@ class MassCalcWidget;
 class TreeDockWidget;
 class TableDockWidget;
 class AlignmentPolyVizDockWidget;
+class IsotopePlotDockWidget;
 class Classifier;
 class ClassifierNeuralNet;
 class ClassifierNaiveBayes;
@@ -158,6 +160,7 @@ public:
 	AlignmentVizWidget *alignmentVizWidget;
 	AlignmentPolyVizDockWidget *alignmentPolyVizDockWidget;
 	AlignmentVizAllGroupsWidget * alignmentVizAllGroupsWidget;
+	IsotopePlotDockWidget *isotopePlotDockWidget;
 	QCustomPlot *customPlot;
 	QCustomPlot *alignmentVizPlot;
 	QCustomPlot *alignmentPolyVizPlot;
@@ -174,7 +177,6 @@ public:
 	QDockWidget *spectraDockWidget;
 	QDockWidget *alignmentVizDockWidget;
 	QDockWidget *alignmentVizAllGroupsDockWidget;
-	QDockWidget *isotopePlotsDockWidget;
 	QDockWidget *pathwayDockWidget;
 	QDockWidget *heatMapDockWidget;
 	QDockWidget *scatterDockWidget;

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -78,6 +78,7 @@ class TreeDockWidget;
 class TableDockWidget;
 class AlignmentPolyVizDockWidget;
 class IsotopePlotDockWidget;
+class IsotopePlot;
 class Classifier;
 class ClassifierNeuralNet;
 class ClassifierNaiveBayes;
@@ -405,7 +406,7 @@ private Q_SLOTS:
 	void checkSRMList();
 	void readSettings();
 	void writeSettings();
-	void showIsotopicBarPlot(bool);
+	void toggleIsotopicBarPlot();
 	inline void slotReboot() {
  		qDebug() << "Performing application reboot...";
 		QString rep = QDir::cleanPath(QCoreApplication::applicationFilePath());

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -109,7 +109,8 @@ FORMS = forms/settingsform.ui  \
         forms/spectramatching.ui\
         forms/peptidefragmentation.ui \
     forms/awsbucketcredentialsdialog.ui \
-    forms/alignmentpolyvizdockwidget.ui
+    forms/alignmentpolyvizdockwidget.ui \
+    forms/isotopeplotdockwidget.ui
 
 HEADERS +=  stable.h \
             globals.h \
@@ -177,7 +178,8 @@ HEADERS +=  stable.h \
                     controller.h \
                     numeric_treewidgetitem.h \
                     analytics.h \
-                    ElmavCrashHandler.h
+                    ElmavCrashHandler.h \
+                    isotopeplotdockwidget.h
 
 
 
@@ -244,7 +246,8 @@ database.cpp \
     controller.cpp \
     numeric_treewidgetitem.cpp \
     analytics.cpp \
-    ElmavCrashHandler.cpp
+    ElmavCrashHandler.cpp \
+    isotopeplotdockwidget.cpp
 
 
 contains (DEFINES,EMBEDHTTPSERVER) {

--- a/src/gui/mzroll/settingsform.cpp
+++ b/src/gui/mzroll/settingsform.cpp
@@ -24,11 +24,6 @@ OptionsDialogSettings::OptionsDialogSettings(SettingsForm* dialog): sf(dialog)
     settings.insert("N15Labeled_BPE", QVariant::fromValue(sf->N15Labeled_BPE));
     settings.insert("S34Labeled_BPE", QVariant::fromValue(sf->S34Labeled_BPE));
 
-    settings.insert("D2Labeled_Barplot", QVariant::fromValue(sf->D2Labeled_Barplot));
-    settings.insert("C13Labeled_Barplot", QVariant::fromValue(sf->C13Labeled_Barplot));
-    settings.insert("N15Labeled_Barplot", QVariant::fromValue(sf->N15Labeled_Barplot));
-    settings.insert("S34Labeled_Barplot", QVariant::fromValue(sf->S34Labeled_Barplot));
-
     settings.insert("D2Labeled_IsoWidget", QVariant::fromValue(sf->D2Labeled_IsoWidget));
     settings.insert("C13Labeled_IsoWidget", QVariant::fromValue(sf->C13Labeled_IsoWidget));
     settings.insert("N15Labeled_IsoWidget", QVariant::fromValue(sf->N15Labeled_IsoWidget));
@@ -123,11 +118,6 @@ SettingsForm::SettingsForm(QSettings* s, MainWindow *w): QDialog(w) {
     connect(N15Labeled_BPE,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
     connect(S34Labeled_BPE,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
     connect(D2Labeled_BPE, SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
-        //isotope detection setting
-    connect(C13Labeled_Barplot,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
-    connect(N15Labeled_Barplot,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
-    connect(S34Labeled_Barplot,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
-    connect(D2Labeled_Barplot, SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
     connect(doubleSpinBoxAbThresh, SIGNAL(valueChanged(double)),SLOT(recomputeIsotopes()));
         //isotope detection setting
     connect(C13Labeled_IsoWidget,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));


### PR DESCRIPTION
Changes made:

- Refactor to move isotope plot functions out of eicWidget
- move isotope plot to a dockwidget
- Plot does not clear unless group is changed
- Horizontal plot instead of vertical
- Add checkboxes for which labels should be displayed
- Sort samples in the same order as barplot
- Natural sort for labels
- Label information on hover at mouse position
- Opaque background for label info for clarity
- Use distinct colors for label bars 
- Add black separators between labels