### PR TITLE
Warn when compounds are discarded while loading

### DIFF
--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -557,8 +557,14 @@ void PeakDetectorCLI::loadCompoundsFile() {
 		mavenParameters->compounds = DB.compoundsDB;
 		if (loadCount == 0) {
 			cerr << "Warning: Given compound database is empty!" << endl;
+		} else if (DB.invalidRows.size() == 0) {
+			cout << "Total Compounds Loaded : " << loadCount << endl;
 		} else {
 			cout << "Total Compounds Loaded : " << loadCount << endl;
+			cout << "The following compounds had insufficient information for peak detection, and were not loaded:" << endl;
+			for (auto compoundID: DB.invalidRows) {
+				cout << " - " << compoundID << endl;
+			}
 		}
 	} else {
 		cerr << "\nPlease provide a compound database file to proceed with targeted analysis."

--- a/src/core/libmaven/databases.cpp
+++ b/src/core/libmaven/databases.cpp
@@ -10,6 +10,9 @@ int Databases::loadCompoundCSVFile(string filename) {
     map<string, int> header;
     vector<string> headers;
 
+    // reset the contents of the vector containing the names of invalid rows
+    invalidRows.clear();
+
     //assume that files are tab delimited, unless matched ".csv", then comma delimited
     string sep="\t";
     if(filename.find(".csv") != -1 || filename.find(".CSV") != -1) sep=",";
@@ -138,6 +141,10 @@ Compound* Databases::extractCompoundfromEachLine(vector<string>& fields, map<str
         
         return compound;
     }
+
+    if (!name.empty())
+        id = name;
+    invalidRows.push_back(id);
 
     return NULL;
     

--- a/src/core/libmaven/databases.h
+++ b/src/core/libmaven/databases.h
@@ -16,6 +16,7 @@ class Databases {
         vector<string> getCategoryFromDB(vector<string>& fields, map<string, int> & header);
         void closeAll();
         vector<Compound*> compoundsDB;
+        vector<string> invalidRows;
 
     private:
         map<string,Compound*> compoundIdMap;

--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -462,6 +462,7 @@ int Database::loadCompoundCSVFile(string filename){
     string sep="\t";
     if(filename.find(".csv") != -1 || filename.find(".CSV") != -1) sep=",";
     notFoundColumns.resize(0);
+    invalidRows.clear();
     //cerr << filename << " sep=" << sep << endl;
     while(!myFile.atEnd()) {
         string line = QString(myFile.readLine()).toStdString();
@@ -570,6 +571,10 @@ int Database::loadCompoundCSVFile(string filename){
             for(int i=0; i < categorylist.size(); i++) compound->category.push_back(categorylist[i]);
             if (addCompound(compound))
                 loadCount++;
+        } else {
+            if (!name.empty())
+                id = name;
+            invalidRows.push_back(id);
         }
     }
     sort(compoundsDB.begin(),compoundsDB.end(), Compound::compMass);

--- a/src/gui/mzroll/database.h
+++ b/src/gui/mzroll/database.h
@@ -78,6 +78,7 @@ class Database {
 	map<string, Pathway*> pathwayIdMap;
 	map<string, Molecule2D*> coordinatesMap;
     vector<string> notFoundColumns;
+    vector<string> invalidRows;
     //Added while merging with Maven776 - Kiran
     const std::string ANYDATABASE;
        private:

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1822,6 +1822,18 @@ void MainWindow::loadCompoundsFile() {
 			msgBox.setIcon(QMessageBoxResize::Information);
 			int ret = msgBox.exec();
 		}
+		if (DB.invalidRows.size() > 0) {
+			string invalidRowsString = "The following compounds had insufficient information for peak detection, and were not loaded:";
+			QMessageBoxResize msgBox;
+			msgBox.setText(tr("Invalid compounds found"));
+			for(auto compoundID: DB.invalidRows) {
+    			invalidRowsString += "\n - " + compoundID;
+			}
+			msgBox.setDetailedText(QString::fromStdString(invalidRowsString));
+			msgBox.setWindowFlags(Qt::CustomizeWindowHint);
+			msgBox.setIcon(QMessageBoxResize::Information);
+			int ret = msgBox.exec();
+		}
 	}
 }
 


### PR DESCRIPTION
This pair of commit makes changes on both CLI and GUI side to ensure that the user is informed about any compounds discarded while loading a compounds DB file.

Tested the changes with:
- DB having rows with missing m/z and formula.
- DB having rows with missing name, m/z and formula.

Got expected behavior on both GUI and CLI.