### PR TITLE
Fix: Redirect to GitHub through crash link

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -605,7 +605,7 @@ using namespace mzUtils;
 	if (settings->contains("closeEvent")
 			and settings->value("closeEvent").toInt() == 0) {
 
-		setUrl("http://genomics-pubs.princeton.edu/mzroll/index.php?show=bugs",
+		setUrl("https://github.com/ElucidataInc/ElMaven/issues",
 				"Woops.. did the program crash last time? Would you like to report a bug?");
 	}
 


### PR DESCRIPTION
The crash link within the status bar directed the user to
Princeton's bug reports page used by the original MAVEN devs. Now
they will instead be led to the El-MAVEN GitHub issues page where
they can browse existing issues or report a new one.