### PR TITLE
[Fix] Crash while closing the application

### DIFF
--- a/src/gui/mzroll/pollywaitdialog.cpp
+++ b/src/gui/mzroll/pollywaitdialog.cpp
@@ -1,6 +1,6 @@
 #include "pollywaitdialog.h"
 
-PollyWaitDialog::PollyWaitDialog(QWidget *parent) : QDialog(parent) {
+PollyWaitDialog::PollyWaitDialog(QWidget *parent) : QDialog(parent), ui(new Ui::PollyWaitDialog) {
     setupUi(this);
     statusLabel->setStyleSheet("QLabel {color : green; }");
     statusLabel->setAlignment(Qt::AlignCenter);


### PR DESCRIPTION
memory was not allocated to pointer ui