### PR TITLE
Provide labeling options in isoPlot

### DIFF
--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -455,6 +455,14 @@ class PeakGroup{
         static bool compMz(const PeakGroup& a, const PeakGroup& b ) { return(a.meanMz > b.meanMz); }
 
         /**
+         * @brief sort isotopes in natural order
+         * @param a reference to PeakGroup object
+         * @param b reference to PeakGroup object
+         * @return True if tagString of a is lesser than b
+         **/
+        static bool compTagString(const PeakGroup& a, const PeakGroup& b ) { return mzUtils::strcasecmp_withNumbers(a.tagString, b.tagString); }
+        
+        /**
          * [compIntensity ]
          * @method compIntensity
          * @param  a             []

--- a/src/core/libmaven/default_settings.xml
+++ b/src/core/libmaven/default_settings.xml
@@ -48,10 +48,6 @@
         <C13Labeled_BPE>1</C13Labeled_BPE>
         <N15Labeled_BPE>1</N15Labeled_BPE>
         <S34Labeled_BPE>1</S34Labeled_BPE>
-        <D2Labeled_Barplot>1</D2Labeled_Barplot>
-        <C13Labeled_Barplot>1</C13Labeled_Barplot>
-        <N15Labeled_Barplot>1</N15Labeled_Barplot>
-        <S34Labeled_Barplot>1</S34Labeled_Barplot>
         <D2Labeled_IsoWidget>1</D2Labeled_IsoWidget>
         <C13Labeled_IsoWidget>1</C13Labeled_IsoWidget>
         <N15Labeled_IsoWidget>1</N15Labeled_IsoWidget>

--- a/src/core/libmaven/isotopeDetection.cpp
+++ b/src/core/libmaven/isotopeDetection.cpp
@@ -45,6 +45,8 @@ void IsotopeDetection::pullIsotopes(PeakGroup* parentgroup)
 
     addIsotopes(parentgroup, isotopes);
 
+    sortIsotopes(parentgroup);
+
 }
 
 map<string, PeakGroup> IsotopeDetection::getIsotopes(PeakGroup* parentgroup, vector<Isotope> masslist)
@@ -344,4 +346,17 @@ bool IsotopeDetection::filterLabel(string isotopeName)
 
     return true;
 
+}
+
+void IsotopeDetection::sortIsotopes(PeakGroup *group)
+{
+    if (group->children.size())
+        sort(group->children.begin(), group->children.end(), PeakGroup::compTagString);
+    
+    if (group->childrenBarPlot.size())
+        sort(group->childrenBarPlot.begin(), group->childrenBarPlot.end(), PeakGroup::compTagString);
+    
+    if (group->childrenIsoWidget.size())
+        sort(group->childrenIsoWidget.begin(), group->childrenIsoWidget.end(), PeakGroup::compTagString);
+    
 }

--- a/src/core/libmaven/isotopeDetection.h
+++ b/src/core/libmaven/isotopeDetection.h
@@ -55,6 +55,7 @@ class IsotopeDetection
 	bool filterLabel(string isotopeName);
 	void addChild(PeakGroup *parentgroup, PeakGroup &child, string isotopeName);
 	bool checkChildExist(vector<PeakGroup> &children, string isotopeName);
+	void sortIsotopes(PeakGroup *group);
 
 };
 

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -98,7 +98,7 @@ MavenParameters::MavenParameters(string settingsPath):lastUsedSettingsPath(setti
 	S34Labeled_BPE = false;
 	D2Labeled_BPE = false;
 	
-	C13Labeled_Barplot = false;
+	C13Labeled_Barplot = true;
 	N15Labeled_Barplot = false;
 	S34Labeled_Barplot = false;
 	D2Labeled_Barplot = false;

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -355,18 +355,6 @@ void MavenParameters::setOptionsDialogSettings(const char* key, const char* valu
     if(strcmp(key, "S34Labeled_BPE") == 0)
         S34Labeled_BPE = atof(value);
 
-    if(strcmp(key, "D2Labeled_Barplot") == 0)
-        D2Labeled_Barplot = atof(value);
-
-    if(strcmp(key, "C13Labeled_Barplot") == 0)
-        C13Labeled_Barplot = atof(value);
-
-    if(strcmp(key, "N15Labeled_Barplot") == 0)
-        N15Labeled_Barplot = atof(value);
-
-    if(strcmp(key, "S34Labeled_Barplot") == 0)
-        S34Labeled_Barplot = atof(value);
-
     if(strcmp(key, "D2Labeled_IsoWidget") == 0)
         D2Labeled_IsoWidget = atof(value);
 

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -557,6 +557,14 @@ class mzSample
                           */
     static bool compSampleOrder(const mzSample *a, const mzSample *b) { return a->_sampleOrder < b->_sampleOrder; }
 
+    /**
+     * @brief Compare sample order of two samples
+     * @param a object of class mzSample
+     * @param b object of class mzSample
+     * @return True if sample order of 'a' is higher than 'b' else false
+     **/
+    static bool compRevSampleOrder(const mzSample *a, const mzSample *b) { return a->_sampleOrder > b->_sampleOrder; }
+
     static bool compSampleSort(const mzSample *a, const mzSample *b) { return mzUtils::strcasecmp_withNumbers(a->sampleName, b->sampleName); }
 
     /**

--- a/src/gui/mzroll/forms/isotopeplotdockwidget.ui
+++ b/src/gui/mzroll/forms/isotopeplotdockwidget.ui
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>IsotopePlotDockWidget</class>
  <widget class="QDockWidget" name="IsotopePlotDockWidget">
@@ -5,12 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>595</width>
     <height>300</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>DockWidget</string>
   </property>
+  <widget class="QWidget" name="isotopePlot"/>
  </widget>
+ <resources/>
+ <connections/>
 </ui>

--- a/src/gui/mzroll/forms/isotopeplotdockwidget.ui
+++ b/src/gui/mzroll/forms/isotopeplotdockwidget.ui
@@ -1,4 +1,7 @@
+<<<<<<< c9b211be62274ef911e081ba108599510c814283
 <?xml version="1.0" encoding="UTF-8"?>
+=======
+>>>>>>> [UI] Move isotope plot to a dockwidget
 <ui version="4.0">
  <class>IsotopePlotDockWidget</class>
  <widget class="QDockWidget" name="IsotopePlotDockWidget">

--- a/src/gui/mzroll/forms/isotopeplotdockwidget.ui
+++ b/src/gui/mzroll/forms/isotopeplotdockwidget.ui
@@ -1,7 +1,4 @@
-<<<<<<< c9b211be62274ef911e081ba108599510c814283
 <?xml version="1.0" encoding="UTF-8"?>
-=======
->>>>>>> [UI] Move isotope plot to a dockwidget
 <ui version="4.0">
  <class>IsotopePlotDockWidget</class>
  <widget class="QDockWidget" name="IsotopePlotDockWidget">

--- a/src/gui/mzroll/forms/settingsform.ui
+++ b/src/gui/mzroll/forms/settingsform.ui
@@ -608,24 +608,10 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="2" column="4">
-           <widget class="QCheckBox" name="S34Labeled_Barplot">
-            <property name="text">
-             <string>S34</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
+          <item row="2" column="1">
            <widget class="QCheckBox" name="D2Labeled_IsoWidget">
             <property name="text">
              <string>D2</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_Barplot">
-            <property name="text">
-             <string>Isotopic barplot </string>
             </property>
            </widget>
           </item>
@@ -636,35 +622,14 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="3">
-           <widget class="QCheckBox" name="N15Labeled_Barplot">
-            <property name="text">
-             <string>N15</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="D2Labeled_Barplot">
-            <property name="text">
-             <string>D2</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QCheckBox" name="C13Labeled_Barplot">
-            <property name="text">
-             <string>C13</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="label_IsoWidget">
             <property name="text">
              <string>Isotopic widget</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="4">
+          <item row="2" column="4">
            <widget class="QCheckBox" name="S34Labeled_IsoWidget">
             <property name="text">
              <string>S34</string>
@@ -678,7 +643,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="2">
+          <item row="2" column="2">
            <widget class="QCheckBox" name="C13Labeled_IsoWidget">
             <property name="text">
              <string>C13</string>
@@ -702,7 +667,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="3">
+          <item row="2" column="3">
            <widget class="QCheckBox" name="N15Labeled_IsoWidget">
             <property name="text">
              <string>N15</string>
@@ -1440,10 +1405,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>C13Labeled_BPE</tabstop>
   <tabstop>N15Labeled_BPE</tabstop>
   <tabstop>S34Labeled_BPE</tabstop>
-  <tabstop>D2Labeled_Barplot</tabstop>
-  <tabstop>C13Labeled_Barplot</tabstop>
-  <tabstop>N15Labeled_Barplot</tabstop>
-  <tabstop>S34Labeled_Barplot</tabstop>
   <tabstop>D2Labeled_IsoWidget</tabstop>
   <tabstop>C13Labeled_IsoWidget</tabstop>
   <tabstop>N15Labeled_IsoWidget</tabstop>
@@ -1481,7 +1442,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>formulaWithoutOverlap</tabstop>
  </tabstops>
  <resources>
-  <include location="../mzroll.qrc"/>
   <include location="../mzroll.qrc"/>
  </resources>
  <connections>

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -52,10 +52,9 @@ void IsotopePlot::setPeakGroup(PeakGroup* group) {
         setPeakGroup(group->getParent());
     }
 
-    if ( isVisible() == true && group == _group) return;
-    _group = group;
-    //clear plot if new group is selected 
     clear();
+
+    _group = group;
 
 	_samples.clear();
 	_samples = _mw->getVisibleSamples();

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -182,7 +182,7 @@ void IsotopePlot::showBars() {
     if(!mpMouseText) return;
 
     mpMouseText->setFont(QFont("Helvetica", 12)); // make font a bit larger
-    mpMouseText->position->setType(QCPItemPosition::ptAxisRectRatio);
+    mpMouseText->position->setType(QCPItemPosition::ptPlotCoords);
     mpMouseText->setPositionAlignment(Qt::AlignLeft);
     mpMouseText->position->setCoords(QPointF(0, 0));
     mpMouseText->setText("");
@@ -228,6 +228,9 @@ void IsotopePlot::showPointToolTip(QMouseEvent *event) {
             mpMouseText->setText(name);
         }
 
+        double xPos = _mw->customPlot->xAxis->pixelToCoord(event->pos().x());
+        double yPos = _mw->customPlot->yAxis->pixelToCoord(event->pos().y());
+        mpMouseText->position->setCoords(xPos, yPos);
         mpMouseText->setFont(QFont("Helvetica", 9, QFont::Bold));
     }
     _mw->customPlot->replot();

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -187,6 +187,7 @@ void IsotopePlot::showBars() {
     mpMouseText->position->setCoords(QPointF(0, 0));
     mpMouseText->setText("");
     mpMouseText->setPen(QPen(Qt::black)); // show black border around text
+    mpMouseText->setBrush(QColor::fromRgb(255,255,255));
 
     _mw->setIsotopicPlotStyling();
     _mw->customPlot->yAxis->setRange(-0.5, MM.rows());

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -249,35 +249,3 @@ void IsotopePlot::contextMenuEvent(QContextMenuEvent * event) {
 }
 
 void IsotopePlot::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) { return; }
-
-/*
-void IsotopeBar::mouseDoubleClickEvent (QGraphicsSceneMouseEvent*event) {
-	QVariant v = data(1);
-   	PeakGroup*  x = v.value<PeakGroup*>();
-}
-
-void IsotopeBar::mousePressEvent (QGraphicsSceneMouseEvent*event) {}
-*/
-
-
-void IsotopeBar::hoverEnterEvent (QGraphicsSceneHoverEvent*event) {
-    QVariant v = data(0);
-    QString note = v.value<QString>();
-    if (note.length() == 0 ) return;
-
-    QString htmlNote = note;
-    setToolTip(note);
-    QPointF posG = mapToScene(event->pos());
-    Q_EMIT(showInfo(htmlNote, posG.x(), posG.y()+5));
-}
-
-void IsotopeBar::keyPressEvent(QKeyEvent *e) {
-    if (e->key() == Qt::Key_Delete || e->key() == Qt::Key_Backspace ) {
-        QVariant v = data(1);
-    	PeakGroup*  g = v.value<PeakGroup*>();
-        if (g && g->parent && g->parent != g) { g->parent->deleteChild(g); Q_EMIT(groupUpdated(g->parent)); }
-        IsotopePlot* parent = (IsotopePlot*) parentItem();
-        if (parent) parent->showBars();
-    }
-}
-

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -218,10 +218,11 @@ void IsotopePlot::showPointToolTip(QMouseEvent *event) {
             if (MMDuplicate(y,j)*100 > _mw->getSettings()->value("AbthresholdBarplot").toDouble()) 
             {
                 name += tr("\n %1 : %2\%").arg(_isotopes[j]->tagString.c_str(),
-                                                    QString::number(MMDuplicate(y,j)*100));
+                            QString::number(MMDuplicate(y,j)*100, 'f', 2));
             }
         }
         if(!mpMouseText) return;
+        mpMouseText->setTextAlignment(Qt::AlignLeft);
         int g = QString::compare(name, labels.at(y), Qt::CaseInsensitive);
         if(g == 0) {
             mpMouseText->setText("");

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -59,7 +59,7 @@ void IsotopePlot::setPeakGroup(PeakGroup* group) {
 	_samples.clear();
 	_samples = _mw->getVisibleSamples();
     if (_samples.size() == 0) return;
-	 sort(_samples.begin(), _samples.end(), mzSample::compSampleOrder);
+	    sort(_samples.begin(), _samples.end(), mzSample::compRevSampleOrder);
 
     _isotopes.clear();
     for(int i=0; i < group->childCountBarPlot(); i++ ) {
@@ -106,7 +106,7 @@ void IsotopePlot::showBars() {
     if (_samples.size() == 0 ) return;
 
     int visibleSamplesCount = _samples.size();
-    sort(_samples.begin(), _samples.end(), mzSample::compSampleOrder);
+    sort(_samples.begin(), _samples.end(), mzSample::compRevSampleOrder);
 
     PeakGroup::QType qtype = PeakGroup::AreaTop;
     if ( _mw ) qtype = _mw->getUserQuantType();
@@ -124,7 +124,7 @@ void IsotopePlot::showBars() {
     }
 
     labels.resize(0);
-    for(int i=0; i<MM.rows(); i++ ) {		//samples
+    for(int i=0; i<MM.rows(); i++ ) {		//samples 
         //float sum= MM.row(i).sum();
         labels << QString::fromStdString(_samples[i]->sampleName.c_str());
         //if (sum == 0) continue;

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -202,26 +202,26 @@ void IsotopePlot::showPointToolTip(QMouseEvent *event) {
     if (!event) return;
     if (_mw->customPlot->plotLayout()->elementCount() <= 0) return;
 
-    int x = _mw->customPlot->xAxis->pixelToCoord(event->pos().x());
-    double keyPixel =  _mw->customPlot->xAxis->coordToPixel(x);
-    double shiftRight =  _mw->customPlot->xAxis->coordToPixel(x + .75 * 0.5) - keyPixel;
-    x = _mw->customPlot->xAxis->pixelToCoord(event->pos().x() + shiftRight);
     int y = _mw->customPlot->yAxis->pixelToCoord(event->pos().y());
+    double keyPixel =  _mw->customPlot->yAxis->coordToPixel(y);
+    double shiftAbove =  _mw->customPlot->yAxis->coordToPixel(y + .75 * 0.5) - keyPixel;
+    y = _mw->customPlot->yAxis->pixelToCoord(event->pos().y() + shiftAbove);
+    int x = _mw->customPlot->xAxis->pixelToCoord(event->pos().x());
 
-    if (x < labels.count() && x >= 0) {
-        QString name = labels.at(x);
+    if (y < labels.count() && y >= 0) {
+        QString name = labels.at(y);
         if (MMDuplicate.cols() != _isotopes.size()) return;
 
         for(int j=0; j < MMDuplicate.cols(); j++ ) {
-            if (x  >= MMDuplicate.rows()) return;
-            if (MMDuplicate(x,j)*100 > _mw->getSettings()->value("AbthresholdBarplot").toDouble()) 
+            if (y  >= MMDuplicate.rows()) return;
+            if (MMDuplicate(y,j)*100 > _mw->getSettings()->value("AbthresholdBarplot").toDouble()) 
             {
                 name += tr("\n %1 : %2\%").arg(_isotopes[j]->tagString.c_str(),
-                                                    QString::number(MMDuplicate(x,j)*100));
+                                                    QString::number(MMDuplicate(y,j)*100));
             }
         }
         if(!mpMouseText) return;
-        int g = QString::compare(name, labels.at(x), Qt::CaseInsensitive);
+        int g = QString::compare(name, labels.at(y), Qt::CaseInsensitive);
         if(g == 0) {
             mpMouseText->setText("");
         } else {

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -154,9 +154,9 @@ void IsotopePlot::showBars() {
         isotopesType[j] = new QCPBars(_mw->customPlot->yAxis, _mw->customPlot->xAxis);
         isotopesType[j]->setAntialiased(true); // gives more crisp, pixel aligned bar borders
         isotopesType[j]->setStackingGap(0);
-        int h = j % 20;
+        int h = j % 10;
         isotopesType[j]->setPen(barPen);
-	    isotopesType[j]->setBrush(QColor::fromHsvF(h/20.0,1.0,1.0,1.0));
+	    isotopesType[j]->setBrush(QColor::fromHsvF(h/10.0,1.0,1.0,1.0));
         if (j != 0 ){
             isotopesType[j]->moveAbove(isotopesType[j - 1]);
         }

--- a/src/gui/mzroll/isotopeplot.h
+++ b/src/gui/mzroll/isotopeplot.h
@@ -11,42 +11,6 @@ class PeakGroup;
 class QGraphicsItem;
 class QGraphicsScene;
 
-class IsotopeBar : public QObject, public QGraphicsRectItem
-{
-    Q_OBJECT
-#if QT_VERSION >= 0x040600
-    Q_INTERFACES( QGraphicsItem )
-#endif
-
-	public:
-	IsotopeBar(QGraphicsItem *parent, QGraphicsScene *scene):QGraphicsRectItem(parent){
-			setFlag(ItemIsSelectable);
-			setFlag(ItemIsFocusable);
-			setAcceptHoverEvents(true);
-	}
-
-        QRectF boundingRect() {
-              return QGraphicsRectItem::boundingRect();
-        }
-
-	Q_SIGNALS:
-		void groupSelected(PeakGroup* g);
-		void groupUpdated(PeakGroup*  g);
-		void showInfo(QString,int xpos=0, int ypos=0);
-		void showMiniEICPlot(PeakGroup*g);
-
-	protected:        
-                void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) {
-                    QGraphicsRectItem::paint(painter,option,widget);
-                }
-
-	void hoverEnterEvent (QGraphicsSceneHoverEvent*event);
-//	void mouseDoubleClickEvent (QGraphicsSceneMouseEvent*event);
-//	void mousePressEvent (QGraphicsSceneMouseEvent*event);
-	void keyPressEvent(QKeyEvent *e);
-};
-
-
 class IsotopePlot : public QObject, public QGraphicsItem
 {
     Q_OBJECT

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -8,10 +8,56 @@ IsotopePlotDockWidget::IsotopePlotDockWidget(MainWindow *mw) :
     this->_mw = mw;
     ui->setupUi(this);
     setObjectName("IsotopePlotDockWidget");
-    setWindowTitle("Isotope Plot: ");
+
+    setToolBar();
+
 }
 
 IsotopePlotDockWidget::~IsotopePlotDockWidget()
 {
     delete ui;
+}
+
+void IsotopePlotDockWidget::setToolBar()
+{
+    QToolBar *toolBar = new QToolBar(this);
+    toolBar->setFloatable(false);
+    toolBar->setMovable(false);
+
+    QLabel *title = new QLabel("Isotope Plot: ");
+    toolBar->addWidget(title);
+
+    QWidget* spacer1 = new QWidget();
+    spacer1->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar->addWidget(spacer1);
+
+    QCheckBox *C13 = new QCheckBox("C13");
+    C13->setChecked(true);
+    toolBar->addWidget(C13);
+
+    QWidget *spacer2 = new QWidget();
+    spacer2->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar->addWidget(spacer2);
+
+    QCheckBox *N15 = new QCheckBox("N15");
+    N15->setChecked(true);
+    toolBar->addWidget(N15);
+
+    QWidget *spacer3 = new QWidget();
+    spacer3->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar->addWidget(spacer3);
+
+    QCheckBox *D2 = new QCheckBox("D2");
+    D2->setChecked(true);
+    toolBar->addWidget(D2);
+
+    QWidget *spacer4 = new QWidget();
+    spacer4->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar->addWidget(spacer4);
+
+    QCheckBox *S34 = new QCheckBox("S34");
+    S34->setChecked(true);
+    toolBar->addWidget(S34);
+
+    setTitleBarWidget(toolBar);
 }

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -62,11 +62,32 @@ void IsotopePlotDockWidget::setToolBar()
     setTitleBarWidget(toolBar);
 
     connect(C13, SIGNAL(toggled(bool)), this, SLOT(updateC13Flag(bool)));
+    connect(N15, SIGNAL(toggled(bool)), this, SLOT(updateN15Flag(bool)));
+    connect(D2, SIGNAL(toggled(bool)), this, SLOT(updateD2Flag(bool)));
+    connect(S34, SIGNAL(toggled(bool)), this, SLOT(updateS34Flag(bool)));
 }
 
 void IsotopePlotDockWidget::updateC13Flag(bool setState)
 {
     _mw->mavenParameters->C13Labeled_Barplot = setState;
+    recompute();
+}
+
+void IsotopePlotDockWidget::updateN15Flag(bool setState)
+{
+    _mw->mavenParameters->N15Labeled_Barplot = setState;
+    recompute();
+}
+
+void IsotopePlotDockWidget::updateD2Flag(bool setState)
+{
+    _mw->mavenParameters->D2Labeled_Barplot = setState;
+    recompute();
+}
+
+void IsotopePlotDockWidget::updateS34Flag(bool setState)
+{
+    _mw->mavenParameters->S34Labeled_Barplot = setState;
     recompute();
 }
 

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -60,4 +60,24 @@ void IsotopePlotDockWidget::setToolBar()
     toolBar->addWidget(S34);
 
     setTitleBarWidget(toolBar);
+
+    connect(C13, SIGNAL(toggled(bool)), this, SLOT(updateC13Flag(bool)));
+}
+
+void IsotopePlotDockWidget::updateC13Flag(bool setState)
+{
+    _mw->mavenParameters->C13Labeled_Barplot = setState;
+    recompute();
+}
+
+void IsotopePlotDockWidget::recompute()
+{
+    if (_mw->getEicWidget()->isVisible()) {
+        PeakGroup* group = _mw->getEicWidget()->getParameters()->getSelectedGroup();
+        if (group)
+        {
+            group->childrenBarPlot.clear();
+            _mw->isotopeWidget->updateIsotopicBarplot(group);
+        }
+    }
 }

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -11,6 +11,7 @@ IsotopePlotDockWidget::IsotopePlotDockWidget(MainWindow *mw) :
 
     setToolBar();
 
+    setWindowTitle("Isotope Plot: ");
 }
 
 IsotopePlotDockWidget::~IsotopePlotDockWidget()

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -40,7 +40,7 @@ void IsotopePlotDockWidget::setToolBar()
     toolBar->addWidget(spacer2);
 
     QCheckBox *N15 = new QCheckBox("N15");
-    N15->setChecked(true);
+    N15->setChecked(false);
     toolBar->addWidget(N15);
 
     QWidget *spacer3 = new QWidget();
@@ -48,7 +48,7 @@ void IsotopePlotDockWidget::setToolBar()
     toolBar->addWidget(spacer3);
 
     QCheckBox *D2 = new QCheckBox("D2");
-    D2->setChecked(true);
+    D2->setChecked(false);
     toolBar->addWidget(D2);
 
     QWidget *spacer4 = new QWidget();
@@ -56,7 +56,7 @@ void IsotopePlotDockWidget::setToolBar()
     toolBar->addWidget(spacer4);
 
     QCheckBox *S34 = new QCheckBox("S34");
-    S34->setChecked(true);
+    S34->setChecked(false);
     toolBar->addWidget(S34);
 
     setTitleBarWidget(toolBar);

--- a/src/gui/mzroll/isotopeplotdockwidget.h
+++ b/src/gui/mzroll/isotopeplotdockwidget.h
@@ -19,6 +19,7 @@ public:
 private:
     Ui::IsotopePlotDockWidget *ui;
     MainWindow *_mw;
+    void setToolBar();
 };
 
 #endif // ISOTOPEPLOTDOCKWIDGET_H

--- a/src/gui/mzroll/isotopeplotdockwidget.h
+++ b/src/gui/mzroll/isotopeplotdockwidget.h
@@ -18,6 +18,9 @@ public:
 
 private Q_SLOTS:
     void updateC13Flag(bool setState);
+    void updateN15Flag(bool setState);
+    void updateD2Flag(bool setState);
+    void updateS34Flag(bool setState);
 
 private:
     Ui::IsotopePlotDockWidget *ui;

--- a/src/gui/mzroll/isotopeplotdockwidget.h
+++ b/src/gui/mzroll/isotopeplotdockwidget.h
@@ -16,10 +16,14 @@ public:
     explicit IsotopePlotDockWidget(MainWindow *mw = 0);
     ~IsotopePlotDockWidget();
 
+private Q_SLOTS:
+    void updateC13Flag(bool setState);
+
 private:
     Ui::IsotopePlotDockWidget *ui;
     MainWindow *_mw;
     void setToolBar();
+    void recompute();
 };
 
 #endif // ISOTOPEPLOTDOCKWIDGET_H

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -403,8 +403,6 @@ void IsotopeWidget::setClipboard()
 
 void IsotopeWidget::updateIsotopicBarplot()
 {
-	_mw->isotopePlotDockWidget->show();
-	_mw->isotopePlotDockWidget->raise();
 	if (isotopeParametersBarPlot->_group)
 	{
 		_mw->isotopePlot->setPeakGroup(isotopeParametersBarPlot->_group);

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -366,7 +366,6 @@ using namespace mzUtils;
 	alignmentVizDockWidget->setVisible(false);
 	alignmentPolyVizDockWidget->setVisible(false);
 	alignmentVizAllGroupsDockWidget->setVisible(false);
-	isotopePlotDockWidget->show();
 	scatterDockWidget->setVisible(false);
 	notesDockWidget->setVisible(false);
 	heatMapDockWidget->setVisible(false);
@@ -3352,12 +3351,8 @@ QWidget* MainWindowWidgetAction::createWidget(QWidget *parent) {
 		btnShowIsotopeplot->setToolTip(tr("Show Isotope Plot"));
 		btnShowIsotopeplot->setCheckable(true);
 
-		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw, SLOT(toggleIsotopicBarPlot()));
+		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw, SLOT(toggleIsotopicBarPlot(bool)));
 		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw->isotopeWidget, SLOT(updateIsotopicBarplot()));
-
-		btnShowIsotopeplot->setChecked(mw->isotopePlotDockWidget->isVisible());
-		connect(mw->isotopePlotDockWidget, SIGNAL(visibilityChanged(bool)), btnShowIsotopeplot,
-				SLOT(setChecked(bool)));
 
 		return btnShowIsotopeplot;
 
@@ -3591,13 +3586,14 @@ int MainWindow::versionCheck() {
 	return 0;
 }
 
-void MainWindow::toggleIsotopicBarPlot()
+void MainWindow::toggleIsotopicBarPlot(bool show)
 {
-	if (isotopePlotDockWidget->isVisible()) {
-		isotopePlotDockWidget->hide();
+	if (show) {
+		isotopePlotDockWidget->show();
+		isotopePlotDockWidget->raise();
 	}
 	else {
-		isotopePlotDockWidget->show();
+		isotopePlotDockWidget->hide();
 	}
 }
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3615,7 +3615,7 @@ MatrixXf MainWindow::getIsotopicMatrix(PeakGroup* group) {
 	PeakGroup::QType qtype = getUserQuantType();
 	//get visiable samples
 	vector<mzSample*> vsamples = getVisibleSamples();
-	sort(vsamples.begin(), vsamples.end(), mzSample::compSampleOrder);
+	sort(vsamples.begin(), vsamples.end(), mzSample::compRevSampleOrder);
 	map<unsigned int, string> carbonIsotopeSpecies;
 
 	//get isotopic groups

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -406,7 +406,7 @@ private Q_SLOTS:
 	void checkSRMList();
 	void readSettings();
 	void writeSettings();
-	void toggleIsotopicBarPlot();
+	void toggleIsotopicBarPlot(bool show);
 	inline void slotReboot() {
  		qDebug() << "Performing application reboot...";
 		QString rep = QDir::cleanPath(QCoreApplication::applicationFilePath());

--- a/src/gui/mzroll/settingsform.cpp
+++ b/src/gui/mzroll/settingsform.cpp
@@ -24,11 +24,6 @@ OptionsDialogSettings::OptionsDialogSettings(SettingsForm* dialog): sf(dialog)
     settings.insert("N15Labeled_BPE", QVariant::fromValue(sf->N15Labeled_BPE));
     settings.insert("S34Labeled_BPE", QVariant::fromValue(sf->S34Labeled_BPE));
 
-    settings.insert("D2Labeled_Barplot", QVariant::fromValue(sf->D2Labeled_Barplot));
-    settings.insert("C13Labeled_Barplot", QVariant::fromValue(sf->C13Labeled_Barplot));
-    settings.insert("N15Labeled_Barplot", QVariant::fromValue(sf->N15Labeled_Barplot));
-    settings.insert("S34Labeled_Barplot", QVariant::fromValue(sf->S34Labeled_Barplot));
-
     settings.insert("D2Labeled_IsoWidget", QVariant::fromValue(sf->D2Labeled_IsoWidget));
     settings.insert("C13Labeled_IsoWidget", QVariant::fromValue(sf->C13Labeled_IsoWidget));
     settings.insert("N15Labeled_IsoWidget", QVariant::fromValue(sf->N15Labeled_IsoWidget));
@@ -123,11 +118,6 @@ SettingsForm::SettingsForm(QSettings* s, MainWindow *w): QDialog(w) {
     connect(N15Labeled_BPE,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
     connect(S34Labeled_BPE,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
     connect(D2Labeled_BPE, SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
-        //isotope detection setting
-    connect(C13Labeled_Barplot,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
-    connect(N15Labeled_Barplot,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
-    connect(S34Labeled_Barplot,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
-    connect(D2Labeled_Barplot, SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));
     connect(doubleSpinBoxAbThresh, SIGNAL(valueChanged(double)),SLOT(recomputeIsotopes()));
         //isotope detection setting
     connect(C13Labeled_IsoWidget,SIGNAL(toggled(bool)),SLOT(recomputeIsotopes()));


### PR DESCRIPTION
Changes made in this PR:

- Delete redundant IsotopeBar class and related functions
- Remove Isotope plot label checkboxes from Options dialog
- Add label checkboxes to isotope Plot toolbar. C13 checked by default.
- Update plot on interacting with checkboxes
- Reduce number of shades to 10 for easier distinction between labels