### PR TITLE
Pull isotopes for selected labels in CLI

### DIFF
--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -84,9 +84,13 @@ void PeakDetectorCLI::processOptions(int argc, char* argv[]) {
 				if (label > 0) {
 					mavenParameters->pullIsotopesFlag = 1;
 					if (label & 1) mavenParameters->C13Labeled_BPE = true;
+					else mavenParameters->C13Labeled_BPE = false;
 					if (label & 2) mavenParameters->S34Labeled_BPE = true;
+					else mavenParameters->S34Labeled_BPE = false;
 					if (label & 4) mavenParameters->N15Labeled_BPE = true;
+					else mavenParameters->N15Labeled_BPE = false;
 					if (label & 8) mavenParameters->D2Labeled_BPE  = true;
+					else mavenParameters->D2Labeled_BPE  = false;
 				}
 			}
 			break;
@@ -342,9 +346,13 @@ void PeakDetectorCLI::processPeaksArgsXML(xml_node& peaksArgs) {
 				if (label > 0) {
 					mavenParameters->pullIsotopesFlag = 1;
 					if (label & 1) mavenParameters->C13Labeled_BPE = true;
+					else mavenParameters->C13Labeled_BPE = false;
 					if (label & 2) mavenParameters->S34Labeled_BPE = true;
+					else mavenParameters->S34Labeled_BPE = false;
 					if (label & 4) mavenParameters->N15Labeled_BPE = true;
+					else mavenParameters->N15Labeled_BPE = false;
 					if (label & 8) mavenParameters->D2Labeled_BPE  = true;
+					else mavenParameters->D2Labeled_BPE  = false;
 				}
 
 		}

--- a/tests/MavenTests/testCLI.cpp
+++ b/tests/MavenTests/testCLI.cpp
@@ -61,8 +61,8 @@ void TestCLI::testProcessXml() {
     QVERIFY(peakdetectorCLI->mavenParameters->processAllSlices == 0);
     QVERIFY(peakdetectorCLI->mavenParameters->C13Labeled_BPE == true);
     QVERIFY(peakdetectorCLI->mavenParameters->N15Labeled_BPE == true);
-    QVERIFY(peakdetectorCLI->mavenParameters->S34Labeled_BPE == true);
-    QVERIFY(peakdetectorCLI->mavenParameters->D2Labeled_BPE == true);
+    QVERIFY(peakdetectorCLI->mavenParameters->S34Labeled_BPE == false);
+    QVERIFY(peakdetectorCLI->mavenParameters->D2Labeled_BPE == false);
     QVERIFY(peakdetectorCLI->mavenParameters->grouping_maxRtWindow == 2.5);
     QVERIFY(peakdetectorCLI->mavenParameters->minGroupIntensity == 500);
     QVERIFY(peakdetectorCLI->mavenParameters->quantileIntensity == 50);


### PR DESCRIPTION
Currently, all labels are pulled if any one label is switched on in CLI. This PR will ensure that only selected labels are pulled.