### PR TITLE
[Fix] Highlight correct group acc to rank

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -751,7 +751,6 @@ Scan* PeakGroup::getAverageFragmenationScan( MassCutoff *massCutoff) {
     }
 
 void PeakGroup::calGroupRank(bool deltaRtCheckFlag,
-                            float compoundRTWindow,
                             int qualityWeight,
                             int intensityWeight,
                             int deltaRTWeight) {

--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -529,7 +529,6 @@ class PeakGroup{
         bool operator< (const PeakGroup* b) const { return this->maxIntensity < b->maxIntensity; }
 
         void calGroupRank(bool deltaRtCheckFlag,
-                            float compoundRTWindow,
                             int qualityWeight,
                             int intensityWeight,
                             int deltaRTWeight);

--- a/src/core/libmaven/eiclogic.cpp
+++ b/src/core/libmaven/eiclogic.cpp
@@ -28,7 +28,6 @@ void EICLogic::associateNameWithPeakGroups() {
 PeakGroup* EICLogic::selectGroupNearRt(float rt,
 									   	PeakGroup* selGroup,
 										bool deltaRtCheckFlag,
-										float compoundRTWindow,
 										int qualityWeight,
 										int intensityWeight,
 										int deltaRTWeight) {
@@ -42,12 +41,10 @@ PeakGroup* EICLogic::selectGroupNearRt(float rt,
 			}
 
 			selGroup->calGroupRank(deltaRtCheckFlag,
-									compoundRTWindow,
 									qualityWeight,
 									intensityWeight,
 									deltaRTWeight);
 			peakgroups[i].calGroupRank(deltaRtCheckFlag,
-									compoundRTWindow,
 									qualityWeight,
 									intensityWeight,
 									deltaRTWeight);

--- a/src/core/libmaven/eiclogic.h
+++ b/src/core/libmaven/eiclogic.h
@@ -30,7 +30,6 @@ public:
 	PeakGroup* selectGroupNearRt(float rt,
 								PeakGroup* selGroup,
 								bool matchRtFlag,
-								float compoundRTWindow,
 								int qualityWeight,
 								int intensityWeight,
 								int deltaRTWeight);

--- a/src/core/libmaven/isotopeDetection.cpp
+++ b/src/core/libmaven/isotopeDetection.cpp
@@ -305,7 +305,6 @@ void IsotopeDetection::childStatistics(
     int deltaRTWeight = _mavenParameters->deltaRTWeight;
 
     child.calGroupRank(deltaRtCheckFlag,
-                       compoundRTWindow,
                        qualityWeight,
                        intensityWeight,
                        deltaRTWeight);

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1869,8 +1869,7 @@ void EicWidget::selectGroupNearRt(float rt) {
 	PeakGroup* selGroup = NULL;
 	selGroup = eicParameters->selectGroupNearRt(rt,
 												selGroup,
-												getMainWindow()->mavenParameters->matchRtFlag,
-												getMainWindow()->mavenParameters->compoundRTWindow,
+												getMainWindow()->mavenParameters->deltaRtCheckFlag,
 												getMainWindow()->mavenParameters->qualityWeight,
 												getMainWindow()->mavenParameters->intensityWeight,
 												getMainWindow()->mavenParameters->deltaRTWeight);


### PR DESCRIPTION
The lowest ranking (therefore the best) group was not highlighted on checking the 'Consider Retention Time' checkbox.
This was due to the wrong flag sent to groupHighlight and rank calculation function.

Also removed a redundant variable.