### PR TITLE
Add explicit warning when compound database is empty

### DIFF
--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -555,7 +555,11 @@ void PeakDetectorCLI::loadCompoundsFile() {
 		cout << "\nLoading ligand database" << endl;
 		int loadCount = DB.loadCompoundCSVFile(mavenParameters->ligandDbFilename);
 		mavenParameters->compounds = DB.compoundsDB;
-		cout << "Total Compounds Loaded : " << loadCount << endl;
+		if (loadCount == 0) {
+			cerr << "Warning: Given compound database is empty!" << endl;
+		} else {
+			cout << "Total Compounds Loaded : " << loadCount << endl;
+		}
 	} else {
 		cerr << "\nPlease provide a compound database file to proceed with targeted analysis."
 		     << "Use the '-h' argument to see all available options." << endl;


### PR DESCRIPTION
If no compounds are loaded from the provided compound database using CLI, the user should be notified as such.