### PR TITLE
Fix crash on develop

### DIFF
--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -455,14 +455,6 @@ class PeakGroup{
         static bool compMz(const PeakGroup& a, const PeakGroup& b ) { return(a.meanMz > b.meanMz); }
 
         /**
-         * @brief sort isotopes in natural order
-         * @param a reference to PeakGroup object
-         * @param b reference to PeakGroup object
-         * @return True if tagString of a is lesser than b
-         **/
-        static bool compTagString(const PeakGroup& a, const PeakGroup& b ) { return mzUtils::strcasecmp_withNumbers(a.tagString, b.tagString); }
-        
-        /**
          * [compIntensity ]
          * @method compIntensity
          * @param  a             []

--- a/src/core/libmaven/isotopeDetection.cpp
+++ b/src/core/libmaven/isotopeDetection.cpp
@@ -45,8 +45,6 @@ void IsotopeDetection::pullIsotopes(PeakGroup* parentgroup)
 
     addIsotopes(parentgroup, isotopes);
 
-    sortIsotopes(parentgroup);
-
 }
 
 map<string, PeakGroup> IsotopeDetection::getIsotopes(PeakGroup* parentgroup, vector<Isotope> masslist)
@@ -346,17 +344,4 @@ bool IsotopeDetection::filterLabel(string isotopeName)
 
     return true;
 
-}
-
-void IsotopeDetection::sortIsotopes(PeakGroup *group)
-{
-    if (group->children.size())
-        sort(group->children.begin(), group->children.end(), PeakGroup::compTagString);
-    
-    if (group->childrenBarPlot.size())
-        sort(group->childrenBarPlot.begin(), group->childrenBarPlot.end(), PeakGroup::compTagString);
-    
-    if (group->childrenIsoWidget.size())
-        sort(group->childrenIsoWidget.begin(), group->childrenIsoWidget.end(), PeakGroup::compTagString);
-    
 }

--- a/src/core/libmaven/isotopeDetection.h
+++ b/src/core/libmaven/isotopeDetection.h
@@ -55,7 +55,6 @@ class IsotopeDetection
 	bool filterLabel(string isotopeName);
 	void addChild(PeakGroup *parentgroup, PeakGroup &child, string isotopeName);
 	bool checkChildExist(vector<PeakGroup> &children, string isotopeName);
-	void sortIsotopes(PeakGroup *group);
 
 };
 

--- a/src/core/libmaven/mzMassCalculator.cpp
+++ b/src/core/libmaven/mzMassCalculator.cpp
@@ -109,6 +109,25 @@ vector<Isotope> MassCalculator::computeIsotopes(
     Isotope parent(C12_PARENT_LABEL, parentMass);
     isotopes.push_back(parent);
 
+    if(C13Flag) {
+        for (int i = 1; i <= CatomCount; i++) {
+            Isotope x(C13_LABEL + integer2string(i),
+                    parentMass + (i * C_MASS_DELTA), i, 0, 0, 0);
+            isotopes.push_back(x);
+        }
+    }
+
+    if(C13Flag && D2Flag) {
+        for (int i = 1; i <= CatomCount; i++) {
+            for (int j = 1; j <= HatomCount; j++) {
+                string name = C13H2_LABEL + integer2string(i) + "-" + integer2string(j);
+                double mass = parentMass + (j * D_MASS_DELTA) + (i * C_MASS_DELTA);
+                Isotope x(name, mass, i, 0, 0, j);
+                isotopes.push_back(x);
+            }
+        }
+    }
+
     if(C13Flag && N15Flag) {
         for (int i = 1; i <= CatomCount; i++) {
             for (int j = 1; j <= NatomCount; j++) {
@@ -131,21 +150,10 @@ vector<Isotope> MassCalculator::computeIsotopes(
         }
     }
 
-    if(C13Flag && D2Flag) {
-        for (int i = 1; i <= CatomCount; i++) {
-            for (int j = 1; j <= HatomCount; j++) {
-                string name = C13H2_LABEL + integer2string(i) + "-" + integer2string(j);
-                double mass = parentMass + (j * D_MASS_DELTA) + (i * C_MASS_DELTA);
-                Isotope x(name, mass, i, 0, 0, j);
-                isotopes.push_back(x);
-            }
-        }
-    }
-
-    if(C13Flag) {
-        for (int i = 1; i <= CatomCount; i++) {
-            Isotope x(C13_LABEL + integer2string(i),
-                    parentMass + (i * C_MASS_DELTA), i, 0, 0, 0);
+    if(D2Flag) {
+        for (int i = 1; i <= HatomCount; i++) {
+            Isotope x(H2_LABEL + integer2string(i), parentMass + (i * D_MASS_DELTA),
+                    0, 0, 0, i);
             isotopes.push_back(x);
         }
     }
@@ -162,14 +170,6 @@ vector<Isotope> MassCalculator::computeIsotopes(
         for (int i = 1; i <= SatomCount; i++) {
             Isotope x(S34_LABEL + integer2string(i),
                     parentMass + (i * S_MASS_DELTA), 0, 0, i, 0);
-            isotopes.push_back(x);
-        }
-    }
-
-    if(D2Flag) {
-        for (int i = 1; i <= HatomCount; i++) {
-            Isotope x(H2_LABEL + integer2string(i), parentMass + (i * D_MASS_DELTA),
-                    0, 0, 0, i);
             isotopes.push_back(x);
         }
     }

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -762,9 +762,7 @@ void EicWidget::addBaseLine(EIC* eic) {
         line->addPoint(QPointF(toX(eic->rt[j]), toY(eic->baseline[j])));
     }
 
-    if (baselineSum == 0) {
-        return;
-    }
+    if (baselineSum == 0) return;
 
     QColor color = QColor::fromRgbF( eic->color[0], eic->color[1], eic->color[2], 1 );
     line->setColor(color);

--- a/tests/MavenTests/testMassCalculator.cpp
+++ b/tests/MavenTests/testMassCalculator.cpp
@@ -98,21 +98,21 @@ void TestMassCalculator::testComputeIsotopes() {
     //verify C12 parent mass
     QVERIFY(floor(isotopes[0].mass) == 346);
     //verify C13 mass
-    QVERIFY(floor(isotopes[277].mass) == 347);
+    QVERIFY(floor(isotopes[277].mass) == 349);
     //verify N15 mass
     QVERIFY(floor(isotopes[290].mass) == 348);
     //verify D2 mass
-    QVERIFY(floor(isotopes[294].mass) == 347);
+    QVERIFY(floor(isotopes[294].mass) == 352);
     //verify S34 mass
-    QVERIFY(floor(isotopes[293].mass) == 348);
+    QVERIFY(floor(isotopes[293].mass) == 351);
     //verify C13N15 dual label mass
-    QVERIFY(floor(isotopes[1].mass) == 348);
+    QVERIFY(floor(isotopes[1].mass) == 347);
     //verify C13D2 dual label mass
-    QVERIFY(floor(isotopes[61].mass) == 348);
+    QVERIFY(floor(isotopes[61].mass) == 362);
     //verify C13S34 dual label mass
-    QVERIFY(floor(isotopes[49].mass) == 349);
+    QVERIFY(floor(isotopes[49].mass) == 350);
     //verify abundance calculation
-    QVERIFY(isotopes[294].abundance > 0.00169 && isotopes[294].abundance < 0.0017);
+    QVERIFY(isotopes[3].abundance > 0.0002 && isotopes[3].abundance < 0.0003);
 
     C13Labeled_BPE = true;
     N15Labeled_BPE = false;


### PR DESCRIPTION
Reverting the commit for natural sorting of isotopes. The PeakGroup vector is not threadsafe and is resulting in random crashes on Windows and Mac. 

The order of labels has been changed while adding isotopes to the parent group. Still need to debug where the order is getting changed again on its way to the isotope plot.