### PR TITLE
UI: Hide unnecessary fields

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -314,8 +314,7 @@ using namespace mzUtils;
 	ligandWidget = new LigandWidget(this);
 	heatmap = new HeatMap(this);
 	galleryWidget = new GalleryWidget(this);
-	bookmarkedPeaks = new TableDockWidget(this, "Bookmarked Groups", 0, 1);
-	bookmarkedPeaks->bookmarkPeaksTAble = true;
+	bookmarkedPeaks = new TableDockWidget(this, "Bookmarked Groups", 0, TableDockWidget::bookmarkTable);
 
 	alignmentPolyVizDockWidget = new AlignmentPolyVizDockWidget(this);
 	alignmentPolyVizDockWidget->setWidget(alignmentPolyVizPlot);

--- a/src/gui/mzroll/scatterplot.cpp
+++ b/src/gui/mzroll/scatterplot.cpp
@@ -32,7 +32,7 @@ ScatterPlot::ScatterPlot(QWidget* w):PlotDockWidget(w,0) {
 
 void ScatterPlot::setPeakTable(QWidget* w) {
 
-    _peakTable = new TableDockWidget((MainWindow*) w, "Bookmarked Groups", 0);
+    _peakTable = new TableDockWidget((MainWindow*) w, "Bookmarked Groups", 0, TableDockWidget::scatterplotTable);
     _peakTable->setVisible(false);
     _peakTable->tableId = -1;
      (((MainWindow*) w)->noOfPeakTables)--;

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -1,6 +1,6 @@
 #include "tabledockwidget.h";
 
-TableDockWidget::TableDockWidget(MainWindow* mw, QString title, int numColms, int bookmarkFlag) {
+TableDockWidget::TableDockWidget(MainWindow* mw, QString title, int numColms, tableType type) {
     setAllowedAreas(Qt::AllDockWidgetAreas);
     setFloating(false);
     _mainwindow = mw;
@@ -13,6 +13,7 @@ TableDockWidget::TableDockWidget(MainWindow* mw, QString title, int numColms, in
 
     numColms=11;
     viewType = groupView;
+    setTableType(type);
 
     treeWidget=new QTreeWidget(this);
     treeWidget->setSortingEnabled(false);
@@ -56,7 +57,7 @@ TableDockWidget::TableDockWidget(MainWindow* mw, QString title, int numColms, in
     btnMergeMenu = new QMenu("Merge Groups");
     btnMerge->setMenu(btnMergeMenu);
     btnMerge->setPopupMode(QToolButton::InstantPopup);
-    if(!bookmarkFlag) btnMerge->setVisible(false);
+    if(type != bookmarkTable) btnMerge->setVisible(false);
 	connect(btnMergeMenu, SIGNAL(aboutToShow()), SLOT(showMergeTableOptions())); 
     connect(btnMergeMenu, SIGNAL(triggered(QAction*)), SLOT(mergeGroupsIntoPeakTable(QAction*)));
 
@@ -1192,7 +1193,7 @@ void TableDockWidget::markGroupGood() {
     setGroupLabel('g');
     showNextGroup();
     _mainwindow->peaksMarked++;
-    if (checkLabeledGroups() && !bookmarkPeaksTAble) _mainwindow->allPeaksMarked = true; 
+    if (checkLabeledGroups() && type != bookmarkTable) _mainwindow->allPeaksMarked = true; 
     _mainwindow->autoSaveSignal();
 }
 
@@ -1201,7 +1202,7 @@ void TableDockWidget::markGroupBad() {
     setGroupLabel('b');
     showNextGroup();
     _mainwindow->peaksMarked++;
-    if (checkLabeledGroups() && !bookmarkPeaksTAble) _mainwindow->allPeaksMarked = true; 
+    if (checkLabeledGroups() && type != bookmarkTable) _mainwindow->allPeaksMarked = true; 
     _mainwindow->autoSaveSignal();
 }
 

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -299,6 +299,21 @@ void TableDockWidget::setupPeakTable() {
     treeWidget->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     treeWidget->header()->adjustSize();
 
+    /* Remove "Ratio Change" and "P-value" fields from non-scatterplot
+     * tables where they are not relevant.
+     */
+    if (viewType == groupView && type != scatterplotTable) {
+        treeWidget->setColumnHidden(colNames.indexOf("Ratio Change"), true);
+        treeWidget->setColumnHidden(colNames.indexOf("P-value"), true);
+    }
+    else {
+        // make any hidden columns visible again
+        for (int i=0; i<colNames.size(); i++) {
+            treeWidget->setColumnHidden(i, false);
+        }
+    }
+
+
     treeWidget->setSortingEnabled(true);
 
 

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -62,7 +62,13 @@ class TableDockWidget : public QDockWidget
 
     QMap<QAction *, int> mergeAction;
     //QAction *hell;
-    bool bookmarkPeaksTAble = false;
+
+    enum tableType
+    {
+        peakTable = 0,
+        bookmarkTable = 1,
+        scatterplotTable = 2
+    };
 
     enum tableViewType
     {
@@ -77,7 +83,7 @@ class TableDockWidget : public QDockWidget
         Bad = 3
     };
 
-    TableDockWidget(MainWindow *mw, QString title, int numColms, int bookmarkFlag = 0);
+    TableDockWidget(MainWindow *mw, QString title, int numColms, tableType type = peakTable);
     ~TableDockWidget();
 
     int groupCount() { return allgroups.size(); }
@@ -227,6 +233,7 @@ public Q_SLOTS:
     void mergeGroupsIntoPeakTable(QAction *action);
     void switchTableView();
 
+    void setTableType(tableType t) { type = t; }
     void setTableView(tableViewType t) { viewType = t; }
     void clearClusters();
 
@@ -283,6 +290,7 @@ private:
     QDialog *filtersDialog;
     QMap<QString, QHistogramSlider *> sliders;
     float rtWindow = 2;
+    tableType type;
     tableViewType viewType;
     peakTableSelectionType peakTableSelection;
     QList<PeakGroup *> getCustomGroups(peakTableSelectionType peakSelection);


### PR DESCRIPTION
The fields "Ratio Change" and "P-value" are not required within regular peak tables and bookmarks table. These fields should be only visible when the table instance is showing scatter-plot groups. This PR addresses this issue.