### PR TITLE
Fix missing C12 label

### DIFF
--- a/src/core/libmaven/csvreports.h
+++ b/src/core/libmaven/csvreports.h
@@ -108,6 +108,8 @@ public:
     QString sanitizeString(const char* s);
     ofstream groupReport;       /**@param-  output file for groups report*/
     ofstream peakReport;         /**@param-  output file for peaks report*/
+    int groupId;	/**@param-  incremental group numbering. Increment by 1 when a group is added for csv report  */
+
 private:
     void writeGroupInfo(PeakGroup* group);      /**@brief-  helper function to write group info*/
     void writePeakInfo(PeakGroup* group);           /**@brief-  helper function to write peak info*/
@@ -129,7 +131,6 @@ private:
     int insertIsotpesFoundInSamples (PeakGroup* group, string isotopeName, int counter, int k);     /**@brief-  tke child of group and write about it to csv file*/
 
 
-    int groupId;	/**@param-  incremental group numbering. Increment by 1 when a group is added for csv report  */
     string SEP;     /**@param-  separator in output file*/
 
     QString errorReport;    /**@param-  error message, TODO- QString should not be in libmaven folder, only standard C++ statement should be here*/


### PR DESCRIPTION
This should fix missing "C12 PARENT" labels in the exported CSV, when PeakDetector CLI is run on Masha-1 (neg C12) dataset. After writing to the CSV file, a second pass is done to check which ones are missing labels. For these group's, if their meanMz is within the set ppm range around Compound's computed mz value, then they are given a C12 PARENT child that is a copy of the group itself. This ensures that at least for the groups passing this check, isotope label is not empty in the exported (again) CSV.

TL;DR - This is literally a patch, the underlying issue still exists.