### PR TITLE
Fix isoPlot crash on merging tables

### DIFF
--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -404,6 +404,7 @@ void IsotopeWidget::setClipboard()
 
 void IsotopeWidget::updateIsotopicBarplot()
 {
+	isotopeParametersBarPlot->_group = _mw->getEicWidget()->getParameters()->getSelectedGroup();
 	if (isotopeParametersBarPlot->_group)
 	{
 		_mw->isotopePlot->setPeakGroup(isotopeParametersBarPlot->_group);


### PR DESCRIPTION
El-MAVEN was crashing on interacting with the isoPlot right after merging the bookmark and peak table. This was because the selected group from bookmark table was deleted when moving to peaktable but isoPlot group wasn't getting updated.