### PR TITLE
Fix negative intensity

### DIFF
--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -544,6 +544,7 @@ void EIC::getPeakDetails(Peak &peak)
     }
     peak.peakAreaTop /= n;
     peak.peakAreaTopCorrected /= n;
+    if (peak.peakAreaTopCorrected < 0) peak.peakAreaTopCorrected = 0;
 
     peak.peakMz = mz[peak.pos];
 
@@ -551,8 +552,7 @@ void EIC::getPeakDetails(Peak &peak)
     peak.peakBaseLineLevel = baseline[peak.pos];
     peak.noNoiseFraction = (float)peak.noNoiseObs / (this->eic_noNoiseObs + 1);
     peak.peakAreaCorrected = peak.peakArea - baselineArea;
-    if (peak.peakAreaCorrected < 0) 
-        peak.peakAreaCorrected = 0; 
+    if (peak.peakAreaCorrected < 0) peak.peakAreaCorrected = 0; 
     peak.peakAreaFractional = peak.peakAreaCorrected / (totalIntensity + 1);
     peak.signalBaselineRatio = peak.peakIntensity / maxBaseLine;
     peak.signalBaselineDifference = peak.peakIntensity - maxBaseLine;

--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -551,6 +551,8 @@ void EIC::getPeakDetails(Peak &peak)
     peak.peakBaseLineLevel = baseline[peak.pos];
     peak.noNoiseFraction = (float)peak.noNoiseObs / (this->eic_noNoiseObs + 1);
     peak.peakAreaCorrected = peak.peakArea - baselineArea;
+    if (peak.peakAreaCorrected < 0) 
+        peak.peakAreaCorrected = 0; 
     peak.peakAreaFractional = peak.peakAreaCorrected / (totalIntensity + 1);
     peak.signalBaselineRatio = peak.peakIntensity / maxBaseLine;
     peak.signalBaselineDifference = peak.peakIntensity - maxBaseLine;


### PR DESCRIPTION
We sometimes see negative values for AreaCorrected and AreaTopCorrected. That is, baselineArea is higher than the peakArea even though the baseline signal is less than peakIntensity. (The baselineArea can be higher than the peakArea because of baseline smoothing for a noisy peak)