### PR TITLE
Fix slowdown peaks

### DIFF
--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -411,37 +411,31 @@ void LigandWidget::showTable() {
     
     Hash.clear();
     QTreeWidgetItemIterator itr(treeWidget);
-    cerr<<"-------------------------Creating new hash table-----------------------------"<<"\n";
-    while(*itr)
-    {     
-    QTreeWidgetItem* item =(*itr);
-    QVariant v = item->data(0,Qt::UserRole);
-    Compound*  c =  v.value<Compound*>();                                                                                   
-    Hash.insert(c , item);
-     ++itr;
-    }
-
+        while(*itr)
+        {     
+        QTreeWidgetItem* item =(*itr);
+        QVariant v = item->data(0,Qt::UserRole);
+        Compound*  c =  v.value<Compound*>();                                                                                   
+        Hash.insert(c , item);
+        ++itr;
+        }
 treeWidget->setSortingEnabled(true);
 }
 
 void LigandWidget::markAsDone(Compound* compound) {
+    if(compound != NULL)
+    {
+        QHash<Compound *, QTreeWidgetItem *>::const_iterator i = Hash.find(compound);
+        if (i != Hash.end() & i.key() == compound) {
+            QTreeWidgetItem* item = i.value();  
 
-
-if(compound != NULL)
-{
-    QHash<Compound *, QTreeWidgetItem *>::const_iterator i = Hash.find(compound);
-if (i != Hash.end() & i.key() == compound) {
-     QTreeWidgetItem* item = i.value();  
-
-        if (item != NULL) {
-             
-            for (int col = 0; col < treeWidget->columnCount(); col++) {
-                item->setBackgroundColor(col, QColor(61, 204, 85, 100));
-            }
+                if (item != NULL) {
+                    for (int col = 0; col < treeWidget->columnCount(); col++) {
+                        item->setBackgroundColor(col, QColor(61, 204, 85, 100));
+                    }
+                }
         }
-}
-}    
-
+    }    
 }
 
 void LigandWidget::resetColor() {

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -79,6 +79,7 @@ LigandWidget::LigandWidget(MainWindow* mw) {
 
 
 
+
   //disconnect(&http, SIGNAL(readyRead(const QHttpResponseHeader &)));
   //connect(&http, SIGNAL(readyRead(const QHttpResponseHeader &)), SLOT(readRemoteData(const QHttpResponseHeader &)));
   
@@ -403,39 +404,43 @@ void LigandWidget::showTable() {
                 QTreeWidgetItem *item = new QTreeWidgetItem(parent, PathwayType);
                 item->setText(0,QString(compound->category[i].c_str()));
                 //parent->setData(0,Qt::UserRole,QVariant::fromValue(QString(pathway_id.c_str())));
-
             }*/
 
     }
-    treeWidget->setSortingEnabled(true);
-}
-
-void LigandWidget::markAsDone(QTreeWidget* group) {
   
-   // QTreeWidgetItem* matchedItem = nullptr;
-
-    QTreeWidgetItem* item = nullptr;
-    QTreeWidgetItemIterator itr(treeWidget);
-      while (*itr) {
-        item =(*itr);
-        if(item){
-       if(item->backgroundColor(0)  != QColor(61, 204, 85, 100))
-        {  
-           
-            QTreeWidgetItem* chq = getItem(group, item); 
-
-             if (chq != NULL) {
-            for (int col = 0; col < treeWidget->columnCount(); col++) {
-                chq->setBackgroundColor(col, QColor(61, 204, 85, 100));
-            }
-        }
-       
-       }
-       }
-        ++itr;   
-    }    
+      QTreeWidgetItemIterator itr(treeWidget);
+  cerr<<"-------------------------Creating new hash table-----------------------------"<<"\n";
+    while(*itr)
+    {     
+    QTreeWidgetItem* item =(*itr);
+    QVariant v = item->data(0,Qt::UserRole);
+    Compound*  c =  v.value<Compound*>();                                                                                   
+    Hash.insert(c , item);
+     ++itr;
     }
 
+treeWidget->setSortingEnabled(true);
+}
+
+void LigandWidget::markAsDone(Compound* compound) {
+
+
+if(compound != NULL)
+{
+    QHash<Compound *, QTreeWidgetItem *>::const_iterator i = Hash.find(compound);
+if (i.key() == compound) {
+     QTreeWidgetItem* item = i.value();  
+
+        if (item != NULL) {
+             
+            for (int col = 0; col < treeWidget->columnCount(); col++) {
+                item->setBackgroundColor(col, QColor(61, 204, 85, 100));
+            }
+        }
+}
+}    
+
+}
 
 void LigandWidget::resetColor() {
 
@@ -451,33 +456,6 @@ void LigandWidget::resetColor() {
     }
 }
 
-QTreeWidgetItem* LigandWidget::getItem(QTreeWidget* group, QTreeWidgetItem* compound) {
-    QTreeWidgetItem* matchedItem = nullptr;
-
-    QTreeWidgetItemIterator itr(group);
-    while (*itr) {
-        QTreeWidgetItem* item =(*itr);
-        if (item) {
-            QVariant v1 = compound->data(0,Qt::UserRole);
-            Compound* itemCompound =  v1.value<Compound*>();
-
-            QVariant v = item->data(0,Qt::UserRole);
-            PeakGroup* groups =  v.value<PeakGroup*>();
-            Compound * grp = groups->compound;
-           
-                if(grp == itemCompound)
-                {
-                // cerr<<grp<<" ";
-                // cerr<<itemCompound<<"\n";
-                matchedItem = compound;
-                return matchedItem;
-                }
-        }
-        ++itr;
-    }
-
-return matchedItem;
-}
 
 void LigandWidget::saveCompoundList(){
 
@@ -605,7 +583,6 @@ void LigandWidget::showLigand() {
 
     }
 }
-
 void LigandWidget::fetchRemoteCompounds()
 {
     qDebug() << "fetchRemoteCompounds()";

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -411,51 +411,51 @@ setHash();
 treeWidget->setSortingEnabled(true);
 }
 
-
-
 void LigandWidget::setHash()
 {
     CompoundsHash.clear();
     QTreeWidgetItemIterator itr(treeWidget);
-        while(*itr)
-            {     
-                QTreeWidgetItem* item =(*itr);
-                QVariant v = item->data(0,Qt::UserRole);
-                Compound*  c =  v.value<Compound*>();                                                                                   
-                CompoundsHash.insert(c , item);
-                ++itr;
-            }
-}
-
-void LigandWidget::markAsDone(Compound* compound) {
-    if(compound == NULL)
-    return;
-    {
-        QHash<Compound *, QTreeWidgetItem *>::const_iterator i = CompoundsHash.find(compound);
-        if (i != CompoundsHash.end() & i.key() == compound) {
-            QTreeWidgetItem* item = i.value();  
-
-                if (item != NULL) {
-                    for (int col = 0; col < treeWidget->columnCount(); col++) {
-                        item->setBackground(col,QBrush(QColor(61, 204, 85, 100)));
-                    }
-                }
-        }
-    }    
-}
-
-void LigandWidget::resetColor() {
-
-    QTreeWidgetItemIterator itr(treeWidget);
-    while (*itr) {
+     while(*itr)
+    {     
         QTreeWidgetItem* item =(*itr);
-        if (item) {
-            for (int col = 0; col < treeWidget->columnCount(); col++) {
-                item->setBackgroundColor(col, QColor(255, 255, 255, 100));
-            }
-        }
+        QVariant v = item->data(0,Qt::UserRole);
+        Compound*  c =  v.value<Compound*>();                                                                                   
+        CompoundsHash.insert(c , item);
         ++itr;
     }
+}
+
+void LigandWidget::markAsDone(Compound* compound) 
+{
+if(compound == NULL)
+    return;
+QHash<Compound *, QTreeWidgetItem *>::const_iterator i = CompoundsHash.find(compound);
+if (i != CompoundsHash.end() & i.key() == compound) 
+{
+    QTreeWidgetItem* item = i.value();  
+    if (item != NULL) 
+    {
+        for (int col = 0; col < treeWidget->columnCount(); col++) 
+        {
+        item->setBackground(col,QBrush(QColor(61, 204, 85, 100)));
+        }
+    }
+}    
+}
+
+void LigandWidget::resetColor() 
+{
+
+QTreeWidgetItemIterator itr(treeWidget);
+while (*itr) {
+    QTreeWidgetItem* item =(*itr);
+    if (item) {
+        for (int col = 0; col < treeWidget->columnCount(); col++) {
+            item->setBackgroundColor(col, QColor(255, 255, 255, 100));
+        }
+    }
+    ++itr;
+}
 }
 
 

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -407,16 +407,16 @@ void LigandWidget::showTable() {
             }*/
 
     }
-setHash();
-treeWidget->setSortingEnabled(true);
+    setHash();
+    treeWidget->setSortingEnabled(true);
 }
 
 void LigandWidget::setHash()
 {
     CompoundsHash.clear();
     QTreeWidgetItemIterator itr(treeWidget);
-     while(*itr)
-    {     
+    
+    while(*itr) {     
         QTreeWidgetItem* item =(*itr);
         QVariant v = item->data(0,Qt::UserRole);
         Compound*  c =  v.value<Compound*>();                                                                                   
@@ -427,35 +427,34 @@ void LigandWidget::setHash()
 
 void LigandWidget::markAsDone(Compound* compound) 
 {
-if(compound == NULL)
-    return;
-QHash<Compound *, QTreeWidgetItem *>::const_iterator i = CompoundsHash.find(compound);
-if (i != CompoundsHash.end() & i.key() == compound) 
-{
-    QTreeWidgetItem* item = i.value();  
-    if (item != NULL) 
-    {
-        for (int col = 0; col < treeWidget->columnCount(); col++) 
-        {
-        item->setBackground(col,QBrush(QColor(61, 204, 85, 100)));
+    if(compound == nullptr)
+        return;
+    
+    QHash<Compound *, QTreeWidgetItem *>::const_iterator i = CompoundsHash.find(compound);
+    
+    if (i != CompoundsHash.end() & i.key() == compound) {
+        QTreeWidgetItem* item = i.value();  
+        if (item != nullptr) {
+            for (int col = 0; col < treeWidget->columnCount(); col++) {
+                item->setBackground(col,QBrush(QColor(61, 204, 85, 100)));
+            }
         }
-    }
-}    
+    }    
 }
 
 void LigandWidget::resetColor() 
 {
-
-QTreeWidgetItemIterator itr(treeWidget);
-while (*itr) {
-    QTreeWidgetItem* item =(*itr);
-    if (item) {
-        for (int col = 0; col < treeWidget->columnCount(); col++) {
-            item->setBackgroundColor(col, QColor(255, 255, 255, 100));
+    QTreeWidgetItemIterator itr(treeWidget);
+    
+    while (*itr) {
+        QTreeWidgetItem* item = (*itr);
+        if (item) {
+            for (int col = 0; col < treeWidget->columnCount(); col++) {
+                item->setBackgroundColor(col, QColor(255, 255, 255, 100));
+            }
         }
+        ++itr;
     }
-    ++itr;
-}
 }
 
 

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -410,19 +410,32 @@ void LigandWidget::showTable() {
     treeWidget->setSortingEnabled(true);
 }
 
-void LigandWidget::markAsDone(Compound* compound) {
+void LigandWidget::markAsDone(QTreeWidget* group) {
+  
+   // QTreeWidgetItem* matchedItem = nullptr;
 
-    if (compound != NULL) {
-        QTreeWidgetItem* item = getItem(compound);
+    QTreeWidgetItem* item = nullptr;
+    QTreeWidgetItemIterator itr(treeWidget);
+      while (*itr) {
+        item =(*itr);
+        if(item){
+       if(item->backgroundColor(0)  != QColor(61, 204, 85, 100))
+        {  
+           
+            QTreeWidgetItem* chq = getItem(group, item); 
 
-        if (item != NULL) {
+             if (chq != NULL) {
             for (int col = 0; col < treeWidget->columnCount(); col++) {
-                item->setBackgroundColor(col, QColor(61, 204, 85, 100));
+                chq->setBackgroundColor(col, QColor(61, 204, 85, 100));
             }
         }
+       
+       }
+       }
+        ++itr;   
+    }    
     }
 
-}
 
 void LigandWidget::resetColor() {
 
@@ -438,35 +451,32 @@ void LigandWidget::resetColor() {
     }
 }
 
-QTreeWidgetItem* LigandWidget::getItem(Compound* compound) {
-
+QTreeWidgetItem* LigandWidget::getItem(QTreeWidget* group, QTreeWidgetItem* compound) {
     QTreeWidgetItem* matchedItem = nullptr;
-    QTreeWidgetItemIterator itr(treeWidget);
 
-    QTreeWidgetItem* item = nullptr;   
-    QTreeWidgetItem* item1 = nullptr;
-    item1 = (*itr);
-    if(item1->backgroundColor(0)  == QColor(61, 204, 85, 100))
-    {}
-    else{
-   while (*itr) {
-        item =(*itr);
-        if(item->backgroundColor(0)  != QColor(61, 204, 85, 100))
-        {   
-        QVariant v = item->data(0,Qt::UserRole);
-        Compound* itemCompound =  v.value<Compound*>();
-        if (itemCompound) {
-            if (itemCompound == compound) {
-                matchedItem = item;
-                break;
-            }
-        }
-        }
-        ++itr;   
-    }
-    }
-    return matchedItem;
+    QTreeWidgetItemIterator itr(group);
+    while (*itr) {
+        QTreeWidgetItem* item =(*itr);
+        if (item) {
+            QVariant v1 = compound->data(0,Qt::UserRole);
+            Compound* itemCompound =  v1.value<Compound*>();
 
+            QVariant v = item->data(0,Qt::UserRole);
+            PeakGroup* groups =  v.value<PeakGroup*>();
+            Compound * grp = groups->compound;
+           
+                if(grp == itemCompound)
+                {
+                // cerr<<grp<<" ";
+                // cerr<<itemCompound<<"\n";
+                matchedItem = compound;
+                return matchedItem;
+                }
+        }
+        ++itr;
+    }
+
+return matchedItem;
 }
 
 void LigandWidget::saveCompoundList(){

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -408,8 +408,10 @@ void LigandWidget::showTable() {
 
     }
   
-      QTreeWidgetItemIterator itr(treeWidget);
-  cerr<<"-------------------------Creating new hash table-----------------------------"<<"\n";
+    
+    Hash.clear();
+    QTreeWidgetItemIterator itr(treeWidget);
+    cerr<<"-------------------------Creating new hash table-----------------------------"<<"\n";
     while(*itr)
     {     
     QTreeWidgetItem* item =(*itr);
@@ -428,7 +430,7 @@ void LigandWidget::markAsDone(Compound* compound) {
 if(compound != NULL)
 {
     QHash<Compound *, QTreeWidgetItem *>::const_iterator i = Hash.find(compound);
-if (i.key() == compound) {
+if (i != Hash.end() & i.key() == compound) {
      QTreeWidgetItem* item = i.value();  
 
         if (item != NULL) {

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -409,14 +409,14 @@ void LigandWidget::showTable() {
     }
   
     
-    Hash.clear();
+    CompoundsHash.clear();
     QTreeWidgetItemIterator itr(treeWidget);
         while(*itr)
         {     
         QTreeWidgetItem* item =(*itr);
         QVariant v = item->data(0,Qt::UserRole);
         Compound*  c =  v.value<Compound*>();                                                                                   
-        Hash.insert(c , item);
+        CompoundsHash.insert(c , item);
         ++itr;
         }
 treeWidget->setSortingEnabled(true);
@@ -425,13 +425,13 @@ treeWidget->setSortingEnabled(true);
 void LigandWidget::markAsDone(Compound* compound) {
     if(compound != NULL)
     {
-        QHash<Compound *, QTreeWidgetItem *>::const_iterator i = Hash.find(compound);
-        if (i != Hash.end() & i.key() == compound) {
+        QHash<Compound *, QTreeWidgetItem *>::const_iterator i = CompoundsHash.find(compound);
+        if (i != CompoundsHash.end() & i.key() == compound) {
             QTreeWidgetItem* item = i.value();  
 
                 if (item != NULL) {
                     for (int col = 0; col < treeWidget->columnCount(); col++) {
-                        item->setBackgroundColor(col, QColor(61, 204, 85, 100));
+                        item->setBackground(col,QBrush(QColor(61, 204, 85, 100)));
                     }
                 }
         }

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -407,23 +407,29 @@ void LigandWidget::showTable() {
             }*/
 
     }
-  
-    
-    CompoundsHash.clear();
-    QTreeWidgetItemIterator itr(treeWidget);
-        while(*itr)
-        {     
-        QTreeWidgetItem* item =(*itr);
-        QVariant v = item->data(0,Qt::UserRole);
-        Compound*  c =  v.value<Compound*>();                                                                                   
-        CompoundsHash.insert(c , item);
-        ++itr;
-        }
+setHash();
 treeWidget->setSortingEnabled(true);
 }
 
+
+
+void LigandWidget::setHash()
+{
+    CompoundsHash.clear();
+    QTreeWidgetItemIterator itr(treeWidget);
+        while(*itr)
+            {     
+                QTreeWidgetItem* item =(*itr);
+                QVariant v = item->data(0,Qt::UserRole);
+                Compound*  c =  v.value<Compound*>();                                                                                   
+                CompoundsHash.insert(c , item);
+                ++itr;
+            }
+}
+
 void LigandWidget::markAsDone(Compound* compound) {
-    if(compound != NULL)
+    if(compound == NULL)
+    return;
     {
         QHash<Compound *, QTreeWidgetItem *>::const_iterator i = CompoundsHash.find(compound);
         if (i != CompoundsHash.end() & i.key() == compound) {

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -443,10 +443,16 @@ QTreeWidgetItem* LigandWidget::getItem(Compound* compound) {
     QTreeWidgetItem* matchedItem = nullptr;
     QTreeWidgetItemIterator itr(treeWidget);
 
-    QTreeWidgetItem* item = nullptr;
-
-    while (*itr) {
+    QTreeWidgetItem* item = nullptr;   
+    QTreeWidgetItem* item1 = nullptr;
+    item1 = (*itr);
+    if(item1->backgroundColor(0)  == QColor(61, 204, 85, 100))
+    {}
+    else{
+   while (*itr) {
         item =(*itr);
+        if(item->backgroundColor(0)  != QColor(61, 204, 85, 100))
+        {   
         QVariant v = item->data(0,Qt::UserRole);
         Compound* itemCompound =  v.value<Compound*>();
         if (itemCompound) {
@@ -455,9 +461,10 @@ QTreeWidgetItem* LigandWidget::getItem(Compound* compound) {
                 break;
             }
         }
-        ++itr;
+        }
+        ++itr;   
     }
-
+    }
     return matchedItem;
 
 }

--- a/src/gui/mzroll/ligandwidget.h
+++ b/src/gui/mzroll/ligandwidget.h
@@ -57,6 +57,7 @@ public:
     void setDatabaseAltered(QString dbame,bool altered);
 	Compound* getSelectedCompound();
     void loadCompoundDBMzroll(QString fileName);
+    void setHash();
 
     /**
      * @brief returns QTreeWidgetItem associated with specific compound

--- a/src/gui/mzroll/ligandwidget.h
+++ b/src/gui/mzroll/ligandwidget.h
@@ -30,6 +30,7 @@
 //Added when merged with Maven776
 #include <QtNetwork>
 #include <QNetworkReply>
+#include <QHash>
 
 class QAction;
 class QMenu;
@@ -62,7 +63,7 @@ public:
      * @param compound pointer to class Compound
      * @return QTreeWidgetItem pointer to class QTreeWidgetItem
      */
-    QTreeWidgetItem* getItem(QTreeWidget* group, QTreeWidgetItem* compound);
+    
 
 public Q_SLOTS: 
     void setCompoundFocus(Compound* c);
@@ -86,7 +87,7 @@ public Q_SLOTS:
      * @brief change the color of the compound which is present is peaks table
      * @param compound pointer to class Compound
      */
-    void markAsDone(QTreeWidget* group);
+    void markAsDone(Compound* compound);
 
 
 Q_SIGNALS:
@@ -112,6 +113,7 @@ private:
     QToolButton *loadButton;
     QLineEdit*  filterEditor;
     QPoint dragStartPosition;
+    QHash<Compound *, QTreeWidgetItem *> Hash;
 
     QHash<QString,bool>alteredDatabases;
 

--- a/src/gui/mzroll/ligandwidget.h
+++ b/src/gui/mzroll/ligandwidget.h
@@ -62,7 +62,7 @@ public:
      * @param compound pointer to class Compound
      * @return QTreeWidgetItem pointer to class QTreeWidgetItem
      */
-    QTreeWidgetItem* getItem(Compound* compound);
+    QTreeWidgetItem* getItem(QTreeWidget* group, QTreeWidgetItem* compound);
 
 public Q_SLOTS: 
     void setCompoundFocus(Compound* c);
@@ -86,7 +86,7 @@ public Q_SLOTS:
      * @brief change the color of the compound which is present is peaks table
      * @param compound pointer to class Compound
      */
-    void markAsDone(Compound* compound);
+    void markAsDone(QTreeWidget* group);
 
 
 Q_SIGNALS:

--- a/src/gui/mzroll/ligandwidget.h
+++ b/src/gui/mzroll/ligandwidget.h
@@ -113,7 +113,7 @@ private:
     QToolButton *loadButton;
     QLineEdit*  filterEditor;
     QPoint dragStartPosition;
-    QHash<Compound *, QTreeWidgetItem *> Hash;
+    QHash<Compound *, QTreeWidgetItem *> CompoundsHash;
 
     QHash<QString,bool>alteredDatabases;
 

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -384,7 +384,7 @@ void TableDockWidget::updateCompoundWidget() {
             if (item) {
                 QVariant v = item->data(0,Qt::UserRole);
                 PeakGroup* group =  v.value<PeakGroup*>();
-                if ( group == NULL ) continue;
+                if ( group == nullptr ) continue;
                 _mainwindow->ligandWidget->markAsDone(group->compound);
             }
         ++itr;

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -249,7 +249,6 @@ void TableDockWidget::setIntensityColName() {
 }
 
 void TableDockWidget::setupPeakTable() {
-    cerr<<"------------------Set up peak table called------------------\n";
 
     QStringList colNames;
     
@@ -310,7 +309,6 @@ void TableDockWidget::setupPeakTable() {
 }
 
 void TableDockWidget::updateTable() {
-    cerr<<"--------------------------------Update table called--------------------------\n";
     QTreeWidgetItemIterator it(treeWidget);
     while (*it) {
         updateItem(*it);
@@ -320,13 +318,6 @@ void TableDockWidget::updateTable() {
 }
 
 
-void TableDockWidget::updateTable1() {
-    QTreeWidgetItemIterator it(treeWidget);
-    while (*it) {
-        updateItem(*it);
-        ++it;
-    }
-}
 
 void TableDockWidget::updateItem(QTreeWidgetItem* item) {
     QVariant v = item->data(0,Qt::UserRole);
@@ -384,57 +375,27 @@ void TableDockWidget::updateItem(QTreeWidgetItem* item) {
     }
 }
 
-// void TableDockWidget::updateCompoundWidget() {
-//     QTime myTimer;
-//     myTimer.start();
-
-//     _mainwindow->ligandWidget->resetColor();
-//     cerr<<"Update Compound Widget called\n";
-
-//     QTreeWidgetItemIterator itr(treeWidget);
-
-    
-//     while (*itr) {
-//         QTreeWidgetItem* item =(*itr);
-//         if (item) {
-//             QVariant v = item->data(0,Qt::UserRole);
-//             PeakGroup* group =  v.value<PeakGroup*>();
-//             if ( group == NULL ) continue;
-
-//             _mainwindow->ligandWidget->markAsDone(group->compound);
-//         }
-//         ++itr;
-//     }
-//     int nMilliseconds = myTimer.elapsed();
-//     cerr<<nMilliseconds;
-// }
-
 
 void TableDockWidget::updateCompoundWidget() {
     QTime myTimer;
     myTimer.start();
-
     _mainwindow->ligandWidget->resetColor();
-    cerr<<"Update Compound Widget called\n";
+    QTreeWidgetItemIterator itr(treeWidget);
+    while (*itr) {
+        QTreeWidgetItem* item =(*itr);
+        if (item) {
+            QVariant v = item->data(0,Qt::UserRole);
+            PeakGroup* group =  v.value<PeakGroup*>();
+            if ( group == NULL ) continue;
 
-    // QTreeWidgetItemIterator itr(treeWidget);
 
-    // while (*itr) {
-    //     QTreeWidgetItem* item =(*itr);
-    //     if (item) {
-    //         QVariant v = item->data(0,Qt::UserRole);
-    //         PeakGroup* group =  v.value<PeakGroup*>();
-    //         if ( group == NULL ) continue;
-
-    //         _mainwindow->ligandWidget->markAsDone(group->compound);
-    //     }
-    //     ++itr;
-    // }
-    _mainwindow->ligandWidget->markAsDone(treeWidget);
+            _mainwindow->ligandWidget->markAsDone(group->compound);
+        }
+        ++itr;
+    }
     int nMilliseconds = myTimer.elapsed();
     cerr<<nMilliseconds;
 }
-
 
 void TableDockWidget::heatmapBackground(QTreeWidgetItem* item) {
     if(viewType != peakView) return;
@@ -692,8 +653,6 @@ void TableDockWidget::deleteAll() {
 
 void TableDockWidget::showAllGroups() {
     treeWidget->clear();
-    cerr<<"----------showw all groups called--------------------\n";
-
     _mainwindow->getAnalytics()->hitEvent("PeaksTable", "ShowAllGroups", allgroups.size());
 
     setFocus();
@@ -731,7 +690,6 @@ void TableDockWidget::showAllGroups() {
     }
     treeWidget->setSortingEnabled(true);
     updateStatus();
-    cerr<<"------------------------------------Called from showallgrp()----------------------------------\n";
     updateCompoundWidget();
 
 }
@@ -1162,7 +1120,6 @@ void TableDockWidget::deleteGroup(PeakGroup *groupX) {
         allgroups[i].groupId = i + 1;
     }
     updateTable();
-    cerr<<"---------------------------------Called from delete group----------------------------\n";
     updateCompoundWidget();
 }
 
@@ -1635,7 +1592,6 @@ void TableDockWidget::focusInEvent(QFocusEvent * event) {
     if (event->gotFocus()) {    
         pal.setColor(QPalette::Background, QColor(255, 255, 255, 100));
         setPalette(pal);
-        cerr<<"------------------------------------------Called from focus in event------------------------------------------\n";
         updateCompoundWidget();
     }
 }
@@ -2004,7 +1960,6 @@ void TableDockWidget::savePeakTable(QString fileName) {
 }
 
 void TableDockWidget::loadPeakTable() {
-    cerr<<"load peak table called\n";
     QString dir = ".";
     QSettings* settings = _mainwindow->getSettings();
     if ( settings->contains("lastDir") ) dir = settings->value("lastDir").value<QString>();
@@ -2421,12 +2376,10 @@ int TableDockWidget::loadCSVFile(QString filename, QString sep="\t"){
 
 
 void TableDockWidget::switchTableView() {
-    cerr<<"Switch Table view called\n";
     viewType == groupView ? viewType=peakView: viewType=groupView;
     setupPeakTable();
     showAllGroups();
-    cerr<<"Reached Here\n";
-    updateTable1();
+    updateTable();
 }
 
 MatrixXf TableDockWidget::getGroupMatrix() {

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -384,6 +384,32 @@ void TableDockWidget::updateItem(QTreeWidgetItem* item) {
     }
 }
 
+// void TableDockWidget::updateCompoundWidget() {
+//     QTime myTimer;
+//     myTimer.start();
+
+//     _mainwindow->ligandWidget->resetColor();
+//     cerr<<"Update Compound Widget called\n";
+
+//     QTreeWidgetItemIterator itr(treeWidget);
+
+    
+//     while (*itr) {
+//         QTreeWidgetItem* item =(*itr);
+//         if (item) {
+//             QVariant v = item->data(0,Qt::UserRole);
+//             PeakGroup* group =  v.value<PeakGroup*>();
+//             if ( group == NULL ) continue;
+
+//             _mainwindow->ligandWidget->markAsDone(group->compound);
+//         }
+//         ++itr;
+//     }
+//     int nMilliseconds = myTimer.elapsed();
+//     cerr<<nMilliseconds;
+// }
+
+
 void TableDockWidget::updateCompoundWidget() {
     QTime myTimer;
     myTimer.start();
@@ -391,21 +417,24 @@ void TableDockWidget::updateCompoundWidget() {
     _mainwindow->ligandWidget->resetColor();
     cerr<<"Update Compound Widget called\n";
 
-    QTreeWidgetItemIterator itr(treeWidget);
-    while (*itr) {
-        QTreeWidgetItem* item =(*itr);
-        if (item) {
-            QVariant v = item->data(0,Qt::UserRole);
-            PeakGroup* group =  v.value<PeakGroup*>();
-            if ( group == NULL ) continue;
+    // QTreeWidgetItemIterator itr(treeWidget);
 
-            _mainwindow->ligandWidget->markAsDone(group->compound);
-        }
-        ++itr;
-    }
+    // while (*itr) {
+    //     QTreeWidgetItem* item =(*itr);
+    //     if (item) {
+    //         QVariant v = item->data(0,Qt::UserRole);
+    //         PeakGroup* group =  v.value<PeakGroup*>();
+    //         if ( group == NULL ) continue;
+
+    //         _mainwindow->ligandWidget->markAsDone(group->compound);
+    //     }
+    //     ++itr;
+    // }
+    _mainwindow->ligandWidget->markAsDone(treeWidget);
     int nMilliseconds = myTimer.elapsed();
     cerr<<nMilliseconds;
 }
+
 
 void TableDockWidget::heatmapBackground(QTreeWidgetItem* item) {
     if(viewType != peakView) return;

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -377,24 +377,18 @@ void TableDockWidget::updateItem(QTreeWidgetItem* item) {
 
 
 void TableDockWidget::updateCompoundWidget() {
-    QTime myTimer;
-    myTimer.start();
     _mainwindow->ligandWidget->resetColor();
     QTreeWidgetItemIterator itr(treeWidget);
     while (*itr) {
         QTreeWidgetItem* item =(*itr);
-        if (item) {
-            QVariant v = item->data(0,Qt::UserRole);
-            PeakGroup* group =  v.value<PeakGroup*>();
-            if ( group == NULL ) continue;
-
-
-            _mainwindow->ligandWidget->markAsDone(group->compound);
-        }
+            if (item) {
+                QVariant v = item->data(0,Qt::UserRole);
+                PeakGroup* group =  v.value<PeakGroup*>();
+                if ( group == NULL ) continue;
+                _mainwindow->ligandWidget->markAsDone(group->compound);
+            }
         ++itr;
     }
-    int nMilliseconds = myTimer.elapsed();
-    cerr<<nMilliseconds;
 }
 
 void TableDockWidget::heatmapBackground(QTreeWidgetItem* item) {

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -249,6 +249,7 @@ void TableDockWidget::setIntensityColName() {
 }
 
 void TableDockWidget::setupPeakTable() {
+    cerr<<"------------------Set up peak table called------------------\n";
 
     QStringList colNames;
     
@@ -309,12 +310,22 @@ void TableDockWidget::setupPeakTable() {
 }
 
 void TableDockWidget::updateTable() {
+    cerr<<"--------------------------------Update table called--------------------------\n";
     QTreeWidgetItemIterator it(treeWidget);
     while (*it) {
         updateItem(*it);
         ++it;
     }
     updateStatus();
+}
+
+
+void TableDockWidget::updateTable1() {
+    QTreeWidgetItemIterator it(treeWidget);
+    while (*it) {
+        updateItem(*it);
+        ++it;
+    }
 }
 
 void TableDockWidget::updateItem(QTreeWidgetItem* item) {
@@ -374,8 +385,11 @@ void TableDockWidget::updateItem(QTreeWidgetItem* item) {
 }
 
 void TableDockWidget::updateCompoundWidget() {
+    QTime myTimer;
+    myTimer.start();
 
     _mainwindow->ligandWidget->resetColor();
+    cerr<<"Update Compound Widget called\n";
 
     QTreeWidgetItemIterator itr(treeWidget);
     while (*itr) {
@@ -389,6 +403,8 @@ void TableDockWidget::updateCompoundWidget() {
         }
         ++itr;
     }
+    int nMilliseconds = myTimer.elapsed();
+    cerr<<nMilliseconds;
 }
 
 void TableDockWidget::heatmapBackground(QTreeWidgetItem* item) {
@@ -647,6 +663,7 @@ void TableDockWidget::deleteAll() {
 
 void TableDockWidget::showAllGroups() {
     treeWidget->clear();
+    cerr<<"----------showw all groups called--------------------\n";
 
     _mainwindow->getAnalytics()->hitEvent("PeaksTable", "ShowAllGroups", allgroups.size());
 
@@ -685,6 +702,7 @@ void TableDockWidget::showAllGroups() {
     }
     treeWidget->setSortingEnabled(true);
     updateStatus();
+    cerr<<"------------------------------------Called from showallgrp()----------------------------------\n";
     updateCompoundWidget();
 
 }
@@ -1115,6 +1133,7 @@ void TableDockWidget::deleteGroup(PeakGroup *groupX) {
         allgroups[i].groupId = i + 1;
     }
     updateTable();
+    cerr<<"---------------------------------Called from delete group----------------------------\n";
     updateCompoundWidget();
 }
 
@@ -1587,6 +1606,7 @@ void TableDockWidget::focusInEvent(QFocusEvent * event) {
     if (event->gotFocus()) {    
         pal.setColor(QPalette::Background, QColor(255, 255, 255, 100));
         setPalette(pal);
+        cerr<<"------------------------------------------Called from focus in event------------------------------------------\n";
         updateCompoundWidget();
     }
 }
@@ -1955,6 +1975,7 @@ void TableDockWidget::savePeakTable(QString fileName) {
 }
 
 void TableDockWidget::loadPeakTable() {
+    cerr<<"load peak table called\n";
     QString dir = ".";
     QSettings* settings = _mainwindow->getSettings();
     if ( settings->contains("lastDir") ) dir = settings->value("lastDir").value<QString>();
@@ -2371,11 +2392,12 @@ int TableDockWidget::loadCSVFile(QString filename, QString sep="\t"){
 
 
 void TableDockWidget::switchTableView() {
-
+    cerr<<"Switch Table view called\n";
     viewType == groupView ? viewType=peakView: viewType=groupView;
     setupPeakTable();
     showAllGroups();
-    updateTable();
+    cerr<<"Reached Here\n";
+    updateTable1();
 }
 
 MatrixXf TableDockWidget::getGroupMatrix() {

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -186,6 +186,7 @@ public Q_SLOTS:
     void saveModel();
     void printPdfReport();
     void updateTable();
+    void updateTable1();
     void updateItem(QTreeWidgetItem *item);
     void updateStatus();
     //   void runScript();

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -186,7 +186,6 @@ public Q_SLOTS:
     void saveModel();
     void printPdfReport();
     void updateTable();
-    void updateTable1();
     void updateItem(QTreeWidgetItem *item);
     void updateStatus();
     //   void runScript();


### PR DESCRIPTION
Issue Number: #795
Reasons that led to slow down during navigating between large peak tables:
1) A new comparison between compound item list and group list was triggered every time the user switched between the peaks. This leads to a complexity of O(n^2)  when navigating between the peaks.

Solution:
1) Creating a hash to store the list of compounds. So now searching a group item in the compound list takes O(1), thus reducing the complexity of the operation to O(n).