### PR TITLE
Fix polly compounds db upload

### DIFF
--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -342,7 +342,7 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir){
         // As of now, uploading what is currently there in the compound section of Elmaven.
         // If advanced settings were used to upload compound DB, we need not do this.
         QString compound_db = mainwindow->ligandWidget->getDatabaseName();
-        mainwindow->ligandWidget->saveCompoundList(writable_temp_dir+QDir::separator()+datetimestamp+"_Compound_DB_Elmaven",compound_db);
+        mainwindow->ligandWidget->saveCompoundList(writable_temp_dir+QDir::separator()+datetimestamp+"_Compound_DB_Elmaven.csv",compound_db);
     }
 
     qDebug()<< "Now uploading all groups, needed for firstview app..";
@@ -384,10 +384,10 @@ void PollyElmavenInterfaceDialog::handle_advanced_settings(QString writable_temp
             user_filename = "intensity_file.csv";
         }
         if (user_compound_DB_name==""){
-            user_compound_DB_name = "compounds.csv";
+            user_compound_DB_name = "compounds";
         }
         if (_advancedSettings->get_upload_compoundDB()){
-            mainwindow->ligandWidget->saveCompoundList(writable_temp_dir+QDir::separator()+datetimestamp+"_Compound_DB_"+user_compound_DB_name,compound_db);
+            mainwindow->ligandWidget->saveCompoundList(writable_temp_dir+QDir::separator()+datetimestamp+"_Compound_DB_"+user_compound_DB_name+".csv",compound_db);
         }
         
         if (_advancedSettings->get_upload_Peak_Table()){

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -333,12 +333,18 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir){
 
     if (use_advanced_settings=="yes"){
         handle_advanced_settings(writable_temp_dir,datetimestamp);
-        }
+    }
+    
+    if (use_advanced_settings != "yes" || !_advancedSettings->get_upload_compoundDB()) {
+        // Now uploading the Compound DB that was used for peak detection.
+        // This is needed for Elmaven->Firstview->PollyPhi relative LCMS workflow.
+        // ToDo Kailash, Keep track of compound DB used for each peak table,
+        // As of now, uploading what is currently there in the compound section of Elmaven.
+        // If advanced settings were used to upload compound DB, we need not do this.
+        QString compound_db = mainwindow->ligandWidget->getDatabaseName();
+        mainwindow->ligandWidget->saveCompoundList(writable_temp_dir+QDir::separator()+datetimestamp+"_Compound_DB_Elmaven",compound_db);
+    }
 
-    // Now uploading the Compound DB that was used for peakdetection..this is needed for Elmaven->Firstview->PollyPhi relative LCMS workflow..
-    //ToDo Kailash, Keep track of compound DB used for each peak table, As of now.. uploading what is currently there in the compound section of Elmaven
-    QString compound_db = mainwindow->ligandWidget->getDatabaseName();
-    mainwindow->ligandWidget->saveCompoundList(writable_temp_dir+QDir::separator()+datetimestamp+"_Compound_DB_Elmaven",compound_db);
     qDebug()<< "Now uploading all groups, needed for firstview app..";
     _tableDockWidget->wholePeakSet();
     _tableDockWidget->treeWidget->selectAll();


### PR DESCRIPTION
There were reports of Polly ElMaven interface not working when using advanced settings and opting for a custom database upload. ElMaven was sending two databases in this case, one used in the peak detection operation and the other that the user specifies. It was also sending these files sometimes in `.tab` format and in `.csv` only when the user left the custom DB name entry blank.

These two oddities have been corrected: only one compounds DB file is uploaded and files are always uploaded in CSV format. This pull request covers the same.

However, it turns out that the upload sometimes still leads to failures on Polly's FirstView visualization tool, even when using the same sample dataset, peak table and compounds DB which occasionally works totally fine. In short, this issue is not very reproducible on ElMaven's end. And maybe it is not entirely at fault either.