### PR TITLE
Notify compounds DB file not provided for targeted analysis using CLI

### DIFF
--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -556,6 +556,10 @@ void PeakDetectorCLI::loadCompoundsFile() {
 		int loadCount = DB.loadCompoundCSVFile(mavenParameters->ligandDbFilename);
 		mavenParameters->compounds = DB.compoundsDB;
 		cout << "Total Compounds Loaded : " << loadCount << endl;
+	} else {
+		cerr << "\nPlease provide a compound database file to proceed with targeted analysis."
+		     << "Use the '-h' argument to see all available options." << endl;
+		exit(0);
 	}
 
 }


### PR DESCRIPTION
This commit adds a message to CLI output when user opts for
targeted peak detection but does not provide a compounds database
file. The program will also terminated before reading in any sample
files in this case.