### PR TITLE
Uploading in separate thread

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -52,9 +52,66 @@ function read_id_token(token_filename){
     return saved_token;    
 }
 
+function refreshToken(token_filename,email){
+    if (!email) {
+        console.log(chalk.red.bold("Email is required to refresh the token"));
+        return;
+    } else {
+        if (!(email.includes("@"))){
+            console.log(chalk.red.bold("Please provide valid email.."));
+            return;
+            }
+        }
+    console.log(chalk.yellow.bold("Fetching user pool to refresh token..."));
+    
+    var options = {
+        method: 'GET',
+        url: 'https://polly.elucidata.io/userpool',
+        json: true
+    };
+
+    var cognito_client_id = "";
+    var cognito_user_pool = "";
+    var cognito_user_pool_region = "";
+
+    request(options, function (error, response, body) {
+        if (error) throw new Error(chalk.bold.red(error));
+        console.log(chalk.yellow.bgBlack.bold("UserPool response: "));
+        cognito_client_id = body.cognito_client_id;
+        cognito_user_pool = body.cognito_user_pool;
+        cognito_user_pool_region = body.cognito_user_pool_region;
+        
+        var poolData = {
+            UserPoolId : cognito_user_pool,
+            ClientId : cognito_client_id
+        };
+        var userPool = new AmazonCognitoIdentity.CognitoUserPool(poolData);
+        var userData = {
+            Username : email,
+            Pool : userPool
+        };
+        
+        var cognitoUser = new AmazonCognitoIdentity.CognitoUser(userData);
+        var refresh_token = String(read_id_token(token_filename+"_refreshToken"))
+        console.log("trying to refresh the token now..");
+        var refresh_token_object = new AmazonCognitoIdentity.CognitoRefreshToken({ RefreshToken: refresh_token });
+    
+        cognitoUser.refreshSession(refresh_token_object, (err, session) => {
+            if(err) {
+                console.log("error while refreshing the token.."+err);
+            } 
+            else{
+                write_id_token(token_filename, String(session.getIdToken().getJwtToken()));
+                return;
+            }
+        });
+        
+    });
+}
+
 
 module.exports.authenticate = function(token_filename,email, password){
-    if (has_id_token(token_filename)) {
+    if (has_id_token(token_filename) && has_id_token(token_filename+"_refreshToken")) {
         var public_token_header = read_id_token(token_filename);
         var decoded = jwt_decode(String(public_token_header));
         var token_expiry_date = decoded.exp.valueOf();
@@ -63,6 +120,9 @@ module.exports.authenticate = function(token_filename,email, password){
         if (token_expiry_date > nowDate) {
             console.log(chalk.green.bold("already logged in"));
             return;
+        }
+        else{
+            return refreshToken(token_filename,email);
         }
     }
     if (!email) {
@@ -119,7 +179,8 @@ module.exports.authenticate = function(token_filename,email, password){
             onSuccess: function (result) {
                 write_id_token(token_filename,String(result.getIdToken().getJwtToken()));
                 AWS.config.region = cognito_user_pool_region;
-    
+                write_id_token(token_filename+"_refreshToken",String(result.getRefreshToken().getToken()))
+            
                 AWS.config.credentials = new AWS.CognitoIdentityCredentials({
                     IdentityPoolId : cognito_client_id,
                     Logins : {

--- a/bin/index.js
+++ b/bin/index.js
@@ -122,7 +122,7 @@ module.exports.authenticate = function(token_filename,email, password){
             return;
         }
         else{
-            return refreshToken(token_filename,email);
+            return refreshToken(token_filename,decoded.email.valueOf());
         }
     }
     if (!email) {

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -36,11 +36,22 @@ EPIWorkerThread::EPIWorkerThread()
 };
 
 void EPIWorkerThread::run(){
-    QString status_inside = _pollyintegration->authenticate_login(username,password);
-    emit authentication_result(status_inside);
-    if (status_inside=="ok"){
-        QVariantMap projectnames_id = _pollyintegration->getUserProjects();
-        emit resultReady(projectnames_id);
+    if (state=="initial_setup"){
+        qDebug()<<"starting thread to authenticate and fetch project info from polly";
+        QString status_inside = _pollyintegration->authenticate_login(username,password);
+        emit authentication_result(status_inside);
+        if (status_inside=="ok"){
+            QVariantMap projectnames_id = _pollyintegration->getUserProjects();
+            emit resultReady(projectnames_id);
+        }
+    }
+    else if (state=="upload_files"){
+        qDebug()<<"starting thread for uploading files to polly..";
+        //re-login to polly may be required because the token expires after 30 minutes..
+        QString status_inside = _pollyintegration->authenticate_login(username,password);
+        QStringList patch_ids  = _pollyintegration->exportData(filesToUpload,upload_project_id_thread);
+        bool status = tmpDir.removeRecursively();
+        emit filesUploaded(patch_ids);
     }
 }
 
@@ -202,8 +213,8 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
         emit uploadFinished(false);
         return;
     }
+    
     QStringList patch_ids;
-    QString upload_project_id;
 
     QString new_projectname = lineEdit_new_project_name->text();
     QString projectname = comboBox_existing_projects->currentText();
@@ -229,8 +240,7 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
     }
     upload_status->setText("Connecting..");
     QCoreApplication::processEvents();
-    //re-login to polly may be required because the token expires after 30 minutes..
-    QString status_inside = _pollyIntegration->authenticate_login(credentials.at(0),credentials.at(1));
+
     upload_status->setText("Sending files to Polly..");
     QCoreApplication::processEvents();
     if (comboBox_existing_projects->isEnabled()){
@@ -241,7 +251,6 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
             }
         }
         if (project_id!=""){
-            patch_ids = _pollyIntegration->exportData(filenames,project_id);
             upload_project_id = project_id;
         }
         else{
@@ -264,7 +273,6 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
             return;
         }
         QString new_project_id = _pollyIntegration->createProjectOnPolly(new_projectname);
-        patch_ids  = _pollyIntegration->exportData(filenames,new_project_id);   
         upload_project_id = new_project_id;    
     }
     else{
@@ -277,7 +285,17 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
         emit uploadFinished(false);
         return;
     }
-    bool status = qdir.removeRecursively();
+    
+    EPIWorkerThread *EPIworkerThread = new EPIWorkerThread();
+    connect(EPIworkerThread, SIGNAL(filesUploaded(QStringList)), this, SLOT(postUpload(QStringList)));
+    connect(EPIworkerThread, &EPIWorkerThread::finished, EPIworkerThread, &QObject::deleteLater);
+    EPIworkerThread->state = "upload_files";
+    EPIworkerThread->filesToUpload = filenames;
+    EPIworkerThread->tmpDir = qdir;
+    EPIworkerThread->start();
+}
+
+void PollyElmavenInterfaceDialog::postUpload(QStringList patch_ids){
     QCoreApplication::processEvents();
     if (!patch_ids.isEmpty()){
         upload_status->setText("");
@@ -296,7 +314,7 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
         msgBox.exec();
         upload_status->setText("");
     }
-    emit uploadFinished(false);
+    emit uploadFinished(false);   
 }
 
 QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir){

--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -34,6 +34,7 @@ class PollyElmavenInterfaceDialog : public QDialog, public Ui_PollyElmavenInterf
                 * @brief credentials required to connect to polly..
                 */
                 QStringList credentials;
+                QString upload_project_id;
                 QStringList organisationSpecificCompoundDB;
                 /**
                 * @brief constructor with mainwindow pointer..
@@ -188,6 +189,7 @@ class PollyElmavenInterfaceDialog : public QDialog, public Ui_PollyElmavenInterf
         public slots:
             void handleResults(QVariantMap projectnames_id);
             void handleAuthentication(QString status);
+            void postUpload(QStringList patch_ids);
 };
 
 class EPIWorkerThread : public QThread
@@ -199,8 +201,13 @@ class EPIWorkerThread : public QThread
         void run();
         QString username;
         QString password;
+        QString state;
+        QDir tmpDir;
+        QString upload_project_id_thread;
+        QStringList filesToUpload;
         PollyIntegration* _pollyintegration;
     signals:
+        void filesUploaded(QStringList patch_ids);
         void resultReady(QVariantMap projectnames_id);
         void authentication_result(QString status);
 };

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -193,8 +193,6 @@ int PollyIntegration::check_already_logged_in(){
 QString PollyIntegration::authenticate_login(QString username,QString password){
     QString command = "authenticate";
     QString status;
-    QFile file (credFile);
-    file.remove();
     
     QList<QByteArray> result_and_error = run_qt_process(command, QStringList() << credFile << username << password);
     int status_inside = check_already_logged_in();
@@ -218,10 +216,25 @@ int PollyIntegration::check_node_executable(){
     return 1;
     
 }
+
+int PollyIntegration::askForLogin(){
+    qDebug()<<"credFile  -\n"<<credFile;
+    QFile file (credFile);
+    QFile refreshTokenFile (credFile+"_refreshToken");
+    if (file.exists() && refreshTokenFile.exists() ){
+        qDebug()<<"both tokens exist.. moving on to refresh now..";
+        return 0;
+    }
+    qDebug()<<"both tokens do not exist.. moving on to login now..";
+    return 1;
+}
+
 // This function deletes the token and logs out the user..
 void PollyIntegration::logout(){
     QFile file (credFile);
     file.remove();
+    QFile refreshTokenFile (credFile+"_refreshToken");
+    refreshTokenFile.remove();
 }
 // name OF FUNCTION: getUserProjectsMap
 // PURPOSE:

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -28,6 +28,7 @@ class PollyIntegration
 	    QString authenticate_login(QString username,QString password);
 	    int check_already_logged_in();
 		int check_node_executable();
+		int askForLogin();
 	    QStringList exportData(QStringList filenames,QString projectId);
 		QString loadDataFromPolly(QString ProjectId,QStringList filenames);
 		QVariantMap getUserProjects();


### PR DESCRIPTION
This PR bring two major changes on table - 

- Persistent login to Polly, In El-maven

- Now, uploading to Polly will happen in a separate thread. This will ensure that UI doesn't  freeze and also uploading process can be terminated while it is running.

How to test all the changes in this PR -

- [x] Verify that Users only have to log in once, unless they log out.

- [x] verify that GUI doesn't get hanged while uploading.Also, multiple threads can be started in parallel.

TODO - 
implement keychain in EPI, As of now skipping it because users will need their admin password every time they access EPI.
We need it for better security.