### PR TITLE
Fix sample widget slowdown with large peak table

### DIFF
--- a/src/gui/mzroll/alignmentpolyvizdockwidget.cpp
+++ b/src/gui/mzroll/alignmentpolyvizdockwidget.cpp
@@ -41,16 +41,18 @@ AlignmentPolyVizDockWidget::~AlignmentPolyVizDockWidget()
 
 void AlignmentPolyVizDockWidget::plotGraph() {
 
-        intialSetup();
+    if (!_mw->alignmentPolyVizDockWidget->isVisible()) return;
 
-        // plot individual graphs here
-        Q_FOREACH(mzSample* sample, _mw->getSamples()) {
-            if(sample->isSelected) {
-                plotIndividualGraph(sample);
-            }
+    intialSetup();
+
+    // plot individual graphs here
+    Q_FOREACH(mzSample* sample, _mw->getSamples()) {
+        if(sample->isSelected) {
+            plotIndividualGraph(sample);
         }
+    }
 
-        refresh();
+    refresh();
 
 }
 

--- a/src/gui/mzroll/alignmentvizallgroupswidget.cpp
+++ b/src/gui/mzroll/alignmentvizallgroupswidget.cpp
@@ -12,6 +12,7 @@ void AlignmentVizAllGroupsWidget::replotGraph() {
 
 void AlignmentVizAllGroupsWidget::plotGraph(QList<PeakGroup> allgroups) {
 
+    if (!_mw->alignmentVizAllGroupsDockWidget->isVisible()) return;
     saveGroups = allgroups;
 
     _mw->alignmentVizAllGroupsPlot->clearPlottables();

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2588,6 +2588,8 @@ void MainWindow::createToolBars() {
 	connect(pathwayDockWidget, SIGNAL(visibilityChanged(bool)), pathwayPanel,
 			SLOT(setVisible(bool)));
 	connect(btnSRM, SIGNAL(clicked(bool)), SLOT(showSRMList()));
+	connect(btnAlignmentVizAllGroups, SIGNAL(clicked(bool)), SLOT(replotAlignmentVizAllGroupGraph(bool)));
+	connect(btnAlignmentPolyViz, SIGNAL(clicked(bool)), SLOT(plotAlignmentPolyVizDockWidget(bool)));
 
 	sideBar->setOrientation(Qt::Vertical);
 	sideBar->setMovable(false);
@@ -2826,6 +2828,14 @@ void MainWindow::Align() {
 
 void MainWindow::plotAlignmentVizAllGroupGraph(QList<PeakGroup> allgroups) {
 	alignmentVizAllGroupsWidget->plotGraph(allgroups);
+}
+
+void MainWindow::replotAlignmentVizAllGroupGraph(bool active) {
+	if (active) alignmentVizAllGroupsWidget->replotGraph();
+}
+
+void MainWindow::plotAlignmentPolyVizDockWidget(bool active) {
+	if (active) alignmentPolyVizDockWidget->plotGraph();
 }
 
 void MainWindow::showAlignmentWidget() {

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -326,6 +326,8 @@ public Q_SLOTS:
 	void showsettingsForm();
 	void sendAnalytics();
 	void plotAlignmentVizAllGroupGraph(QList<PeakGroup> allgroups);
+	void replotAlignmentVizAllGroupGraph(bool active);
+	void plotAlignmentPolyVizDockWidget(bool active);
 	void createPeakTable(QString);
 
 	void setIonizationModeLabel();


### PR DESCRIPTION
Fixing an issue where having a large peak table would cause the
sample widget, when interacted with, to perform a heavy (blocking)
computation within the alignment visualisation widget(s).

Now this computation will only be performed if the alignment widget
is visible, and replotted whenever it is made visible using the
sidebar widget.

Issue: #723