### PR TITLE
[Fix] Check for peaks before bookmarking a group

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1193,6 +1193,8 @@ PeakGroup* MainWindow::bookmarkPeakGroup() {
 PeakGroup* MainWindow::bookmarkPeakGroup(PeakGroup* group) {
 
 	if ( bookmarkedPeaks == NULL ) return NULL;
+	//TODO: User feedback when group is rejected
+	if (group->peakCount() == 0) return NULL;
 
     if ( bookmarkedPeaks->isVisible() == false ) {
         bookmarkedPeaks->setVisible(true);
@@ -1225,8 +1227,7 @@ PeakGroup* MainWindow::bookmarkPeakGroup(PeakGroup* group) {
                                                   * (1 /(pow(log(group->maxIntensity + 1), B)));
         }
 
-        bookmarkedGroup = bookmarkedPeaks->addPeakGroup(group);
-		//TODO: User feedback when group is rejected
+		bookmarkedGroup = bookmarkedPeaks->addPeakGroup(group);
         bookmarkedPeaks->showAllGroups();
 		bookmarkedPeaks->updateTable();
     }

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -603,7 +603,7 @@ bool TableDockWidget::hasPeakGroup(PeakGroup* group) {
 }
 
 PeakGroup* TableDockWidget::addPeakGroup(PeakGroup* group) {
-    if (group != NULL && group->peakCount() > 0) {
+    if (group != NULL) {
         allgroups.push_back(*group);
         if ( allgroups.size() > 0 ) {
             PeakGroup& g = allgroups[ allgroups.size()-1 ];


### PR DESCRIPTION
The check for peaks has been moved to the bookmark function as shift-drag is the only way to get a group with no peaks. 

In case of mzrolls, groups are read and added before the peaks are assigned which led to filtering out of all peaks.