### PR TITLE
Mass Slicing correlation based post processing #152

### DIFF
--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -285,65 +285,59 @@ bool duplicateComparator(struct customGroup x,struct customGroup y){
     }
     return false;
 }
+vector<PeakGroup> getUnique(vector<customGroup> custom_groups){
+    vector<PeakGroup> returnGroups;
+    int nvec=custom_groups.size();
+    for(int i=0;i<nvec;i++){
+        for(int j=i+1;j<nvec;j++){
+            if(!duplicateComparator(custom_groups[i], custom_groups[j])){
+                returnGroups.push_back(custom_groups[i].actual_vec);
+            }
+        }
+    }
+    return returnGroups;
+}
 
 void PeakDetector::deleteDuplicateGroup(){
-    // double mzdiff=0.01;
-    // double rtdiff=0.1;
-    // double corrthresh=0.99;
-    vector<PeakGroup> finalPeakGroups=mavenParameters->allgroups;
-
-    unsigned int n=finalPeakGroups.size();
-    cerr<< "Group Specific: " << n << endl;
+    double mzdiff=0.01;
+    double rtdiff=0.1;
+    double corrthresh=0.99;
+    vector_intensity_array.clear();
+    vector_mz_array.clear();
+    vector_rt_array.clear();
+    unsigned int n=mavenParameters->allgroups.size();
+    // cerr<< "Group Specific: " << n << endl;
     vector<float> temp;
-    vector<customGroup> processedGroups;
-    for(int i=0;i<n;i++){
-        customGroup tempGroup;        
-        for(int j=0;j<finalPeakGroups[i].peaks.size();j++){
-            temp.push_back(finalPeakGroups[i].peaks[j].peakIntensity);
+    for(unsigned int i=0;i<n;i++){
+        temp.clear();
+        for(unsigned int j=0;j<mavenParameters->allgroups[i].peaks.size();j++){
+            temp.push_back(mavenParameters->allgroups[i].peaks[j].peakIntensity);
         }
-        tempGroup.intensity_vec=temp;
-        tempGroup.actual_vec=finalPeakGroups[i];
-        tempGroup.mz=finalPeakGroups[i].meanMz;
-        tempGroup.rt=finalPeakGroups[i].meanRt;
-        processedGroups.push_back(tempGroup);
+        vector_intensity_array.push_back(temp);
+        vector_mz_array.push_back(mavenParameters->allgroups[i].meanMz);
+        vector_rt_array.push_back(mavenParameters->allgroups[i].meanRt);
     }
-    cerr << "Processed Group size "<<processedGroups.size()<< endl;
-    unique(processedGroups.begin(),processedGroups.end(), duplicateComparator);
-    cerr << "Post Processed Group size "<< processedGroups.size() << endl;
-
-    // int dup_count=0;
-    // int outer_ind=0,inner_ind=0;
-    // int tot_count=finalPeakGroups.size();
-    // while(outer_ind<tot_count){
-    //     inner_ind=outer_ind+1;
-    //     while(inner_ind<tot_count){
-    //         if(abs(vector_mz_array[outer_ind]-vector_mz_array[inner_ind])<=mzdiff && abs(vector_rt_array[outer_ind]-vector_rt_array[inner_ind])<=rtdiff){
-    //             float pearsoncorr=mzUtils::correlation(vector_intensity_array[outer_ind],vector_intensity_array[inner_ind]);
-    //             // cerr << abs(vector_mz_array[outer_ind]-vector_mz_array[inner_ind]) << endl;
-    //             // cerr << pearsoncorr << endl;
-    //             if(pearsoncorr>0.99){
-    //                 dup_count++;
-    //                 finalPeakGroups.erase(finalPeakGroups.begin()+inner_ind);
-    //                 tot_count=finalPeakGroups.size();
-    //                 vector_intensity_array.erase(vector_intensity_array.begin()+inner_ind);
-    //                 vector_mz_array.erase(vector_mz_array.begin()+inner_ind);
-    //                 vector_rt_array.erase(vector_rt_array.begin()+inner_ind);
-    //             }
-    //         }
-    //         // cerr<<"mayank"<<outer_ind<<" "<<inner_ind<<" "<<tot_count << endl;
-    //         inner_ind++;
-    //     }
-    //     // cerr <<"How can this end?"<< outer_ind<< endl;
-    //     outer_ind++;
-    // }
-    // cerr<< "duplicates"<< dup_count<< endl;
-    // // cerr << finalPeakGroups.size() << endl;
-    
-    // mavenParameters->allgroups.clear();
-    // for(unsigned int i=0;i<finalPeakGroups.size();i++){
-    //     mavenParameters->allgroups.push_back(finalPeakGroups[i]);
-    // }
-    cerr << "Correlation Specific Post Process" << endl;
+    int dup_count=0;
+    int nvec=mavenParameters->allgroups.size();
+    int duplicate_flag=0;
+    vector<PeakGroup>  returnPeakGroup;
+    for(unsigned int i=0;i<mavenParameters->allgroups.size();i++){
+        duplicate_flag=0;
+        for(unsigned int j=i+1;j<mavenParameters->allgroups.size();j++){
+            if(abs(vector_mz_array[i]-vector_mz_array[j])<=mzdiff && abs(vector_rt_array[i]-vector_rt_array[j])<=rtdiff){
+                float pearsoncorr=mzUtils::correlation(vector_intensity_array[i],vector_intensity_array[j]);
+                if(pearsoncorr>corrthresh){
+                    duplicate_flag=1;
+                }
+            }
+        }
+        if(duplicate_flag==0){
+            returnPeakGroup.push_back(mavenParameters->allgroups[i]);
+        }
+    }
+    mavenParameters->allgroups.clear();
+    mavenParameters->allgroups=returnPeakGroup;
+    cerr << "Correlation Based duplicate removal" << endl;
 }
 
 void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -274,29 +274,6 @@ void PeakDetector::alignSamples() {
         }
 }
 
-bool duplicateComparator(struct customGroup x,struct customGroup y){
-    float pearsoncorr;
-    if(abs(x.mz-y.mz)<=0.01 && abs(x.rt-y.rt)<0.1){
-        pearsoncorr=mzUtils::correlation(x.intensity_vec,y.intensity_vec);
-        if(pearsoncorr>0.99){
-            return true;
-        }
-
-    }
-    return false;
-}
-vector<PeakGroup> getUnique(vector<customGroup> custom_groups){
-    vector<PeakGroup> returnGroups;
-    int nvec=custom_groups.size();
-    for(int i=0;i<nvec;i++){
-        for(int j=i+1;j<nvec;j++){
-            if(!duplicateComparator(custom_groups[i], custom_groups[j])){
-                returnGroups.push_back(custom_groups[i].actual_vec);
-            }
-        }
-    }
-    return returnGroups;
-}
 
 void PeakDetector::deleteDuplicateGroup(){
     double mzdiff=0.01;

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -274,49 +274,6 @@ void PeakDetector::alignSamples() {
         }
 }
 
-
-void PeakDetector::deleteDuplicateGroup(){
-    double mzdiff=0.01;
-    double rtdiff=0.1;
-    double corrthresh=0.99;
-    vector_intensity_array.clear();
-    vector_mz_array.clear();
-    vector_rt_array.clear();
-    unsigned int n=mavenParameters->allgroups.size();
-    // cerr<< "Group Specific: " << n << endl;
-    vector<float> temp;
-    for(unsigned int i=0;i<n;i++){
-        temp.clear();
-        for(unsigned int j=0;j<mavenParameters->allgroups[i].peaks.size();j++){
-            temp.push_back(mavenParameters->allgroups[i].peaks[j].peakIntensity);
-        }
-        vector_intensity_array.push_back(temp);
-        vector_mz_array.push_back(mavenParameters->allgroups[i].meanMz);
-        vector_rt_array.push_back(mavenParameters->allgroups[i].meanRt);
-    }
-    int dup_count=0;
-    int nvec=mavenParameters->allgroups.size();
-    int duplicate_flag=0;
-    vector<PeakGroup>  returnPeakGroup;
-    for(unsigned int i=0;i<mavenParameters->allgroups.size();i++){
-        duplicate_flag=0;
-        for(unsigned int j=i+1;j<mavenParameters->allgroups.size();j++){
-            if(abs(vector_mz_array[i]-vector_mz_array[j])<=mzdiff && abs(vector_rt_array[i]-vector_rt_array[j])<=rtdiff){
-                float pearsoncorr=mzUtils::correlation(vector_intensity_array[i],vector_intensity_array[j]);
-                if(pearsoncorr>corrthresh){
-                    duplicate_flag=1;
-                }
-            }
-        }
-        if(duplicate_flag==0){
-            returnPeakGroup.push_back(mavenParameters->allgroups[i]);
-        }
-    }
-    mavenParameters->allgroups.clear();
-    mavenParameters->allgroups=returnPeakGroup;
-    cerr << "Correlation Based duplicate removal" << endl;
-}
-
 void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)
 {
 

--- a/src/core/libmaven/PeakDetector.h
+++ b/src/core/libmaven/PeakDetector.h
@@ -159,15 +159,6 @@ private:
 	MavenParameters* mavenParameters;
 	bool zeroStatus;
 };
-/**
- * struct for duplicateDeletion
- */
-struct customGroup{
-	vector<float> intensity_vec;
-	PeakGroup actual_vec;
-	float mz;
-	float rt;
-};
 
 /**
  * struct for EicLoader

--- a/src/core/libmaven/PeakDetector.h
+++ b/src/core/libmaven/PeakDetector.h
@@ -45,10 +45,6 @@ class PeakDetector {
 public:
     boost::signals2::signal< void (const string&,unsigned int , int ) > boostSignal;
 	
-	vector<vector<float>> vector_intensity_array;
-	vector<float> vector_mz_array;
-	vector<float> vector_rt_array;
-	
 	PeakDetector();
 	PeakDetector(MavenParameters* mp);
 
@@ -69,9 +65,6 @@ public:
     {
     boostSignal(progressText, completed_slices, total_slices);
     }
-
-	void deleteDuplicateGroup();
-	// bool duplicateComparator(struct customGroup x,struct customGroup y);
 
 	void resetProgressBar();
 

--- a/src/core/libmaven/PeakDetector.h
+++ b/src/core/libmaven/PeakDetector.h
@@ -44,9 +44,11 @@
 class PeakDetector {
 public:
     boost::signals2::signal< void (const string&,unsigned int , int ) > boostSignal;
-	// vector<vector<float>> vector_intensity_array;
-	// vector<float> vector_mz_array;
-	// vector<float> vector_rt_array;
+	
+	vector<vector<float>> vector_intensity_array;
+	vector<float> vector_mz_array;
+	vector<float> vector_rt_array;
+	
 	PeakDetector();
 	PeakDetector(MavenParameters* mp);
 

--- a/src/core/libmaven/PeakDetector.h
+++ b/src/core/libmaven/PeakDetector.h
@@ -44,9 +44,9 @@
 class PeakDetector {
 public:
     boost::signals2::signal< void (const string&,unsigned int , int ) > boostSignal;
-	vector<vector<float>> vector_intensity_array;
-	vector<float> vector_mz_array;
-	vector<float> vector_rt_array;
+	// vector<vector<float>> vector_intensity_array;
+	// vector<float> vector_mz_array;
+	// vector<float> vector_rt_array;
 	PeakDetector();
 	PeakDetector(MavenParameters* mp);
 
@@ -69,6 +69,8 @@ public:
     }
 
 	void deleteDuplicateGroup();
+	// bool duplicateComparator(struct customGroup x,struct customGroup y);
+
 	void resetProgressBar();
 
 	/**
@@ -154,6 +156,15 @@ private:
 	bool addPeakGroup(PeakGroup& grup1);
 	MavenParameters* mavenParameters;
 	bool zeroStatus;
+};
+/**
+ * struct for duplicateDeletion
+ */
+struct customGroup{
+	vector<float> intensity_vec;
+	PeakGroup actual_vec;
+	float mz;
+	float rt;
 };
 
 /**

--- a/src/core/libmaven/PeakDetector.h
+++ b/src/core/libmaven/PeakDetector.h
@@ -44,7 +44,9 @@
 class PeakDetector {
 public:
     boost::signals2::signal< void (const string&,unsigned int , int ) > boostSignal;
-
+	vector<vector<float>> vector_intensity_array;
+	vector<float> vector_mz_array;
+	vector<float> vector_rt_array;
 	PeakDetector();
 	PeakDetector(MavenParameters* mp);
 
@@ -66,7 +68,7 @@ public:
     boostSignal(progressText, completed_slices, total_slices);
     }
 
-
+	void deleteDuplicateGroup();
 	void resetProgressBar();
 
 	/**

--- a/src/core/libmaven/groupFiltering.cpp
+++ b/src/core/libmaven/groupFiltering.cpp
@@ -132,3 +132,45 @@ bool GroupFiltering::quantileFilters(PeakGroup *group) {
     }
     return false;
 }
+
+void GroupFiltering::deleteDuplicateGroup(){
+    double mzdiff=0.01;
+    double rtdiff=0.1;
+    double corrthresh=0.99;
+    vector_intensity_array.clear();
+    vector_mz_array.clear();
+    vector_rt_array.clear();
+    unsigned int n=_mavenParameters->allgroups.size();
+    cerr<< "Groups Found: " << n << endl;
+    vector<float> temp;
+    for(unsigned int i=0;i<n;i++){
+        temp.clear();
+        for(unsigned int j=0;j<_mavenParameters->allgroups[i].peaks.size();j++){
+            temp.push_back(_mavenParameters->allgroups[i].peaks[j].peakIntensity);
+        }
+        vector_intensity_array.push_back(temp);
+        vector_mz_array.push_back(_mavenParameters->allgroups[i].meanMz);
+        vector_rt_array.push_back(_mavenParameters->allgroups[i].meanRt);
+    }
+    int dup_count=0;
+    int nvec=_mavenParameters->allgroups.size();
+    int duplicate_flag=0;
+    vector<PeakGroup>  returnPeakGroup;
+    for(unsigned int i=0;i<_mavenParameters->allgroups.size();i++){
+        duplicate_flag=0;
+        for(unsigned int j=i+1;j<_mavenParameters->allgroups.size();j++){
+            if(abs(vector_mz_array[i]-vector_mz_array[j])<=mzdiff && abs(vector_rt_array[i]-vector_rt_array[j])<=rtdiff){
+                float pearsoncorr=mzUtils::correlation(vector_intensity_array[i],vector_intensity_array[j]);
+                if(pearsoncorr>corrthresh){
+                    duplicate_flag=1;
+                }
+            }
+        }
+        if(duplicate_flag==0){
+            returnPeakGroup.push_back(_mavenParameters->allgroups[i]);
+        }
+    }
+    _mavenParameters->allgroups.clear();
+    _mavenParameters->allgroups=returnPeakGroup;
+    cerr << "Correlation Based duplicate removal" << endl;
+}

--- a/src/core/libmaven/groupFiltering.h
+++ b/src/core/libmaven/groupFiltering.h
@@ -18,6 +18,11 @@ class GroupFiltering
 	 * @see MavenParameters
 	 * @see PeakGroup
 	 */
+
+	vector<vector<float>> vector_intensity_array;
+	vector<float> vector_mz_array;
+	vector<float> vector_rt_array;
+
     GroupFiltering(MavenParameters *mavenParameters);
 
 	/**
@@ -41,6 +46,8 @@ class GroupFiltering
 	 * @return [True if group has to be rejected, else False]
 	 */
 	bool quantileFilters(PeakGroup *group);
+
+	void deleteDuplicateGroup();
 
   private:
 		mzSlice *_slice;

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -580,7 +580,8 @@ void BackgroundPeakUpdate::processMassSlices() {
         Q_EMIT (updateProgressBar("Computing Mass Slices", 0, 0));
         mavenParameters->sig.connect(boost::bind(&BackgroundPeakUpdate::qtSignalSlot, this, _1, _2, _3));
         peakDetector.processMassSlices();
-        //cerr << "BPU IS " << mavenParameters->allgroups.size() << endl;
+        peakDetector.deleteDuplicateGroup();
+        cerr << "BPU IS " << mavenParameters->allgroups.size() << endl;
 
         align();
 

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -580,7 +580,8 @@ void BackgroundPeakUpdate::processMassSlices() {
         Q_EMIT (updateProgressBar("Computing Mass Slices", 0, 0));
         mavenParameters->sig.connect(boost::bind(&BackgroundPeakUpdate::qtSignalSlot, this, _1, _2, _3));
         peakDetector.processMassSlices();
-        peakDetector.deleteDuplicateGroup();
+        GroupFiltering groupFiltering(mavenParameters);
+        groupFiltering.deleteDuplicateGroup();
         cerr << "BPU IS " << mavenParameters->allgroups.size() << endl;
 
         align();


### PR DESCRIPTION
El-maven reports duplicates because of similar overlapping slice templates. The number is observed to be as high as 10% to 20% of the reported groups. Traversing through the slices and finding the duplicates according to some metric could be the way to go with no considerable performance overhead. We can traverse through the slices and find duplicates in three steps:
1. mz-difference <0.01. Compare the differences in meanMZ values and choose the ones with difference less than this.
2. rt-difference <0.1. Compare the differences in meanRT values and choose the ones with difference less than this.
3. Vector correlation between sample wise intensity values > 0.99.

These must be performed in the same order to reduce the overhead caused by correlation calculation. The constant values may be varied to find duplicates better and faster.