### PR TITLE
[Fix] Skip empty groups when adding to bookmarks table

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1192,7 +1192,7 @@ PeakGroup* MainWindow::bookmarkPeakGroup() {
 
 PeakGroup* MainWindow::bookmarkPeakGroup(PeakGroup* group) {
 
-    if ( bookmarkedPeaks == NULL ) return NULL;
+	if ( bookmarkedPeaks == NULL ) return NULL;
 
     if ( bookmarkedPeaks->isVisible() == false ) {
         bookmarkedPeaks->setVisible(true);
@@ -1226,6 +1226,7 @@ PeakGroup* MainWindow::bookmarkPeakGroup(PeakGroup* group) {
         }
 
         bookmarkedGroup = bookmarkedPeaks->addPeakGroup(group);
+		//TODO: User feedback when group is rejected
         bookmarkedPeaks->showAllGroups();
 		bookmarkedPeaks->updateTable();
     }

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -603,7 +603,7 @@ bool TableDockWidget::hasPeakGroup(PeakGroup* group) {
 }
 
 PeakGroup* TableDockWidget::addPeakGroup(PeakGroup* group) {
-    if (group != NULL ) {
+    if (group != NULL && group->peakCount() > 0) {
         allgroups.push_back(*group);
         if ( allgroups.size() > 0 ) {
             PeakGroup& g = allgroups[ allgroups.size()-1 ];
@@ -663,7 +663,7 @@ void TableDockWidget::showAllGroups() {
     if (viewType == groupView) setIntensityColName();
     
     QMap<int,QTreeWidgetItem*> parents;
-    for(int i=0; i < allgroups.size(); i++ ) { 
+    for(int i=0; i < allgroups.size(); i++ ) {
         int clusterId  = allgroups[i].clusterId;
         if (clusterId && allgroups[i].meanMz > 0 && allgroups[i].peakCount()>0) {
             if (!parents.contains(clusterId)) {


### PR DESCRIPTION
Using shift-drag integration, users can bookmark peaks within a rt range in an EIC.

If all peaks are filtered out based on peakFiltering parameters set in Options dialog, the group is still added. Leads to complications with "Same m/z Rt" prompt.