### PR TITLE
Fix: Prevent pushing data to Polly when peaks table is empty

### DIFF
--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -309,6 +309,15 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir){
         else{
             _tableDockWidget = peakTableNameMapping[peak_table_name];
         }
+
+        if (_tableDockWidget->groupCount() == 0){
+            QString msg = "Peaks Table is Empty";
+            QMessageBox msgBox(mainwindow);
+            msgBox.setWindowTitle("Error");
+            msgBox.setText(msg);
+            msgBox.exec();
+            return filenames;
+        }
     }
     else{
         QString msg = "No Peak tables";


### PR DESCRIPTION
This should correctly stop the upload process if the selected peaks table has no entries.

Issue: #777