### PR TITLE
Add close button to Scatter Plot

### DIFF
--- a/src/gui/mzroll/scatterplot.cpp
+++ b/src/gui/mzroll/scatterplot.cpp
@@ -92,6 +92,10 @@ void ScatterPlot::setupToolBar() {
 	btnF->setToolTip("Show Contrast Groups Dialog");
     connect(btnF, SIGNAL(clicked()),this,SLOT(contrastGroups()));
 
+    QWidget *spacerWidget = new QWidget(this);
+	spacerWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+	spacerWidget->setVisible(true);
+
     QToolButton *btnClose = new QToolButton(toolBar);
     btnClose->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
     connect(btnClose, SIGNAL(clicked()), this, SLOT(hide()));
@@ -105,6 +109,7 @@ void ScatterPlot::setupToolBar() {
     // new feature added - Kiran
     toolBar->addWidget(btnDelete);
     toolBar->addWidget(btnPeakTable);
+    toolBar->addWidget(spacerWidget);
     toolBar->addWidget(btnClose);
     // merged with maven776 - Kiran
     //  toolBar->addWidget(btnCovariants);

--- a/src/gui/mzroll/scatterplot.cpp
+++ b/src/gui/mzroll/scatterplot.cpp
@@ -92,6 +92,10 @@ void ScatterPlot::setupToolBar() {
 	btnF->setToolTip("Show Contrast Groups Dialog");
     connect(btnF, SIGNAL(clicked()),this,SLOT(contrastGroups()));
 
+    QToolButton *btnClose = new QToolButton(toolBar);
+    btnClose->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
+    connect(btnClose, SIGNAL(clicked()), this, SLOT(hide()));
+
     toolBar->addWidget(bntResetZoom);
     toolBar->addWidget(btnF);
     toolBar->addWidget(btnScatter);
@@ -101,6 +105,7 @@ void ScatterPlot::setupToolBar() {
     // new feature added - Kiran
     toolBar->addWidget(btnDelete);
     toolBar->addWidget(btnPeakTable);
+    toolBar->addWidget(btnClose);
     // merged with maven776 - Kiran
     //  toolBar->addWidget(btnCovariants);
 


### PR DESCRIPTION
The Scatter Plot icon on the right side panel was used to open/close the widget. After removing it from the side bar panel, there was no way to close it. 

This PR will add a close button for the widget.