### PR TITLE
Testpolly installer bootcamp

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -232,6 +232,53 @@ module.exports.createProject = function (token_filename,name) {
     });
 }
 
+module.exports.send_email = function (user_email,email_content,email_message) {
+    if (!user_email) {
+        console.log(chalk.red.bold("Email is required param."));
+        return;
+    } else {
+        if (!(user_email.includes("@"))){
+            console.log(chalk.red.bold("First param is email. Second param is email content. Third param is email_message. "));
+            return;
+            }
+        }
+    if (!email_content) {
+        console.log(chalk.red.bold("email_content is required param."));
+        return;
+    }
+    if (!email_message) {
+        console.log(chalk.red.bold("email_message is required param."));
+        return;
+    }
+    var options = {
+        method: 'POST',
+        url: ' https://7w9r94dq3h.execute-api.ap-south-1.amazonaws.com/cpj_beta/pyemail',
+        headers:
+            {
+                'content-type': 'application/json'
+            },
+        body:
+            {
+                user_email:user_email,
+                email_content:email_content,
+                email_message:email_message
+            },
+        json: true
+    };
+    request(options, function (error, response, body) {
+        if (error) throw new Error(chalk.bold.red(error));
+        console.log(chalk.yellow.bgBlack.bold(`send email Response: `));
+        if ((response.statusCode != 200) && (response.statusCode != 400)) {
+            console.log(chalk.red.bold("Unable to send email. Please check your APIs. Status code:"));
+            console.log(chalk.red.bold(response.statusCode));
+            console.log(chalk.green.bold(JSON.stringify(body)));
+            return;
+        }
+        console.log(chalk.green.bold(JSON.stringify(body)));
+        return body
+    });
+}
+
 module.exports.shareProject = function (token_filename,project_id,permission,usernames) {
     if (has_id_token(token_filename)) {
         public_token_header = read_id_token(token_filename);

--- a/bin/index.js
+++ b/bin/index.js
@@ -141,7 +141,7 @@ module.exports.authenticate = function(token_filename,email, password){
     console.log(chalk.yellow.bold("Fetching user pool..."));
     var options = {
         method: 'GET',
-        url: 'https://polly.elucidata.io/userpool',
+        url: 'http://testpolly.elucidata.io/userpool',
         json: true
     };
 
@@ -205,7 +205,7 @@ module.exports.createProject = function (token_filename,name) {
     }
     var options = {
         method: 'POST',
-        url: 'https://polly.elucidata.io/api/project',
+        url: 'http://testpolly.elucidata.io/api/project',
         headers:
             {
                 'cache-control': 'no-cache',
@@ -290,7 +290,7 @@ module.exports.shareProject = function (token_filename,project_id,permission,use
     }
     var options = {
         method: 'POST',
-        url: 'https://polly.elucidata.io/api/sharing/share_project',
+        url: 'http://testpolly.elucidata.io/api/sharing/share_project',
         headers:
             {
                 'cache-control': 'no-cache',
@@ -323,7 +323,7 @@ module.exports.get_upload_Project_urls = function (token_filename,id) {
     }
     var options = {
         method: 'GET',
-        url: 'https://polly.elucidata.io/api/project',
+        url: 'http://testpolly.elucidata.io/api/project',
         headers:
             {
                 'cache-control': 'no-cache',
@@ -358,7 +358,7 @@ module.exports.get_Project_names = function (token_filename) {
     }
     var options = {
         method: 'GET',
-        url: 'https://polly.elucidata.io/api/project',
+        url: 'http://testpolly.elucidata.io/api/project',
         headers:
             {
                 'cache-control': 'no-cache',
@@ -390,7 +390,7 @@ module.exports.get_organizational_databases = function (token_filename,organizat
     }
     var options = {
         method: 'GET',
-        url: 'https://polly.elucidata.io/api/project',
+        url: 'http://testpolly.elucidata.io/api/project',
         headers:
             {
                 'cache-control': 'no-cache',
@@ -424,7 +424,7 @@ module.exports.get_Project_files = function (token_filename,id) {
     }
     var options = {
         method: 'GET',
-        url: 'https://polly.elucidata.io/api/project',
+        url: 'http://testpolly.elucidata.io/api/project',
         headers:
             {
                 'cache-control': 'no-cache',

--- a/bin/index.js
+++ b/bin/index.js
@@ -141,7 +141,7 @@ module.exports.authenticate = function(token_filename,email, password){
     console.log(chalk.yellow.bold("Fetching user pool..."));
     var options = {
         method: 'GET',
-        url: 'http://testpolly.elucidata.io/userpool',
+        url: 'https://polly.elucidata.io/userpool',
         json: true
     };
 
@@ -205,7 +205,7 @@ module.exports.createProject = function (token_filename,name) {
     }
     var options = {
         method: 'POST',
-        url: 'http://testpolly.elucidata.io/api/project',
+        url: 'https://polly.elucidata.io/api/project',
         headers:
             {
                 'cache-control': 'no-cache',
@@ -290,7 +290,7 @@ module.exports.shareProject = function (token_filename,project_id,permission,use
     }
     var options = {
         method: 'POST',
-        url: 'http://testpolly.elucidata.io/api/sharing/share_project',
+        url: 'https://polly.elucidata.io/api/sharing/share_project',
         headers:
             {
                 'cache-control': 'no-cache',
@@ -323,7 +323,7 @@ module.exports.get_upload_Project_urls = function (token_filename,id) {
     }
     var options = {
         method: 'GET',
-        url: 'http://testpolly.elucidata.io/api/project',
+        url: 'https://polly.elucidata.io/api/project',
         headers:
             {
                 'cache-control': 'no-cache',
@@ -358,7 +358,7 @@ module.exports.get_Project_names = function (token_filename) {
     }
     var options = {
         method: 'GET',
-        url: 'http://testpolly.elucidata.io/api/project',
+        url: 'https://polly.elucidata.io/api/project',
         headers:
             {
                 'cache-control': 'no-cache',
@@ -390,7 +390,7 @@ module.exports.get_organizational_databases = function (token_filename,organizat
     }
     var options = {
         method: 'GET',
-        url: 'http://testpolly.elucidata.io/api/project',
+        url: 'https://polly.elucidata.io/api/project',
         headers:
             {
                 'cache-control': 'no-cache',
@@ -424,7 +424,7 @@ module.exports.get_Project_files = function (token_filename,id) {
     }
     var options = {
         method: 'GET',
-        url: 'http://testpolly.elucidata.io/api/project',
+        url: 'https://polly.elucidata.io/api/project',
         headers:
             {
                 'cache-control': 'no-cache',

--- a/sample_cred_file.xml
+++ b/sample_cred_file.xml
@@ -1,11 +1,7 @@
 <credentials>
 	<pollyaccountdetails>
-		<username>kailash.yadav@elucidata.io</username>
+		<username>polly_username_here</username>
 		<password>polly_password_here</password>
-		<project>agios_subset</project>
+		<project>polly_project_here</project>
 	</pollyaccountdetails>
-	<emailcredentials>
-        <email>kailash.yadav@elucidata.io</email>
-        <password></password>
-    </emailcredentials>
 </credentials>

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -691,7 +691,7 @@ void PeakDetectorCLI::writeReport(string setName,QString jsPath,QString nodePath
 				// jspath and nodepath are very important here..node executable will be used to connect to polly, with the help of index.js script..
 				QString upload_project_id = UploadToPolly(jsPath,nodePath,files_to_be_uploaded,creds,pollyProject); 
 				if (upload_project_id!=""){ //That means the upload was successfull, in that case, redirect the user to polly..
-					QString redirection_url = QString("<a href='http://testpolly.elucidata.io/main#project=%1&auto-redirect=%2&elmavenTimestamp=%3'>Go To Polly</a>").arg(upload_project_id).arg(redirect_to).arg(datetimestamp);
+					QString redirection_url = QString("<a href='https://polly.elucidata.io/main#project=%1&auto-redirect=%2&elmavenTimestamp=%3'>Go To Polly</a>").arg(upload_project_id).arg(redirect_to).arg(datetimestamp);
 					qDebug()<<"redirection url - \n"<<redirection_url;
 					QString filename=QStandardPaths::writableLocation(QStandardPaths::QStandardPaths::GenericConfigLocation) + QDir::separator()+datetimestamp+"_redirection_url.txt";
 					qDebug()<<"writing url to this file -"<<filename;

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -788,10 +788,11 @@ QString PeakDetectorCLI::UploadToPolly(QString jsPath,QString nodePath,QStringLi
 			}
 		}
 	if (projectId==""){
-		//In case no project matches with the user defined name or the user has not provided any project name,
-		// upload to default project..
-		_pollyIntegration->exportData(filenames,defaultprojectId);
-		upload_project_id = defaultprojectId;
+		//In case no project matches with the user defined name,
+		// Create the project and upload to it..This makes the project name to be mandatory..
+		QString new_project_id = _pollyIntegration->createProjectOnPolly(creds["polly_project"]);
+		_pollyIntegration->exportData(filenames,new_project_id);
+		upload_project_id = new_project_id;
 	}
 	else{
 		_pollyIntegration->exportData(filenames,projectId);

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -747,26 +747,28 @@ QMap<QString, QString> PeakDetectorCLI::readCredentialsFromXml(QString filename)
 	QMap<QString, QString> creds;
     QDomDocument doc;
     QFile file(filename);
-    if (!file.open(QIODevice::ReadOnly) || !doc.setContent(&file))
-        return creds;
+    if (!file.open(QIODevice::ReadOnly) || !doc.setContent(&file)){
+		qDebug()<<"Something is wrong with your credentials file..Please try again with a valid xml file..";
+		return creds;
+	}
 
 	//Get the root element
    QDomElement docElem = doc.documentElement(); 
    
    // you could check the root tag name here if it matters
-	QString rootTag = docElem.tagName(); // == persons
+	QString rootTag = docElem.tagName(); // == credentials
+	qDebug()<<"rootTag  -"<<rootTag;
 	QDomNodeList polly_creds = doc.elementsByTagName("pollyaccountdetails");
     for (int i = 0; i < polly_creds.size(); i++) {
         QDomNode n = polly_creds.item(i);
         QDomElement username = n.firstChildElement("username");
         QDomElement password = n.firstChildElement("password");
-        QDomElement project = n.firstChildElement("project");
-        if (username.isNull() || password.isNull() || project.isNull()){
+        if (username.isNull() || password.isNull()){
+			qDebug()<<"Both username and password must be provided in the credentials file.Please try again";
 			return creds;
 		}
 		creds["polly_username"]=username.text();
 		creds["polly_password"]=password.text();
-		creds["polly_project"]=project.text();
 		//Only considering the first occurance
         break;
     }

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -818,14 +818,13 @@ bool PeakDetectorCLI::validSampleCohort(QString sample_cohort_file, QStringList 
 	return true;
 }
 
-bool PeakDetectorCLI::validCohorts(QStringList Cohorts){
-	bool valid = false;
-	Cohorts.removeDuplicates();
-	if(Cohorts.size()<=9){
-		valid=true;
-	}
-	return valid;
-	}
+bool PeakDetectorCLI::validCohorts(QStringList cohorts) {
+	cohorts.removeDuplicates();
+	if(cohorts.size() > 9)
+		return false;
+	
+	return true;
+}
 
 void PeakDetectorCLI::saveJson(string setName) {
 	if (saveJsonEIC) {
@@ -848,8 +847,8 @@ QMap<QString, QString> PeakDetectorCLI::readCredentialsFromXml(QString filename)
 	QMap<QString, QString> creds;
     QDomDocument doc;
     QFile file(filename);
-    if (!file.open(QIODevice::ReadOnly) || !doc.setContent(&file)){
-		qDebug()<<"Something is wrong with your credentials file..Please try again with a valid xml file..";
+    if (!file.open(QIODevice::ReadOnly) || !doc.setContent(&file)) {
+		qDebug() << "Something is wrong with your credentials file. Please try again with a valid xml file..";
 		return creds;
 	}
 
@@ -858,8 +857,8 @@ QMap<QString, QString> PeakDetectorCLI::readCredentialsFromXml(QString filename)
    
    // you could check the root tag name here if it matters
 	QString rootTag = docElem.tagName(); // == credentials
-	if (rootTag!="credentials"){
-		qDebug()<<"The root tag of your credentials file is not correct..Please try again with a valid xml file..";
+	if (rootTag != "credentials") {
+		qDebug() << "The root tag of your credentials file is not correct..Please try again with a valid xml file..";
 		return creds;
 	}
 	QDomNodeList polly_creds = doc.elementsByTagName("pollyaccountdetails");
@@ -867,27 +866,30 @@ QMap<QString, QString> PeakDetectorCLI::readCredentialsFromXml(QString filename)
         QDomNode n = polly_creds.item(i);
         QDomElement username = n.firstChildElement("username");
         QDomElement password = n.firstChildElement("password");
-        if (username.isNull() || password.isNull()){
-			qDebug()<<"Both username and password must be provided in the credentials file.Please try again";
+        if (username.isNull() || password.isNull()) {
+			qDebug() << "Both username and password must be provided in the credentials file.Please try again";
 			return creds;
 		}
-		creds["polly_username"]=username.text();
-		creds["polly_password"]=password.text();
+		creds["polly_username"] = username.text();
+		creds["polly_password"] = password.text();
 		//Only considering the first occurance
         break;
     }
 	return creds;
 }
 
-QString PeakDetectorCLI::UploadToPolly(QString jsPath,QString nodePath,QStringList filenames,QMap<QString, QString> creds,QString pollyProject) {
+QString PeakDetectorCLI::UploadToPolly(QString jsPath, QString nodePath, 
+							QStringList filenames, QMap<QString, QString> creds, 
+							QString pollyProject) {
+	
 	QString upload_project_id;
 	
 	// set jspath and nodepath for _pollyIntegration library .
 	_pollyIntegration->jsPath = jsPath;
 	_pollyIntegration->nodePath = nodePath;
-	QString status = _pollyIntegration->authenticate_login(creds["polly_username"],creds["polly_password"]);
+	QString status = _pollyIntegration->authenticate_login(creds["polly_username"], creds["polly_password"]);
 	if (status != "ok") {
-		qDebug() << "Incorrect credentials...Please check..";
+		cerr << "Incorrect credentials. Please check." << endl;
 		return upload_project_id;
 	}
 	// user is logged in, now proceed to upload..
@@ -921,7 +923,8 @@ QString PeakDetectorCLI::UploadToPolly(QString jsPath,QString nodePath,QStringLi
 	return upload_project_id;
 }
 
-bool PeakDetectorCLI::send_user_email(QMap<QString, QString> creds,QString redirection_url,QString jsPath){
+bool PeakDetectorCLI::send_user_email(QMap<QString, QString> creds, QString redirection_url,
+						QString jsPath) {
 	QString user_email = creds["polly_username"];
 	QString email_message = "Data Successfully uploaded to Polly project " + pollyProject;
 	status = _pollyIntegration->send_email(user_email, redirection_url, email_message);

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -627,13 +627,13 @@ void PeakDetectorCLI::makeSampleCohortFile(QString sample_cohort_filename, QStri
 	file.close();
 }
 
-void PeakDetectorCLI::writeReport(string setName,QString jsPath,QString nodePath) {
+void PeakDetectorCLI::writeReport(string setName, QString jsPath, QString nodePath) {
 //TODO kailash, this function should not have jsPath and nodePath as its arguments..
 	cout << "\nwriteReport " << mavenParameters->allgroups.size() << " groups ";
 
 	//No project name with Polly arguments
 	if (!pollyArgs.isEmpty() && pollyProject.isEmpty()) {
-		cerr << "Please provide project name..\n" << endl;
+		cerr << "Please provide project name.\n" << endl;
 		return;
 	}
 
@@ -734,7 +734,7 @@ void PeakDetectorCLI::writeReport(string setName,QString jsPath,QString nodePath
 					QTextStream stream(&file);
 					stream << redirection_url << endl;
 				}
-				bool status = send_user_email(creds, redirection_url, jsPath);
+				bool status = send_user_email(creds, redirection_url);
 				qDebug() << "Emailer status - " << status;
 			}
 			else {
@@ -923,8 +923,7 @@ QString PeakDetectorCLI::UploadToPolly(QString jsPath, QString nodePath,
 	return upload_project_id;
 }
 
-bool PeakDetectorCLI::send_user_email(QMap<QString, QString> creds, QString redirection_url,
-						QString jsPath) {
+bool PeakDetectorCLI::send_user_email(QMap<QString, QString> creds, QString redirection_url) {
 	QString user_email = creds["polly_username"];
 	QString email_message = "Data Successfully uploaded to Polly project " + pollyProject;
 	status = _pollyIntegration->send_email(user_email, redirection_url, email_message);

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -731,7 +731,7 @@ void PeakDetectorCLI::writeReport(string setName, QString jsPath, QString nodePa
 
 			//jspath and nodepath are very important here..node executable will be used to connect to polly, with the help of index.js script..
 			QString upload_project_id = UploadToPolly(jsPath, nodePath, files_to_be_uploaded, 
-											creds, pollyProject); 
+											creds); 
 			
 			//That means the upload was successful, redirect the user to Polly..
 			if (!upload_project_id.isEmpty()) {
@@ -895,8 +895,7 @@ QMap<QString, QString> PeakDetectorCLI::readCredentialsFromXml(QString filename)
 }
 
 QString PeakDetectorCLI::UploadToPolly(QString jsPath, QString nodePath, 
-							QStringList filenames, QMap<QString, QString> creds, 
-							QString pollyProject) {
+							QStringList filenames, QMap<QString, QString> creds) {
 	
 	QString upload_project_id;
 	
@@ -915,7 +914,7 @@ QString PeakDetectorCLI::UploadToPolly(QString jsPath, QString nodePath,
 	QString projectId;
 	QString defaultprojectId;
 	if(pollyProject.isEmpty()){
-		pollyProject = "Default_Symphony_Polly_Project";
+		pollyProject = "Default_Elmaven_Polly_Project";
 	}
 	for (const auto& key : keys) {
 		if (projectnames_id[key].toString() == pollyProject) {

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -773,8 +773,10 @@ bool PeakDetectorCLI::validSampleCohort(QString sample_cohort_file,QStringList l
 			return valid;
 		}
 		if(!(splitRow.at(0)=="Sample")){
-			Samples.append(QString::fromStdString(splitRow.at(0).toStdString()));
-			Cohorts.append(QString::fromStdString(splitRow.at(1).toStdString()));
+			QString sampleName = splitRow.at(0);
+			QString cohortName = splitRow.at(1);
+			Samples.append(QString::fromStdString(sampleName.toStdString()));
+			Cohorts.append(QString::fromStdString(cohortName.toStdString()));
 		}
     }
 	qSort(Samples);

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -36,7 +36,7 @@ void PeakDetectorCLI::processOptions(int argc, char* argv[]) {
 							"X?defaultXml: Create a template config file",
 							"y?eicSmoothingWindow: Enter number of scans used for smoothing at a time <int>",
 							"z?minSignalBaseLineRatio: Enter min signal to baseline ratio threshold for a group <float>",
-							"P?pollyCred: Polly sign in credentials,username,password provided in xml file<string>",
+							"P?pollyCred: Polly sign in credentials,username,password provided in xml file <string>",
 							"N?pollyProject: Polly project where we want to upload our files <string>",
 							"S?sampleCohort: Sample cohort file needed for PollyPhi workflow <string>",
 							NULL 
@@ -612,17 +612,20 @@ string PeakDetectorCLI::cleanSampleName(string sampleName) {
         return out.toStdString();
 }
 
-void PeakDetectorCLI::makeSampleCohortFile(QString sample_cohort_filename,QStringList loadedSamples){
-	    QFile file(sample_cohort_filename);
-		if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
-			return;
-		QTextStream out(&file);
-		out << "Sample"<< ",Cohort"<<"\n";
-		for (int i = 0; i < loadedSamples.size(); i++){
-			out<<loadedSamples.at(i)<<",\n";
-		}
-		qDebug()<<"sample cohort file prepared...moving on to gsheet interface now..";
+void PeakDetectorCLI::makeSampleCohortFile(QString sample_cohort_filename, QStringList loadedSamples) {
+	QFile file(sample_cohort_filename);
+	if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+		return;
+	
+	QTextStream out(&file);
+	out << "Sample" << ",Cohort" << "\n";
+	for (const auto& sampleName : loadedSamples) {
+		out << sampleName << ",\n";
 	}
+
+	qDebug() << "sample cohort file prepared...moving on to gsheet interface now..";
+	file.close();
+}
 
 void PeakDetectorCLI::writeReport(string setName,QString jsPath,QString nodePath) {
 //TODO kailash, this function should not have jsPath and nodePath as its arguments..

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -897,7 +897,7 @@ QString PeakDetectorCLI::UploadToPolly(QString jsPath,QString nodePath,QStringLi
 
 bool PeakDetectorCLI::send_user_email(QMap<QString, QString> creds,QString redirection_url,QString jsPath){
 	QString user_email = creds["polly_username"];
-	QString email_message = "Data Successfully uploaded to Polly project "+creds["polly_project"];
+	QString email_message = "Data Successfully uploaded to Polly project "+pollyProject;
 	status = _pollyIntegration->send_email(user_email,redirection_url,email_message);
 	return status;
 }

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -642,7 +642,6 @@ void PeakDetectorCLI::writeReport(string setName,QString jsPath,QString nodePath
 	if (uploadToPolly_bool){
 		if(pollyProject_provided){
 			QMap<QString, QString> creds = readCredentialsFromXml(pollyArgs);
-			mavenParameters->outputdir = "";
 			cout<<"uploding to polly now.."<<endl;
 			QDateTime current_time;
 			QString datetimestamp= current_time.currentDateTime().toString();
@@ -656,7 +655,6 @@ void PeakDetectorCLI::writeReport(string setName,QString jsPath,QString nodePath
 				QDir qdir(writable_temp_dir);
 			}
 
-			// filedir = QString::fromStdString(mavenParameters->outputdir);//output directory as provided by the user
 			QString csv_filename = writable_temp_dir+QDir::separator()+datetimestamp+"_Peak_table_all_Elmaven_Polly";// uploading the csv file 
 			QString json_filename = writable_temp_dir+QDir::separator()+datetimestamp+"_Peaks_information_json_Elmaven_Polly";//  uploading the json file
 			QString compound_DB_filename = writable_temp_dir+QDir::separator()+datetimestamp+"_Compound_DB_Elmaven_Polly";//  uploading the compound DB file
@@ -717,15 +715,16 @@ void PeakDetectorCLI::writeReport(string setName,QString jsPath,QString nodePath
 	else{
 		//create an output folder
 		mzUtils::createDir(mavenParameters->outputdir.c_str());
-
+		string fileName = mavenParameters->outputdir + setName;
+		
 		//save Eic Json
-		saveJson(setName);
+		saveJson(fileName);
 
 		//save Mzroll File
-		saveMzRoll(setName);
+		saveMzRoll(fileName);
 
 		//save output CSV
-		saveCSV(setName);
+		saveCSV(fileName);
 	}
 }
 
@@ -812,7 +811,7 @@ void PeakDetectorCLI::saveJson(string setName) {
 		#endif
 
 		jsonReports=new JSONReports(mavenParameters);
-		string fileName = mavenParameters->outputdir + setName + ".json";
+		string fileName = setName + ".json";
 		jsonReports->saveMzEICJson(fileName,
 									mavenParameters->allgroups,mavenParameters->samples);
 		#ifndef __APPLE__
@@ -912,7 +911,7 @@ void PeakDetectorCLI::saveMzRoll(string setName) {
          double startSavingMzroll = getTime();
         #endif
 
-         writePeakTableXML(mavenParameters->outputdir + setName + ".mzroll");
+         writePeakTableXML(setName + ".mzroll");
 
         #ifndef __APPLE__
          cout << "\tExecution time (Saving mzroll)   : " << getTime() - startSavingMzroll << " seconds \n";
@@ -927,7 +926,7 @@ void PeakDetectorCLI::saveCSV(string setName) {
      double startSavingCSV = getTime();
     #endif
 	
-	string fileName = mavenParameters->outputdir + setName + ".csv";
+	string fileName = setName + ".csv";
 	
     CSVReports* csvreports = new CSVReports(mavenParameters->samples);
     csvreports->setMavenParameters(mavenParameters);

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -62,6 +62,7 @@ class PeakDetectorCLI {
 		QString pollyArgs;
 		QString pollyProject;
 		QString sample_cohort_file;
+		QString redirect_to = "gsheet_sym_polly_elmaven";
 		QString filedir;
 		QStringList pollyargs_list;
 		PollyIntegration* _pollyIntegration;
@@ -93,6 +94,7 @@ class PeakDetectorCLI {
 		bool uploadToPolly_bool = false;
 		bool pollyProject_provided = false;
 		bool sample_cohort_present = false;
+		bool valid_sample_cohort = false;
 		bool saveMzrollFile=true;
 		string csvFileFieldSeparator=",";
 		PeakGroup::QType quantitationType = PeakGroup::AreaTop;
@@ -174,6 +176,8 @@ class PeakDetectorCLI {
 		 * @param filenames [List of files to be uploaded on polly]
 		*/
 		QString UploadToPolly(QString jsPath,QString nodePath,QStringList filenames,QMap<QString, QString> creds,QString pollyProject);
+		bool validCohorts(QStringList Cohorts);
+		bool validSampleCohort(QString sample_cohort_file);
 		bool send_user_email(QMap<QString, QString> creds,QString redirection_url,QString jsPath);
 		QMap<QString, QString> readCredentialsFromXml(QString filename);
 		/**

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -176,8 +176,10 @@ class PeakDetectorCLI {
 		 * @param filenames [List of files to be uploaded on polly]
 		*/
 		QString UploadToPolly(QString jsPath,QString nodePath,QStringList filenames,QMap<QString, QString> creds,QString pollyProject);
+		QStringList getSampleList();
 		bool validCohorts(QStringList Cohorts);
-		bool validSampleCohort(QString sample_cohort_file);
+		void makeSampleCohortFile(QString sample_cohort_filename,QStringList loadedSamples);
+		bool validSampleCohort(QString sample_cohort_file,QStringList loadedSamples);
 		bool send_user_email(QMap<QString, QString> creds,QString redirection_url,QString jsPath);
 		QMap<QString, QString> readCredentialsFromXml(QString filename);
 		/**

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -60,6 +60,7 @@ class PeakDetectorCLI {
 		QString password;
 		QString projectname;
 		QString pollyArgs;
+		QString sample_cohort_file;
 		QString filedir;
 		QStringList pollyargs_list;
 		PollyIntegration* _pollyIntegration;
@@ -89,6 +90,7 @@ class PeakDetectorCLI {
 		bool reduceGroupsFlag = true;
 		bool saveJsonEIC=false;
 		bool uploadToPolly_bool = false;
+		bool sample_cohort_present = false;
 		bool saveMzrollFile=true;
 		string csvFileFieldSeparator=",";
 		PeakGroup::QType quantitationType = PeakGroup::AreaTop;

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -60,6 +60,7 @@ class PeakDetectorCLI {
 		QString password;
 		QString projectname;
 		QString pollyArgs;
+		QString pollyProject;
 		QString sample_cohort_file;
 		QString filedir;
 		QStringList pollyargs_list;
@@ -90,6 +91,7 @@ class PeakDetectorCLI {
 		bool reduceGroupsFlag = true;
 		bool saveJsonEIC=false;
 		bool uploadToPolly_bool = false;
+		bool pollyProject_provided = false;
 		bool sample_cohort_present = false;
 		bool saveMzrollFile=true;
 		string csvFileFieldSeparator=",";
@@ -171,7 +173,7 @@ class PeakDetectorCLI {
 		 * @param nodepath  [path to node executable]
 		 * @param filenames [List of files to be uploaded on polly]
 		*/
-		QString UploadToPolly(QString jsPath,QString nodePath,QStringList filenames,QMap<QString, QString> creds);
+		QString UploadToPolly(QString jsPath,QString nodePath,QStringList filenames,QMap<QString, QString> creds,QString pollyProject);
 		bool send_user_email(QMap<QString, QString> creds,QString redirection_url,QString jsPath);
 		QMap<QString, QString> readCredentialsFromXml(QString filename);
 		/**

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -190,6 +190,7 @@ class PeakDetectorCLI {
 		bool validSampleCohort(QString sample_cohort_file, QStringList loadedSamples);
 		bool send_user_email(QMap<QString, QString> creds, QString redirection_url);
 		QMap<QString, QString> readCredentialsFromXml(QString filename);
+		QString isReadyForPolly();
 		
 		/**
 		* [write Sample List in XML]

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -191,6 +191,7 @@ class PeakDetectorCLI {
 		bool send_user_email(QMap<QString, QString> creds, QString redirection_url);
 		QMap<QString, QString> readCredentialsFromXml(QString filename);
 		QString isReadyForPolly();
+		int prepareCompoundDbForPolly(QString fileName);
 		
 		/**
 		* [write Sample List in XML]

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -183,13 +183,14 @@ class PeakDetectorCLI {
 		 * @param nodepath  [path to node executable]
 		 * @param filenames [List of files to be uploaded on polly]
 		*/
-		QString UploadToPolly(QString jsPath,QString nodePath,QStringList filenames,QMap<QString, QString> creds,QString pollyProject);
+		QString UploadToPolly(QString jsPath, QString nodePath, QStringList filenames, QMap<QString, QString> creds, QString pollyProject);
 		QStringList getSampleList();
-		bool validCohorts(QStringList Cohorts);
-		void makeSampleCohortFile(QString sample_cohort_filename,QStringList loadedSamples);
-		bool validSampleCohort(QString sample_cohort_file,QStringList loadedSamples);
-		bool send_user_email(QMap<QString, QString> creds,QString redirection_url,QString jsPath);
+		bool validCohorts(QStringList cohorts);
+		void makeSampleCohortFile(QString sample_cohort_filename, QStringList loadedSamples);
+		bool validSampleCohort(QString sample_cohort_file, QStringList loadedSamples);
+		bool send_user_email(QMap<QString, QString> creds, QString redirection_url, QString jsPath);
 		QMap<QString, QString> readCredentialsFromXml(QString filename);
+		
 		/**
 		* [write Sample List in XML]
 		* @param parent [parent node]

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -163,10 +163,22 @@ class PeakDetectorCLI {
 
 		void groupReduction();
 
+		/**
+		 * @brief save output in a json file
+		 * @param setName file name with full path
+		*/
 		void saveJson(string setName);
 
+		/**
+		 * @brief save project as .mzroll
+		 * @param setName file name with full path
+		*/
 		void saveMzRoll(string setName);
 
+		/**
+		 * @brief save project as .mzroll
+		 * @param setName file name with full path
+		*/
 		void saveCSV(string setName);
 
 		/**

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -183,7 +183,7 @@ class PeakDetectorCLI {
 		 * @param nodepath  [path to node executable]
 		 * @param filenames [List of files to be uploaded on polly]
 		*/
-		QString UploadToPolly(QString jsPath, QString nodePath, QStringList filenames, QMap<QString, QString> creds, QString pollyProject);
+		QString UploadToPolly(QString jsPath, QString nodePath, QStringList filenames, QMap<QString, QString> creds);
 		QStringList getSampleList();
 		bool validCohorts(QStringList cohorts);
 		void makeSampleCohortFile(QString sample_cohort_filename, QStringList loadedSamples);

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -91,10 +91,6 @@ class PeakDetectorCLI {
 
 		bool reduceGroupsFlag = true;
 		bool saveJsonEIC=false;
-		bool uploadToPolly_bool = false;
-		bool pollyProject_provided = false;
-		bool sample_cohort_present = false;
-		bool valid_sample_cohort = false;
 		bool saveMzrollFile=true;
 		string csvFileFieldSeparator=",";
 		PeakGroup::QType quantitationType = PeakGroup::AreaTop;

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -188,7 +188,7 @@ class PeakDetectorCLI {
 		bool validCohorts(QStringList cohorts);
 		void makeSampleCohortFile(QString sample_cohort_filename, QStringList loadedSamples);
 		bool validSampleCohort(QString sample_cohort_file, QStringList loadedSamples);
-		bool send_user_email(QMap<QString, QString> creds, QString redirection_url, QString jsPath);
+		bool send_user_email(QMap<QString, QString> creds, QString redirection_url);
 		QMap<QString, QString> readCredentialsFromXml(QString filename);
 		
 		/**

--- a/src/cli/peakdetector/main.cpp
+++ b/src/cli/peakdetector/main.cpp
@@ -85,6 +85,9 @@ int main(int argc, char *argv[]) {
 	if (peakdetectorCLI->mavenParameters->allgroups.size() > 0) {
 		peakdetectorCLI->writeReport("compounds",jsPath,nodePath);
 	}
+	else if (!(peakdetectorCLI->pollyArgs.isEmpty())){
+		qDebug()<<"no peaks found..Please try again with different parameters";
+	}
 
 	//cleanup
 	delete_all(peakdetectorCLI->mavenParameters->samples);

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -305,7 +305,7 @@ void PollyElmavenInterfaceDialog::postUpload(QStringList patch_ids){
     QCoreApplication::processEvents();
     if (!patch_ids.isEmpty()){
         upload_status->setText("");
-        QString redirection_url = QString("http://testpolly.elucidata.io/main#project=%1&auto-redirect=firstview&elmavenTimestamp=%2").arg(upload_project_id).arg(datetimestamp);
+        QString redirection_url = QString("https://polly.elucidata.io/main#project=%1&auto-redirect=firstview&elmavenTimestamp=%2").arg(upload_project_id).arg(datetimestamp);
         qDebug()<<"redirection_url     - "<<redirection_url;
         pollyURL.setUrl(redirection_url);
         pollyButton->setVisible(true);

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -230,7 +230,12 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
     upload_status->setStyleSheet("QLabel {color : green; }");
     upload_status->setText("Preparing files..");
     QCoreApplication::processEvents();
-    QStringList filenames = prepareFilesToUpload(qdir);
+    QDateTime current_time;
+    QString datetimestamp= current_time.currentDateTime().toString();
+    datetimestamp.replace(" ","_");
+    datetimestamp.replace(":","-");
+    
+    QStringList filenames = prepareFilesToUpload(qdir,datetimestamp);
     if (filenames.isEmpty()){
         upload_status->setText("File preparation failed.");
         _loadingDialog->close();
@@ -300,7 +305,7 @@ void PollyElmavenInterfaceDialog::postUpload(QStringList patch_ids){
     QCoreApplication::processEvents();
     if (!patch_ids.isEmpty()){
         upload_status->setText("");
-        QString redirection_url = QString("https://polly.elucidata.io/main#project=%1&auto-redirect=firstview").arg(upload_project_id);
+        QString redirection_url = QString("http://testpolly.elucidata.io/main#project=%1&auto-redirect=firstview&elmavenTimestamp=%2").arg(upload_project_id).arg(datetimestamp);
         qDebug()<<"redirection_url     - "<<redirection_url;
         pollyURL.setUrl(redirection_url);
         pollyButton->setVisible(true);
@@ -318,11 +323,7 @@ void PollyElmavenInterfaceDialog::postUpload(QStringList patch_ids){
     emit uploadFinished(false);   
 }
 
-QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir){
-    QDateTime current_time;
-    QString datetimestamp= current_time.currentDateTime().toString();
-    datetimestamp.replace(" ","_");
-    datetimestamp.replace(":","-");
+QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir,QString datetimestamp){
     
     QString writable_temp_dir =  QStandardPaths::writableLocation(QStandardPaths::QStandardPaths::GenericConfigLocation) + QDir::separator() + "tmp_Elmaven_Polly_files";
     QString peak_table_name = comboBox_table_name->currentText();

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -231,12 +231,12 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
     upload_status->setText("Preparing files..");
     QCoreApplication::processEvents();
     QDateTime current_time;
-    QString datetimestamp= current_time.currentDateTime().toString();
+    QString datetimestamp = current_time.currentDateTime().toString();
     datetimestamp.replace(" ","_");
     datetimestamp.replace(":","-");
     
-    QStringList filenames = prepareFilesToUpload(qdir,datetimestamp);
-    if (filenames.isEmpty()){
+    QStringList filenames = prepareFilesToUpload(qdir, datetimestamp);
+    if (filenames.isEmpty()) {
         upload_status->setText("File preparation failed.");
         _loadingDialog->close();
         QCoreApplication::processEvents();
@@ -303,14 +303,14 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
 
 void PollyElmavenInterfaceDialog::postUpload(QStringList patch_ids){
     QCoreApplication::processEvents();
-    if (!patch_ids.isEmpty()){
+    if (!patch_ids.isEmpty()) {
         upload_status->setText("");
         QString redirection_url = QString("https://polly.elucidata.io/main#project=%1&auto-redirect=firstview&elmavenTimestamp=%2").arg(upload_project_id).arg(datetimestamp);
-        qDebug()<<"redirection_url     - "<<redirection_url;
+        qDebug() << "redirection_url     - " << redirection_url;
         pollyURL.setUrl(redirection_url);
         pollyButton->setVisible(true);
     }
-    else{
+    else {
         upload_status->setStyleSheet("QLabel {color : red; }");
         upload_status->setText("Error!");
         QString msg = "Unable to send data";
@@ -323,7 +323,7 @@ void PollyElmavenInterfaceDialog::postUpload(QStringList patch_ids){
     emit uploadFinished(false);   
 }
 
-QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir,QString datetimestamp){
+QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir, QString datetimestamp) {
     
     QString writable_temp_dir =  QStandardPaths::writableLocation(QStandardPaths::QStandardPaths::GenericConfigLocation) + QDir::separator() + "tmp_Elmaven_Polly_files";
     QString peak_table_name = comboBox_table_name->currentText();

--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -90,7 +90,7 @@ class PollyElmavenInterfaceDialog : public QDialog, public Ui_PollyElmavenInterf
                  * 7. finally output the list of files in that tmp directory..
                  */
 
-                QStringList prepareFilesToUpload(QDir qdir);
+                QStringList prepareFilesToUpload(QDir qdir, QString datetimestamp);
 
                 /**
                  * @brief This function uploads all the files prepared by prepareFilesToUpload function, to Polly

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -354,8 +354,7 @@ bool PollyIntegration::send_email(QString user_email,QString email_content,QStri
     QList<QByteArray> test_list = result_and_error.at(0).split('\n');
     int size = test_list.size();
     QByteArray result2 = test_list[size-2];
-    qDebug()<<"test_list - "<<test_list;
-    if (0){
+    if (result2=="1"){
         status=true;
     }
     return status;

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -31,14 +31,6 @@ PollyIntegration::~PollyIntegration()
     qDebug()<<"exiting PollyIntegration now....";
 }
 
-// name OF FUNCTION: run_qt_process
-// PURPOSE:
-//    This function uses Qprocess from Qt library to execute terminal commands from C++ and
-// Returns its output as QByteArray
-// CALLS TO: none
-//
-// CALLED FROM: multiple functions in this script
-
 QList<QByteArray> PollyIntegration::run_qt_process(QString command, QStringList args){
 
     // e.g: command = "authenticate", "get_Project_names" etc
@@ -65,15 +57,6 @@ QList<QByteArray> PollyIntegration::run_qt_process(QString command, QStringList 
     return QList<QByteArray>()<<result<<result2;
 }
 
-// name OF FUNCTION: get_run_id
-// PURPOSE:
-//    This function parses the output of "createproject" command returned by run_qt_process
-// this command is used to create a new project on polly
-// this function Returns project id for the new project..
-// CALLS TO: none
-//
-// CALLED FROM: createProjectOnPolly
-
 QString PollyIntegration::get_run_id(QByteArray result){
     QList<QByteArray> test_list = result.split('\n');
     int size = test_list.size();
@@ -86,34 +69,14 @@ QString PollyIntegration::get_run_id(QByteArray result){
     return run_id;
 }
 
-// name OF FUNCTION: get_project_upload_url_commands
-// PURPOSE:
-//    This function is responsible for uploading given files to polly.
-// It will take the upload urls as an input.
-// For every file in filenames, it will first modify the url a bit..
-// and then it will call "upload_project_data" command for that url,
-// This command simply does a put request for that url with the help of index.js and node..
-
-// CALLS TO: run_qt_process
-//
-// CALLED FROM: exportData
-
-
-QStringList PollyIntegration::get_project_upload_url_commands(QByteArray result2,QStringList filenames){
+QStringList PollyIntegration::get_project_upload_url_commands(QString url_with_wildcard, QStringList filenames){
     QStringList patch_ids ;
-    QList<QByteArray> test_list = result2.split('\n');
-    int size = test_list.size();
-    QByteArray url_jsons = test_list[size-2];
-    QJsonDocument doc(QJsonDocument::fromJson(url_jsons));
-    // Get JSON object
-    QJsonObject json = doc.object();
-    QVariantMap json_map = json.toVariantMap();
     for (int i=0; i < filenames.size(); ++i){
         QString filename = filenames.at(i);
         QStringList test_files_list = filename.split(QDir::separator());
         int size = test_files_list.size();
         QString new_filename = test_files_list[size-1];
-        QString url_with_wildcard =  json_map["file_upload_urls"].toString();
+        QString copy_url_with_wildcard = url_with_wildcard
         QString url_map_json = url_with_wildcard.replace("*",new_filename) ;
         QString upload_command = "upload_project_data";
         QList<QByteArray> patch_id_result_and_error = run_qt_process(upload_command,QStringList() <<url_map_json <<filename);
@@ -129,7 +92,6 @@ QStringList PollyIntegration::get_project_upload_url_commands(QByteArray result2
 // CALLS TO: run_qt_process
 //
 // CALLED FROM: loadDataFromPolly
-
 
 QStringList PollyIntegration::get_projectFiles_download_url_commands(QByteArray result2,QStringList filenames){
     QStringList patch_ids ;
@@ -401,9 +363,24 @@ QStringList PollyIntegration::exportData(QStringList filenames,QString projectId
     timer.start();
     QString get_upload_Project_urls = "get_upload_Project_urls";
     QList<QByteArray> result_and_error = run_qt_process(get_upload_Project_urls, QStringList() << credFile << projectId);
-    QStringList patch_ids = get_project_upload_url_commands(result_and_error.at(0),filenames);
+    QString url_with_wildcard = getFileUploadURLs(result_and_error.at(0));    
+    QStringList patch_ids = get_project_upload_url_commands(url_with_wildcard,filenames);
     qDebug() << "time taken in uploading json file, by polly cli is - "<<timer.elapsed();
+    
     return patch_ids;
+}
+
+QString PollyIntegration::getFileUploadURLs(QByteArray result2) {
+    QList<QByteArray> test_list = result2.split('\n');
+    int size = test_list.size();
+    QByteArray url_jsons = test_list[size-2];
+    QJsonDocument doc(QJsonDocument::fromJson(url_jsons));
+    // Get JSON object
+    QJsonObject json = doc.object();
+    QVariantMap json_map = json.toVariantMap();
+    QString url_with_wildcard =  json_map["file_upload_urls"].toString();
+
+    return url_with_wildcard;
 }
 
 // name OF FUNCTION: loadDataFromPolly

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -69,17 +69,18 @@ QString PollyIntegration::get_run_id(QByteArray result){
     return run_id;
 }
 
-QStringList PollyIntegration::get_project_upload_url_commands(QString url_with_wildcard, QStringList filenames){
-    QStringList patch_ids ;
-    for (int i=0; i < filenames.size(); ++i){
-        QString filename = filenames.at(i);
+QStringList PollyIntegration::get_project_upload_url_commands(QString url_with_wildcard, 
+                                QStringList filenames) {
+    
+    QStringList patch_ids;
+    for (auto& filename : filenames) {
         QStringList test_files_list = filename.split(QDir::separator());
         int size = test_files_list.size();
         QString new_filename = test_files_list[size-1];
         QString copy_url_with_wildcard = url_with_wildcard;
-        QString url_map_json = url_with_wildcard.replace("*",new_filename) ;
+        QString url_map_json = copy_url_with_wildcard.replace("*", new_filename) ;
         QString upload_command = "upload_project_data";
-        QList<QByteArray> patch_id_result_and_error = run_qt_process(upload_command,QStringList() <<url_map_json <<filename);
+        QList<QByteArray> patch_id_result_and_error = run_qt_process(upload_command, QStringList() << url_map_json << filename);
         patch_ids.append(patch_id_result_and_error.at(0));
     }
     return patch_ids;
@@ -152,17 +153,17 @@ int PollyIntegration::check_already_logged_in(){
 // CALLED FROM: external clients
 
 
-QString PollyIntegration::authenticate_login(QString username,QString password){
+QString PollyIntegration::authenticate_login(QString username, QString password) {
     QString command = "authenticate";
     QString status;
     
     QList<QByteArray> result_and_error = run_qt_process(command, QStringList() << credFile << username << password);
     int status_inside = check_already_logged_in();
-    if (status_inside==1){
-        status="ok";
+    if (status_inside == 1) {
+        status = "ok";
     }
-    else if (result_and_error.at(1)!=""){
-        status="error";
+    else if (result_and_error.at(1) != "") {
+        status = "error";
     }
     else {
         status = "incorrect credentials";
@@ -309,17 +310,19 @@ QString PollyIntegration::createProjectOnPolly(QString projectname){
     return run_id;
 }
 
-bool PollyIntegration::send_email(QString user_email,QString email_content,QString email_message){
-    bool status=false;
+bool PollyIntegration::send_email(QString user_email, QString email_content,
+                        QString email_message) {
+
     QString command2 = "send_email";
-    QList<QByteArray> result_and_error = run_qt_process(command2, QStringList() << user_email<< email_content<<email_message);
+    QList<QByteArray> result_and_error = run_qt_process(command2, QStringList() << user_email << email_content << email_message);
     QList<QByteArray> test_list = result_and_error.at(0).split('\n');
     int size = test_list.size();
     QByteArray result2 = test_list[size-2];
-    if (result2=="1"){
-        status=true;
-    }
-    return status;
+    
+    if (result2 == "1")
+        return true;
+
+    return false;
 }
 
 QString PollyIntegration::get_share_status(QByteArray result){
@@ -357,15 +360,15 @@ QString PollyIntegration::shareProjectOnPolly(QString project_id,QVariantMap col
 // CALLED FROM: external clients
 
 
-QStringList PollyIntegration::exportData(QStringList filenames,QString projectId) {
-    qDebug()<<"files to be uploaded   "<<filenames;
+QStringList PollyIntegration::exportData(QStringList filenames, QString projectId) {
+    qDebug() << "files to be uploaded " << filenames;
     QElapsedTimer timer;
     timer.start();
     QString get_upload_Project_urls = "get_upload_Project_urls";
     QList<QByteArray> result_and_error = run_qt_process(get_upload_Project_urls, QStringList() << credFile << projectId);
     QString url_with_wildcard = getFileUploadURLs(result_and_error.at(0));    
-    QStringList patch_ids = get_project_upload_url_commands(url_with_wildcard,filenames);
-    qDebug() << "time taken in uploading json file, by polly cli is - "<<timer.elapsed();
+    QStringList patch_ids = get_project_upload_url_commands(url_with_wildcard, filenames);
+    qDebug() << "time taken in uploading json file, by polly cli is - " << timer.elapsed();
     
     return patch_ids;
 }

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -76,7 +76,7 @@ QStringList PollyIntegration::get_project_upload_url_commands(QString url_with_w
         QStringList test_files_list = filename.split(QDir::separator());
         int size = test_files_list.size();
         QString new_filename = test_files_list[size-1];
-        QString copy_url_with_wildcard = url_with_wildcard
+        QString copy_url_with_wildcard = url_with_wildcard;
         QString url_map_json = url_with_wildcard.replace("*",new_filename) ;
         QString upload_command = "upload_project_data";
         QList<QByteArray> patch_id_result_and_error = run_qt_process(upload_command,QStringList() <<url_map_json <<filename);

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -347,6 +347,19 @@ QString PollyIntegration::createProjectOnPolly(QString projectname){
     return run_id;
 }
 
+bool PollyIntegration::send_email(QString user_email,QString email_content,QString email_message){
+    bool status=false;
+    QString command2 = "send_email";
+    QList<QByteArray> result_and_error = run_qt_process(command2, QStringList() << user_email<< email_content<<email_message);
+    QList<QByteArray> test_list = result_and_error.at(0).split('\n');
+    int size = test_list.size();
+    QByteArray result2 = test_list[size-2];
+    qDebug()<<"test_list - "<<test_list;
+    if (0){
+        status=true;
+    }
+    return status;
+}
 
 QString PollyIntegration::get_share_status(QByteArray result){
     QList<QByteArray> test_list = result.split('\n');

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -25,6 +25,7 @@ class PollyIntegration
 	    QStringList get_project_upload_url_commands(QByteArray result2,QStringList filenames);
 		QStringList get_projectFiles_download_url_commands(QByteArray result2,QStringList filenames);
 	    QString get_run_id(QByteArray result);
+		bool send_email(QString user_email,QString email_content,QString email_message);
 	    QString authenticate_login(QString username,QString password);
 	    int check_already_logged_in();
 		int check_node_executable();

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -48,7 +48,7 @@ class PollyIntegration
  		 * @return project ID generated for the new project
 		*/
 		QString get_run_id(QByteArray result);
-		bool send_email(QString user_email,QString email_content,QString email_message);
+		bool send_email(QString user_email, QString email_content, QString email_message);
 	    QString authenticate_login(QString username,QString password);
 	    int check_already_logged_in();
 		int check_node_executable();

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -18,13 +18,36 @@ class PollyIntegration
 		QString createProjectOnPolly(QString projectname);
 		QString shareProjectOnPolly(QString project_id,QVariantMap collaborators_map);
 		QString get_share_status(QByteArray result);
+		
+		/**
+ 		 * @brief Execute terminal commands from c++
+ 		 * @details This function uses Qprocess from Qt library to execute terminal commands from C++
+ 		 * @param command Terminal commands to be run
+ 		 * @param args List of arguments for the command
+ 		 * @return QByteArray of output and errors
+		*/
         QList<QByteArray> run_qt_process(QString command, QStringList args = QStringList());
 	    QByteArray run_system_process(QString command);
 	    QString get_urls(QByteArray result);
 	    QStringList get_system_urls(QString filename);
-	    QStringList get_project_upload_url_commands(QByteArray result2,QStringList filenames);
-		QStringList get_projectFiles_download_url_commands(QByteArray result2,QStringList filenames);
-	    QString get_run_id(QByteArray result);
+
+		/**
+		 * @brief Upload given files to Polly
+		 * @param url_with_wildcard URL for uploading the files with a * that has to be replaced
+		 * with the filename
+		 * @param filenames Names of the files to be uploaded to the project
+		 * @return patch_ids output and error for every file upload process
+		*/
+	    QStringList get_project_upload_url_commands(QString url_with_wildcard, QStringList filenames);
+		QString getFileUploadURLs(QByteArray result2);
+		QStringList get_projectFiles_download_url_commands(QByteArray result2, QStringList filenames);
+	    
+		/**
+ 		 * @brief Parse and return the project ID for a new Polly project
+ 		 * @param result output from running "createproject" command that creates a new Polly project
+ 		 * @return project ID generated for the new project
+		*/
+		QString get_run_id(QByteArray result);
 		bool send_email(QString user_email,QString email_content,QString email_message);
 	    QString authenticate_login(QString username,QString password);
 	    int check_already_logged_in();

--- a/tests/MavenTests/testCLI.cpp
+++ b/tests/MavenTests/testCLI.cpp
@@ -178,7 +178,7 @@ void TestCLI::testWriteReport() {
         QFileInfo mzrollFile(QString::fromStdString(peakdetectorCLI->mavenParameters->outputdir + "testmzRoll" + ".mzroll"));
         QVERIFY(mzrollFile.exists() && mzrollFile.isFile());
 
-        peakdetectorCLI->saveCSV("testcsv");
+        peakdetectorCLI->saveCSV(peakdetectorCLI->mavenParameters->outputdir + "testcsv");
         QFileInfo csvFile(QString::fromStdString(peakdetectorCLI->mavenParameters->outputdir + "testcsv" + ".csv"));
         QVERIFY(csvFile.exists() && csvFile.isFile());
 


### PR DESCRIPTION
This PR has the following features -

- Adding Polly emailer in Elmaven now.
 - - previously, users had an option to send email using any email id and password. Users did not prefer this, because it required exposing there gmail password. So now, an email (with redirection button) from polly will be sent every time users have successfully uploaded data to polly. 
- Filtering based on timestamp -
 - - Elmaven now provides timestamp for one particular upload. this is needed on polly to filter only the files corresponding to the given upload.
- providing an option to upload sample cohort file from CLI itself.
- changed the way users provide polly project to CLI - 
 - - initially we were taking polly project from the credentials file, now users can specify their project using -N argument. If this project exists on polly, EPI will upload to that project else it will create the project first and then upload to it.
- validating the cohort file on Elmaven layer - 
 - - CLI checks if the cohort file provided by the user has exact same samples that were loaded in elmaven or not. Also, the cohort file should not have more than 9 cohorts.
- redirection url changes -
 - - if the user has not provided cohort file or if the file is incorrect, elmaven will redirect to gsheet interface otherwise it will directly redirect to visualisation dashboard where users can get insights from their mass spec data.