### PR TITLE
UI: Hide feedback button temporarily

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -284,6 +284,9 @@ using namespace mzUtils;
 	connect(btnBugs, SIGNAL(clicked()), SLOT(reportBugs()));
 	statusBar()->addPermanentWidget(btnBugs, 0);
 
+	// hide this button until it does something meaningful.
+	btnBugs->setHidden(true);
+
 	setWindowIcon(QIcon(":/images/icon.png"));
 
 	//dock widgets


### PR DESCRIPTION
The feedback button brings up the crash reporter which is not the
correct behaviour for such a button. Until we decide upon what the
button should exactly do or whether it should exist at all, this
commit will hide the button.

Issue: #872