### PR TITLE
[fix] crash on sample deletion

### DIFF
--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -921,4 +921,12 @@ void ProjectDockWidget::unloadSample(mzSample* sample) {
             break;
         }
     }
+
+    //remove sample from maven parameters sample list
+    for(unsigned int i=0; i<_mainwindow->mavenParameters->samples.size(); i++) {
+        if (_mainwindow->mavenParameters->samples[i] == sample) {
+            _mainwindow->mavenParameters->samples.erase( _mainwindow->mavenParameters->samples.begin()+i);
+            break;
+        }
+    }
 }


### PR DESCRIPTION
Delete samples crash occurred when deleting the first sample and then uploading a file. The fix was to update the samples vector in maven parameters.