### PR TITLE
Profile sample uploading

### DIFF
--- a/src/core/libmaven/libmaven.pro
+++ b/src/core/libmaven/libmaven.pro
@@ -11,7 +11,8 @@ CONFIG += staticlib warn_off console silent
 
 QMAKE_CXXFLAGS +=  -std=c++11
 QMAKE_CXXFLAGS += -DOMP_PARALLEL
-
+linux: QMAKE_CXXFLAGS += -Ofast -ffast-math
+win32: QMAKE_CXXFLAGS += -Ofast -ffast-math
 !macx: QMAKE_CXXFLAGS += -fopenmp
 !macx: LIBS += -fopenmp
 

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -305,7 +305,7 @@ void mzSample::parseMzML(const char *filename)
 	xml_node experimentRun = doc.first_child().first_element_by_path("mzML/run");
 	if (!experimentRun.empty())
 	{
-		parseMzMLInjectionTimeStamp(experimentRun);
+        parseMzMLInjectionTimeStamp(experimentRun.attribute("startTimeStamp"));
 	}
 
 	//Get a spectrumstore node
@@ -322,9 +322,8 @@ void mzSample::parseMzML(const char *filename)
 	}
 }
 
-void mzSample::parseMzMLInjectionTimeStamp(xml_node &experimentRun)
+void mzSample::parseMzMLInjectionTimeStamp(const xml_attribute &injectionTimeStamp)
 {
-	xml_attribute injectionTimeStamp = experimentRun.attribute("startTimeStamp");
 
 	if (!injectionTimeStamp.empty())
 	{
@@ -339,7 +338,7 @@ void mzSample::parseMzMLInjectionTimeStamp(xml_node &experimentRun)
 	}
 }
 
-void mzSample::parseMzMLChromatogramList(xml_node &chromatogramList)
+void mzSample::parseMzMLChromatogramList(const xml_node &chromatogramList)
 {
 
 	int scannum = 0;
@@ -444,7 +443,7 @@ string mzSample::filterChromatogramId(const string &chromatogramId) {
 	return filteredChromatogramId;
 }
 
-void mzSample::parseMzMLSpectrumList(xml_node &spectrumList)
+void mzSample::parseMzMLSpectrumList(const xml_node &spectrumList)
 {
 
 	//Iterate through spectrums
@@ -705,7 +704,7 @@ void mzSample::setInstrumentSettigs(xml_document &doc, xml_node spectrumstore)
 	}
 }
 
-void mzSample::parseMzXMLData(xml_document &doc, xml_node spectrumstore)
+void mzSample::parseMzXMLData(const xml_node& spectrumstore)
 {
 	//Iterate through spectrums
 	int scannum = 0;
@@ -740,7 +739,7 @@ void mzSample::parseMzXML(const char *filename)
         //Setting the instrument related information
         setInstrumentSettigs(doc, spectrumstore);
         //parse mzXML information from the scan
-        parseMzXMLData(doc, spectrumstore);
+        parseMzXMLData(spectrumstore);
     }
     else
         throw MavenException(ErrorMsg::ParsemzXml);
@@ -861,7 +860,7 @@ vector<float> mzSample::parsePeaksFromMzXML(const xml_node &scan)
 	return mzint;
 }
 
-void mzSample::populateMzAndIntensity(vector<float> mzint, Scan *_scan)
+void mzSample::populateMzAndIntensity(const vector<float>& mzint, Scan *_scan)
 {
 	int j = 0, count = 0, size = mzint.size() / 2;
 
@@ -886,7 +885,7 @@ void mzSample::populateMzAndIntensity(vector<float> mzint, Scan *_scan)
 	_scan->intensity.resize(count);
 }
 
-void mzSample::populateFilterline(string filterLine, Scan *_scan)
+void mzSample::populateFilterline(const string& filterLine, Scan *_scan)
 {
 
 	if (!filterLine.empty())
@@ -899,7 +898,7 @@ void mzSample::populateFilterline(string filterLine, Scan *_scan)
 	}
 }
 
-void mzSample::parseMzXMLScan(const xml_node &scan, int scannum)
+void mzSample::parseMzXMLScan(const xml_node &scan, const int& scannum)
 {
 
     float rt = 0.0, precursorMz = 0.0, productMz = 0, collisionEnergy = 0;

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -256,7 +256,7 @@ class mzSample
     * @param scan xml_node object of pugixml library
     * @param scannum scan number
     */
-    void parseMzXMLScan(const xml_node &scan, int scannum);
+    void parseMzXMLScan(const xml_node &scan, const int& scannum);
 
     /**
     * @brief Write mzCSV file
@@ -275,13 +275,13 @@ class mzSample
      * @brief Update injection time stamp
      * @param xml_node xml_node object of pugixml library
      */
-    void parseMzMLInjectionTimeStamp(xml_node&);
+    void parseMzMLInjectionTimeStamp(const xml_attribute&);
 
     /**
     * @brief Parse mzML chromatogrom list
     * @param xml_node xml_node object of pugixml library
     */
-    void parseMzMLChromatogramList(xml_node&);
+    void parseMzMLChromatogramList(const xml_node&);
 
 
     int getSampleNoChromatogram(const string &chromatogramId);
@@ -292,7 +292,7 @@ class mzSample
     * @brief Parse mzML spectrum list
     * @param xml_node xml_node object of pugixml library
     */
-    void parseMzMLSpectrumList(xml_node&);
+    void parseMzMLSpectrumList(const xml_node&);
 
     /**
     * @brief Print info about sample 
@@ -706,7 +706,7 @@ class mzSample
 
     void setInstrumentSettigs(xml_document &doc, xml_node spectrumstore);
 
-    void parseMzXMLData(xml_document &staticdoc, xml_node spectrumstore);
+    void parseMzXMLData(const xml_node& spectrumstore);
 
     xml_node getmzXMLSpectrumData(xml_document &doc, const char *filename);
 
@@ -718,9 +718,9 @@ class mzSample
 
     vector<float> parsePeaksFromMzXML(const xml_node &scan);
 
-    void populateMzAndIntensity(vector<float> mzint, Scan *_scan);
+    void populateMzAndIntensity(const vector<float>& mzint, Scan *_scan);
 
-    void populateFilterline(string filterLine, Scan *_scan);
+    void populateFilterline(const string& filterLine, Scan *_scan);
 
     void loadAnySample(const char *filename);
 

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -87,15 +87,6 @@ mzSample* mzFileIO::loadSample(QString filename){
         sample->id = ++sampleId;
         mtxSampleId.unlock();
 
-        sample->enumerateSRMScans();
-
-        //set min and max values for rt
-        sample->calculateMzRtRange();
-
-        //set file path
-        sample->fileName = filename.toStdString();
-
-        if (filename.contains("blank",Qt::CaseInsensitive)) sample->isBlank = true;
         return sample;
     }
     return NULL;
@@ -583,16 +574,8 @@ void mzFileIO::fileImport(void) {
             QString filename = samples.at(i);
             mzSample* sample = loadSample(filename);
             if (sample) {
-                    sample->enumerateSRMScans();
-                    sample->calculateMzRtRange();    //set min and max values for rt
-                    sample->fileName = filename.toStdString();
-
-                    if ( filename.contains("blank",Qt::CaseInsensitive))
-                            sample->isBlank = true;   //check if this is a blank sample
-
                     if (sample->scans.size()>0)
                         emit addNewSample(sample);
-
             }
             #ifndef __APPLE__
             #pragma omp atomic

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -573,10 +573,9 @@ void mzFileIO::fileImport(void) {
         for (int i = 0; i < samples.size(); i++) {
             QString filename = samples.at(i);
             mzSample* sample = loadSample(filename);
-            if (sample) {
-                    if (sample->scans.size()>0)
-                        emit addNewSample(sample);
-            }
+            if (sample && sample->scans.size() > 0)
+                emit addNewSample(sample);
+
             #ifndef __APPLE__
             #pragma omp atomic
             #endif
@@ -590,18 +589,9 @@ void mzFileIO::fileImport(void) {
         for (int i = 0; i < samples.size(); i++) {
             QString filename = samples.at(i);
             mzSample* sample = loadSample(filename);
-            if (sample) {
-                    sample->enumerateSRMScans();
-                    sample->calculateMzRtRange();    //set min and max values for rt
-                    sample->fileName = filename.toStdString();
+            if (sample && sample->scans.size() > 0)
+                _mainwindow->addSample(sample);
 
-                    if ( filename.contains("blank",Qt::CaseInsensitive))
-                            sample->isBlank = true;   //check if this is a blank sample
-
-                    if (sample->scans.size()>0)
-                            _mainwindow->addSample(sample);
-
-            }
             iter++;
 
             Q_EMIT (updateProgressBar( tr("Importing file %1").arg(filename), iter, samples.size()));

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -37,7 +37,7 @@ void mzFileIO::loadSamples(QStringList& files) {
     //start();
 }
 
-mzSample* mzFileIO::loadSample(QString filename){
+mzSample* mzFileIO::loadSample(const QString& filename){
 
     //check if file exists
     QFile file(filename);

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -38,7 +38,7 @@ Q_OBJECT
          * @param  filename [name of the file]
          * @return          [pointer to Sample]
          */
-        mzSample* loadSample(QString filename);
+        mzSample* loadSample(const QString& filename);
 
         /**
          * [parse MzData]

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -10,6 +10,8 @@ CONFIG += qt thread warn_off sql svg console precompile_header
 
 QMAKE_CXXFLAGS +=  -std=c++11
 QMAKE_CXXFLAGS += -DOMP_PARALLEL
+linux: QMAKE_CXXFLAGS += -Ofast -ffast-math
+win32: QMAKE_CXXFLAGS += -Ofast -ffast-math
 !macx: QMAKE_CXXFLAGS += -fopenmp
 !macx: LIBS += -fopenmp
 

--- a/tests/MavenTests/testLoadSamples.cpp
+++ b/tests/MavenTests/testLoadSamples.cpp
@@ -181,7 +181,7 @@ void TestLoadSamples::testParseMzMLInjectionTimeStamp() {
         // using the "parseMzMLInjectionTimeStamp" function to get time stamp
         mzSample* sample = new mzSample();
         xml_node experimentRun = doc.first_child().first_element_by_path("run");
-        sample->parseMzMLInjectionTimeStamp(experimentRun);
+        sample->parseMzMLInjectionTimeStamp(experimentRun.attribute("startTimeStamp"));
 
         // comparing expected output with observed output
         unsigned int index_itr = it - test_cases.begin();


### PR DESCRIPTION
Reasons that led to slow down of sample uploading:
1. enumerateSRMScan() and  calculateMzRtRange() were called thrice for every sample
2. Ofast and ffast-math flag were removed and hence compiler was not optimizing parts of code involved in sample uploading process

Solution
1. removed duplicated calls 
2. added compiler flags for windows and linux

Tested on:
Mac
Linux
Windows
