### PR TITLE
Pull isotopes on shift-drag #781

### DIFF
--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -194,7 +194,7 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
 
 	eicParameters->_integratedGroup.groupStatistics();
 	getMainWindow()->isotopeWidget->updateIsotopicBarplot(&eicParameters->_integratedGroup);
-	getMainWindow()->bookmarkPeakGroup(&eicParameters->_integratedGroup);
+	getMainWindow()->isotopeWidget->setPeakGroupAndMore(&eicParameters->_integratedGroup, true);
 }
 
 void EicWidget::mouseDoubleClickEvent(QMouseEvent* event) {

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -96,6 +96,10 @@ void IsotopeWidget::setPeakGroupAndMore(PeakGroup *grp, bool bookmarkflg)
 		isotopeParameters->_group = grp->parent;
 	}
 
+	//TODO: move bookmarking functionality out of isotopeWidget
+	if (bookmarkflg)
+		pullIsotopes(isotopeParameters->_group);
+
 	//select first sample if no peak or sample is selected
 	if (!_selectedSample)
 		updateSelectedSample(0);
@@ -104,10 +108,6 @@ void IsotopeWidget::setPeakGroupAndMore(PeakGroup *grp, bool bookmarkflg)
 		isotopeParameters->_scan = peak->getScan();
 	else
 		return;
-
-	//TODO: move bookmarking functionality out of isotopeWidget
-	if (bookmarkflg)
-		pullIsotopes(isotopeParameters->_group);
 	
 	computeIsotopes(isotopeParameters->_formula);
 }


### PR DESCRIPTION
Reverting the changes made to fix another shift-drag issue. I have tested for both- the previous issue where user couldn't shift-drag integrate certain peaks, and #781. 