### PR TITLE
Fix last database file ignored

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -537,6 +537,13 @@ using namespace mzUtils;
 
 	createMenus();
 	if (ligandWidget) {
+
+		/**
+		 * loadsMethodsFolder changes the value of lastDatabaseFile in .conf
+		 * inorder to revert the value back to the original, its value was saved and set back to original
+		 * Note: the default value present in .conf file is KNOWNS
+		*/
+	
 		QString lastDatabaseFile = settings->value("lastDatabaseFile").value<QString>();
 		loadMethodsFolder(methodsFolder);
 		settings->setValue("lastDatabaseFile",lastDatabaseFile);

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -536,10 +536,14 @@ using namespace mzUtils;
 	}
 
 	createMenus();
-	if (ligandWidget)
+	if (ligandWidget) {
+		QString lastDatabaseFile = settings->value("lastDatabaseFile").value<QString>();
 		loadMethodsFolder(methodsFolder);
-	if (pathwayWidget)
+		settings->setValue("lastDatabaseFile",lastDatabaseFile);
+	}
+	if (pathwayWidget) {
 		loadPathwaysFolder(pathwaysFolder);
+	}
 
 	setCentralWidget(eicWidgetController());	
 


### PR DESCRIPTION
When opening Elmaven, the last compound selected on the previous run was not being displayed in the compounds tab. Issue #568 