### PR TITLE
Handle more qualifiers in SRM name

### DIFF
--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -349,7 +349,7 @@ void mzSample::parseMzMLChromatogramList(const xml_node &chromatogramList)
 		string chromatogramId = chromatogram.attribute("id").value();
 		int sampleNo = getSampleNoChromatogram(chromatogramId);
 
-		chromatogramId = filterChromatogramId(chromatogramId);
+        filterChromatogramId(chromatogramId);
 
 		vector<float> timeVector;
 		vector<float> intsVector;
@@ -430,17 +430,15 @@ int mzSample::getSampleNoChromatogram(const string &chromatogramId) {
 
 }
 
-string mzSample::filterChromatogramId(const string &chromatogramId) {
+void mzSample::filterChromatogramId(string &chromatogramId) {
 
-	string filteredChromatogramId = chromatogramId;
-	for(unsigned int i = 0; i < filterChromatogram.size(); i++) {
-		string filterRegex = filterChromatogram[i];
-		filterRegex += "\ *\=\ *[0-9]*\.?[0-9]+";
-		regex rx(filterRegex);
-		filteredChromatogramId = std::regex_replace(filteredChromatogramId, rx, "");
+    string filterRegex;
+    regex rx;
+    for(const string& filterId: filterChromatogram) {
+        filterRegex = filterId + "\ *\=\ *[0-9]*\.?[0-9]+";
+        rx = filterRegex;
+        chromatogramId = std::regex_replace(chromatogramId, rx, "");
 	}
-
-	return filteredChromatogramId;
 }
 
 void mzSample::parseMzMLSpectrumList(const xml_node &spectrumList)

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -435,7 +435,7 @@ string mzSample::filterChromatogramId(const string &chromatogramId) {
 	string filteredChromatogramId = chromatogramId;
 	for(unsigned int i = 0; i < filterChromatogram.size(); i++) {
 		string filterRegex = filterChromatogram[i];
-		filterRegex += "\ *\=\ *[0-9]+\ *";
+		filterRegex += "\ *\=\ *[0-9]*\.?[0-9]+";
 		regex rx(filterRegex);
 		filteredChromatogramId = std::regex_replace(filteredChromatogramId, rx, "");
 	}

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -286,7 +286,7 @@ class mzSample
 
     int getSampleNoChromatogram(const string &chromatogramId);
 
-    string filterChromatogramId(const string &chromatogramId);
+    void filterChromatogramId(string &chromatogramId);
 
     /**
     * @brief Parse mzML spectrum list

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -733,7 +733,10 @@ class mzSample
     static int filter_polarity;
 
     vector<string> filterChromatogram {
-        "sample"
+        "sample", 
+        "start",
+        "end",
+        "index"
     };
 };
 


### PR DESCRIPTION
Two changes in this PR:

- Added support for 'Scan=', 'start=', 'end=', 'index=' in SRM ID
- Changed regex to handle floating point numbers for these qualifiers