### PR TITLE
Sort sample bars in isoPlot according to other widgets

### DIFF
--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -455,6 +455,14 @@ class PeakGroup{
         static bool compMz(const PeakGroup& a, const PeakGroup& b ) { return(a.meanMz > b.meanMz); }
 
         /**
+         * @brief sort isotopes in natural order
+         * @param a reference to PeakGroup object
+         * @param b reference to PeakGroup object
+         * @return True if tagString of a is lesser than b
+         **/
+        static bool compTagString(const PeakGroup& a, const PeakGroup& b ) { return mzUtils::strcasecmp_withNumbers(a.tagString, b.tagString); }
+        
+        /**
          * [compIntensity ]
          * @method compIntensity
          * @param  a             []

--- a/src/core/libmaven/isotopeDetection.cpp
+++ b/src/core/libmaven/isotopeDetection.cpp
@@ -45,6 +45,8 @@ void IsotopeDetection::pullIsotopes(PeakGroup* parentgroup)
 
     addIsotopes(parentgroup, isotopes);
 
+    sortIsotopes(parentgroup);
+
 }
 
 map<string, PeakGroup> IsotopeDetection::getIsotopes(PeakGroup* parentgroup, vector<Isotope> masslist)
@@ -344,4 +346,17 @@ bool IsotopeDetection::filterLabel(string isotopeName)
 
     return true;
 
+}
+
+void IsotopeDetection::sortIsotopes(PeakGroup *group)
+{
+    if (group->children.size())
+        sort(group->children.begin(), group->children.end(), PeakGroup::compTagString);
+    
+    if (group->childrenBarPlot.size())
+        sort(group->childrenBarPlot.begin(), group->childrenBarPlot.end(), PeakGroup::compTagString);
+    
+    if (group->childrenIsoWidget.size())
+        sort(group->childrenIsoWidget.begin(), group->childrenIsoWidget.end(), PeakGroup::compTagString);
+    
 }

--- a/src/core/libmaven/isotopeDetection.h
+++ b/src/core/libmaven/isotopeDetection.h
@@ -55,6 +55,7 @@ class IsotopeDetection
 	bool filterLabel(string isotopeName);
 	void addChild(PeakGroup *parentgroup, PeakGroup &child, string isotopeName);
 	bool checkChildExist(vector<PeakGroup> &children, string isotopeName);
+	void sortIsotopes(PeakGroup *group);
 
 };
 

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -557,6 +557,14 @@ class mzSample
                           */
     static bool compSampleOrder(const mzSample *a, const mzSample *b) { return a->_sampleOrder < b->_sampleOrder; }
 
+    /**
+     * @brief Compare sample order of two samples
+     * @param a object of class mzSample
+     * @param b object of class mzSample
+     * @return True if sample order of 'a' is higher than 'b' else false
+     **/
+    static bool compRevSampleOrder(const mzSample *a, const mzSample *b) { return a->_sampleOrder > b->_sampleOrder; }
+
     static bool compSampleSort(const mzSample *a, const mzSample *b) { return mzUtils::strcasecmp_withNumbers(a->sampleName, b->sampleName); }
 
     /**

--- a/src/gui/mzroll/forms/isotopeplotdockwidget.ui
+++ b/src/gui/mzroll/forms/isotopeplotdockwidget.ui
@@ -1,4 +1,7 @@
+<<<<<<< c9b211be62274ef911e081ba108599510c814283
 <?xml version="1.0" encoding="UTF-8"?>
+=======
+>>>>>>> [UI] Move isotope plot to a dockwidget
 <ui version="4.0">
  <class>IsotopePlotDockWidget</class>
  <widget class="QDockWidget" name="IsotopePlotDockWidget">

--- a/src/gui/mzroll/forms/isotopeplotdockwidget.ui
+++ b/src/gui/mzroll/forms/isotopeplotdockwidget.ui
@@ -1,7 +1,4 @@
-<<<<<<< c9b211be62274ef911e081ba108599510c814283
 <?xml version="1.0" encoding="UTF-8"?>
-=======
->>>>>>> [UI] Move isotope plot to a dockwidget
 <ui version="4.0">
  <class>IsotopePlotDockWidget</class>
  <widget class="QDockWidget" name="IsotopePlotDockWidget">

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -182,7 +182,7 @@ void IsotopePlot::showBars() {
     if(!mpMouseText) return;
 
     mpMouseText->setFont(QFont("Helvetica", 12)); // make font a bit larger
-    mpMouseText->position->setType(QCPItemPosition::ptAxisRectRatio);
+    mpMouseText->position->setType(QCPItemPosition::ptPlotCoords);
     mpMouseText->setPositionAlignment(Qt::AlignLeft);
     mpMouseText->position->setCoords(QPointF(0, 0));
     mpMouseText->setText("");
@@ -228,6 +228,9 @@ void IsotopePlot::showPointToolTip(QMouseEvent *event) {
             mpMouseText->setText(name);
         }
 
+        double xPos = _mw->customPlot->xAxis->pixelToCoord(event->pos().x());
+        double yPos = _mw->customPlot->yAxis->pixelToCoord(event->pos().y());
+        mpMouseText->position->setCoords(xPos, yPos);
         mpMouseText->setFont(QFont("Helvetica", 9, QFont::Bold));
     }
     _mw->customPlot->replot();

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -187,6 +187,7 @@ void IsotopePlot::showBars() {
     mpMouseText->position->setCoords(QPointF(0, 0));
     mpMouseText->setText("");
     mpMouseText->setPen(QPen(Qt::black)); // show black border around text
+    mpMouseText->setBrush(QColor::fromRgb(255,255,255));
 
     _mw->setIsotopicPlotStyling();
     _mw->customPlot->yAxis->setRange(-0.5, MM.rows());

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -218,10 +218,11 @@ void IsotopePlot::showPointToolTip(QMouseEvent *event) {
             if (MMDuplicate(y,j)*100 > _mw->getSettings()->value("AbthresholdBarplot").toDouble()) 
             {
                 name += tr("\n %1 : %2\%").arg(_isotopes[j]->tagString.c_str(),
-                                                    QString::number(MMDuplicate(y,j)*100));
+                            QString::number(MMDuplicate(y,j)*100, 'f', 2));
             }
         }
         if(!mpMouseText) return;
+        mpMouseText->setTextAlignment(Qt::AlignLeft);
         int g = QString::compare(name, labels.at(y), Qt::CaseInsensitive);
         if(g == 0) {
             mpMouseText->setText("");

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -59,7 +59,7 @@ void IsotopePlot::setPeakGroup(PeakGroup* group) {
 	_samples.clear();
 	_samples = _mw->getVisibleSamples();
     if (_samples.size() == 0) return;
-	 sort(_samples.begin(), _samples.end(), mzSample::compSampleOrder);
+	    sort(_samples.begin(), _samples.end(), mzSample::compRevSampleOrder);
 
     _isotopes.clear();
     for(int i=0; i < group->childCountBarPlot(); i++ ) {
@@ -106,7 +106,7 @@ void IsotopePlot::showBars() {
     if (_samples.size() == 0 ) return;
 
     int visibleSamplesCount = _samples.size();
-    sort(_samples.begin(), _samples.end(), mzSample::compSampleOrder);
+    sort(_samples.begin(), _samples.end(), mzSample::compRevSampleOrder);
 
     PeakGroup::QType qtype = PeakGroup::AreaTop;
     if ( _mw ) qtype = _mw->getUserQuantType();
@@ -124,7 +124,7 @@ void IsotopePlot::showBars() {
     }
 
     labels.resize(0);
-    for(int i=0; i<MM.rows(); i++ ) {		//samples
+    for(int i=0; i<MM.rows(); i++ ) {		//samples 
         //float sum= MM.row(i).sum();
         labels << QString::fromStdString(_samples[i]->sampleName.c_str());
         //if (sum == 0) continue;

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -202,26 +202,26 @@ void IsotopePlot::showPointToolTip(QMouseEvent *event) {
     if (!event) return;
     if (_mw->customPlot->plotLayout()->elementCount() <= 0) return;
 
-    int x = _mw->customPlot->xAxis->pixelToCoord(event->pos().x());
-    double keyPixel =  _mw->customPlot->xAxis->coordToPixel(x);
-    double shiftRight =  _mw->customPlot->xAxis->coordToPixel(x + .75 * 0.5) - keyPixel;
-    x = _mw->customPlot->xAxis->pixelToCoord(event->pos().x() + shiftRight);
     int y = _mw->customPlot->yAxis->pixelToCoord(event->pos().y());
+    double keyPixel =  _mw->customPlot->yAxis->coordToPixel(y);
+    double shiftAbove =  _mw->customPlot->yAxis->coordToPixel(y + .75 * 0.5) - keyPixel;
+    y = _mw->customPlot->yAxis->pixelToCoord(event->pos().y() + shiftAbove);
+    int x = _mw->customPlot->xAxis->pixelToCoord(event->pos().x());
 
-    if (x < labels.count() && x >= 0) {
-        QString name = labels.at(x);
+    if (y < labels.count() && y >= 0) {
+        QString name = labels.at(y);
         if (MMDuplicate.cols() != _isotopes.size()) return;
 
         for(int j=0; j < MMDuplicate.cols(); j++ ) {
-            if (x  >= MMDuplicate.rows()) return;
-            if (MMDuplicate(x,j)*100 > _mw->getSettings()->value("AbthresholdBarplot").toDouble()) 
+            if (y  >= MMDuplicate.rows()) return;
+            if (MMDuplicate(y,j)*100 > _mw->getSettings()->value("AbthresholdBarplot").toDouble()) 
             {
                 name += tr("\n %1 : %2\%").arg(_isotopes[j]->tagString.c_str(),
-                                                    QString::number(MMDuplicate(x,j)*100));
+                                                    QString::number(MMDuplicate(y,j)*100));
             }
         }
         if(!mpMouseText) return;
-        int g = QString::compare(name, labels.at(x), Qt::CaseInsensitive);
+        int g = QString::compare(name, labels.at(y), Qt::CaseInsensitive);
         if(g == 0) {
             mpMouseText->setText("");
         } else {

--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -11,6 +11,7 @@ IsotopePlotDockWidget::IsotopePlotDockWidget(MainWindow *mw) :
 
     setToolBar();
 
+    setWindowTitle("Isotope Plot: ");
 }
 
 IsotopePlotDockWidget::~IsotopePlotDockWidget()

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -403,8 +403,6 @@ void IsotopeWidget::setClipboard()
 
 void IsotopeWidget::updateIsotopicBarplot()
 {
-	_mw->isotopePlotDockWidget->show();
-	_mw->isotopePlotDockWidget->raise();
 	if (isotopeParametersBarPlot->_group)
 	{
 		_mw->isotopePlot->setPeakGroup(isotopeParametersBarPlot->_group);

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -366,7 +366,6 @@ using namespace mzUtils;
 	alignmentVizDockWidget->setVisible(false);
 	alignmentPolyVizDockWidget->setVisible(false);
 	alignmentVizAllGroupsDockWidget->setVisible(false);
-	isotopePlotDockWidget->show();
 	scatterDockWidget->setVisible(false);
 	notesDockWidget->setVisible(false);
 	heatMapDockWidget->setVisible(false);
@@ -3352,12 +3351,8 @@ QWidget* MainWindowWidgetAction::createWidget(QWidget *parent) {
 		btnShowIsotopeplot->setToolTip(tr("Show Isotope Plot"));
 		btnShowIsotopeplot->setCheckable(true);
 
-		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw, SLOT(toggleIsotopicBarPlot()));
+		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw, SLOT(toggleIsotopicBarPlot(bool)));
 		connect(btnShowIsotopeplot,SIGNAL(clicked(bool)), mw->isotopeWidget, SLOT(updateIsotopicBarplot()));
-
-		btnShowIsotopeplot->setChecked(mw->isotopePlotDockWidget->isVisible());
-		connect(mw->isotopePlotDockWidget, SIGNAL(visibilityChanged(bool)), btnShowIsotopeplot,
-				SLOT(setChecked(bool)));
 
 		return btnShowIsotopeplot;
 
@@ -3591,13 +3586,14 @@ int MainWindow::versionCheck() {
 	return 0;
 }
 
-void MainWindow::toggleIsotopicBarPlot()
+void MainWindow::toggleIsotopicBarPlot(bool show)
 {
-	if (isotopePlotDockWidget->isVisible()) {
-		isotopePlotDockWidget->hide();
+	if (show) {
+		isotopePlotDockWidget->show();
+		isotopePlotDockWidget->raise();
 	}
 	else {
-		isotopePlotDockWidget->show();
+		isotopePlotDockWidget->hide();
 	}
 }
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3615,7 +3615,7 @@ MatrixXf MainWindow::getIsotopicMatrix(PeakGroup* group) {
 	PeakGroup::QType qtype = getUserQuantType();
 	//get visiable samples
 	vector<mzSample*> vsamples = getVisibleSamples();
-	sort(vsamples.begin(), vsamples.end(), mzSample::compSampleOrder);
+	sort(vsamples.begin(), vsamples.end(), mzSample::compRevSampleOrder);
 	map<unsigned int, string> carbonIsotopeSpecies;
 
 	//get isotopic groups

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -406,7 +406,7 @@ private Q_SLOTS:
 	void checkSRMList();
 	void readSettings();
 	void writeSettings();
-	void toggleIsotopicBarPlot();
+	void toggleIsotopicBarPlot(bool show);
 	inline void slotReboot() {
  		qDebug() << "Performing application reboot...";
 		QString rep = QDir::cleanPath(QCoreApplication::applicationFilePath());


### PR DESCRIPTION
Sample bars in isoPlot are in reverse order compared to every other part of the code. This has been fixed by adding a reverse function for sample order.