### PR TITLE
Improve the code for Polly Integration

### DIFF
--- a/src/gui/mzroll/loginform.cpp
+++ b/src/gui/mzroll/loginform.cpp
@@ -31,9 +31,10 @@ WorkerThread::WorkerThread()
     
 };
 
-void WorkerThread::run(){
-    QString status_inside = _pollyintegration->authenticateLogin(username,password);
-    emit resultReady(QStringList()<<status_inside<<username<<password);
+void WorkerThread::run()
+{
+    QString status_inside = _pollyintegration->authenticateLogin(username, password);
+    emit resultReady(QStringList() << status_inside << username <<password);
 }
 
 WorkerThread::~WorkerThread()
@@ -57,13 +58,13 @@ void LoginForm::on_pushButton_clicked()
     workerThread->start();
 }
 
-
-void LoginForm::handleResults(QStringList results){
-    QString status_inside=results.at(0);
-    QString username=results.at(1);
-    QString password=results.at(2);
-    if (status_inside=="ok"){
-        qDebug()<<"Logged in, moving on now....";
+void LoginForm::handleResults(QStringList results)
+{
+    QString status_inside = results.at(0);
+    QString username = results.at(1);
+    QString password = results.at(2);
+    if (status_inside == "ok") {
+        qDebug() << "Logged in, moving on now....";
         ui->login_label->setText("Fetching data from Polly..");
         QCoreApplication::processEvents();
         _pollyelmaveninterfacedialog->credentials = QStringList()<< username << password;
@@ -71,26 +72,25 @@ void LoginForm::handleResults(QStringList results){
         hide();
         _pollyelmaveninterfacedialog->show();
         
-    }
-    else if(status_inside=="error"){
+    } else if (status_inside == "error") {
         ui->login_label->setStyleSheet("QLabel {color : red; }");
         ui->login_label->setText("Please check your internet");
         ui->pushButton->setEnabled(true);
-    }
-    else {
+    } else {
         ui->login_label->setStyleSheet("QLabel {color : red; }");
         ui->login_label->setText("Incorrect credentials");
         ui->pushButton->setEnabled(true);
     }
 }
 
-void LoginForm::cancel(){
-    qDebug()<<"closing the log in form now..";
+void LoginForm::cancel()
+{
+    qDebug() << "closing the log in form now..";
     close();
 }
 
-void LoginForm::showAboutPolly(){
-    qDebug()<<"going to show the doc now..";
+void LoginForm::showAboutPolly()
+{
     _aboutPolly =new AboutPolly();
     _aboutPolly->setModal(true);
     _aboutPolly->show();

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -938,18 +938,6 @@ QDockWidget* MainWindow::createDockWidget(QString title, QWidget* w) {
 
 }
 
-//Shubhra TODO: Remove redundant function
-QDockWidget* MainWindow::createDockWidgetIsotopes(QString title, QWidget* w) {
-	QDockWidget* dock = new QDockWidget(title, this, Qt::Widget);
-	dock->setAllowedAreas(Qt::AllDockWidgetAreas);
-	dock->setFloating(false);
-	dock->setVisible(false);
-	dock->setObjectName(title);
-	dock->setWidget(w);
-	return dock;
-
-}
-
 void MainWindow::setIsotopicPlotStyling() {
 	//prepare x axis
 	customPlot->xAxis->setTickLabels( false );

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -307,7 +307,6 @@ public Q_SLOTS:
 	void printvalue();
 	void autosaveMzRoll();
 	QDockWidget* createDockWidget(QString title, QWidget* w);
-	QDockWidget* createDockWidgetIsotopes(QString title, QWidget* w);
 	void showPeakInfo(Peak*);
 	void setProgressBar(QString, int step, int totalSteps);
 	void setStatusText(QString text = QString::null);

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -10,7 +10,7 @@ PollyElmavenInterfaceDialog::PollyElmavenInterfaceDialog(MainWindow* mw) :
         setModal(true);
         setupUi(this);
         createIcons();
-        workflowMenu->setCurrentRow(firstView);
+        workflowMenu->setCurrentRow(PollyApp::FirstView);
 
         _pollyIntegration = new PollyIntegration();
         _loadingDialog = new PollyWaitDialog(this);
@@ -55,8 +55,7 @@ void EPIWorkerThread::run()
             QVariantMap projectNamesId = _pollyintegration->getUserProjects();
             emit resultReady(projectNamesId);
         }
-    }
-    else if (state == "upload_files") {
+    } else if (state == "upload_files") {
         qDebug() << "starting thread for uploading files to polly..";
         //re-login to polly may be required because the token expires after 30 minutes..
         QString statusInside = _pollyintegration->authenticateLogin("","");
@@ -114,12 +113,12 @@ void PollyElmavenInterfaceDialog::goToPolly()
 
 void PollyElmavenInterfaceDialog::handleNewProject()
 {
-    if (stackedWidget->currentIndex() == firstView) {
+    if (stackedWidget->currentIndex() == PollyApp::FirstView) {
         firstViewNewProject->setEnabled(true);
         firstViewProjectList->setEnabled(false);
     }
     
-    if (stackedWidget->currentIndex() == fluxomics) {
+    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
         fluxNewProject->setEnabled(true);
         fluxProjectList->setEnabled(false);
     }
@@ -128,12 +127,12 @@ void PollyElmavenInterfaceDialog::handleNewProject()
 
 void PollyElmavenInterfaceDialog::handleSelectProject()
 {
-    if (stackedWidget->currentIndex() == firstView) {
+    if (stackedWidget->currentIndex() == PollyApp::FirstView) {
         firstViewNewProject->setEnabled(false);
         firstViewProjectList->setEnabled(true);
     }
     
-    if (stackedWidget->currentIndex() == fluxomics) {
+    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
         fluxNewProject->setEnabled(false);
         fluxProjectList->setEnabled(true);
     }
@@ -190,11 +189,10 @@ void PollyElmavenInterfaceDialog::call_login_form()
 
 void PollyElmavenInterfaceDialog::call_initial_EPI_form() 
 {
-    if (stackedWidget->currentIndex() == firstView) {
+    if (stackedWidget->currentIndex() == PollyApp::FirstView) {
         firstViewUpload->setEnabled(false);
         firstViewProjectList->clear();
-    }
-    else {
+    } else {
         fluxUpload->setEnabled(false);
         fluxProjectList->clear();
     }
@@ -237,8 +235,8 @@ void PollyElmavenInterfaceDialog::handleResults(QVariantMap projectnamesIdMap)
 
 void PollyElmavenInterfaceDialog::setFluxPage()
 {
-    stackedWidget->setCurrentIndex(fluxomics);
-    workflowMenu->setCurrentRow(fluxomics);
+    stackedWidget->setCurrentIndex(PollyApp::Fluxomics);
+    workflowMenu->setCurrentRow(PollyApp::Fluxomics);
 }
 
 void PollyElmavenInterfaceDialog::setUiElementsFlux()
@@ -334,7 +332,7 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
     QLineEdit* newProject = firstViewNewProject;
     QComboBox* projectList = firstViewProjectList;
 
-    if (stackedWidget->currentIndex() == fluxomics) {
+    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
         uploadButton = fluxUpload;
         statusUpdate = fluxStatus;
         newProject = fluxNewProject;
@@ -445,7 +443,7 @@ void PollyElmavenInterfaceDialog::postUpload(QStringList patchId, QString upload
     QLabel* statusUpdate = firstViewStatus;
     QPushButton* redirectButton = pollyButton;
 
-    if (stackedWidget->currentIndex() == fluxomics) {
+    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
         statusUpdate = fluxStatus;
         redirectButton = fluxButton;
     }
@@ -470,13 +468,13 @@ QString PollyElmavenInterfaceDialog::getRedirectionUrl(QString datetimestamp, QS
 {
     QString redirectionUrl;
     //redirect to firstView
-    if (stackedWidget->currentIndex() == firstView) {
+    if (stackedWidget->currentIndex() == PollyApp::FirstView) {
         redirectionUrl = QString("https://polly.elucidata.io/main#project=%1&auto-redirect=%2&elmavenTimestamp=%3").arg(uploadProjectIdThread).arg("firstview").arg(datetimestamp);
         return redirectionUrl;
     }
     
     //redirect to fluxomics
-    if (stackedWidget->currentIndex() == fluxomics) { 
+    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) { 
         QString landingPage = QString("relative_lcms_elmaven");
         QString workflowRequestId = _pollyIntegration->createWorkflowRequest(uploadProjectIdThread);
         
@@ -505,7 +503,7 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir, QString
     QComboBox* tableList = firstViewTableList;
     QLabel* statusUpdate = firstViewStatus;
 
-    if (stackedWidget->currentIndex() == fluxomics) {
+    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
         tableList = fluxTableList;
         statusUpdate = fluxStatus;
     }
@@ -557,7 +555,7 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir, QString
                             + "_Peaks_information_json_Elmaven_Polly.json";
     peakTable->exportJsonToPolly(writableTempDir, json_filename);
     
-    if (stackedWidget->currentIndex() == fluxomics) {
+    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
         fluxStatus->setStyleSheet("QLabel {color : green; }");
         fluxStatus->setText("Preparing sample cohort file..");
         QCoreApplication::processEvents();

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -10,7 +10,7 @@ PollyElmavenInterfaceDialog::PollyElmavenInterfaceDialog(MainWindow* mw) :
         setModal(true);
         setupUi(this);
         createIcons();
-        workflowMenu->setCurrentRow(PollyApp::FirstView);
+        workflowMenu->setCurrentRow(int(PollyApp::FirstView));
 
         _pollyIntegration = new PollyIntegration();
         _loadingDialog = new PollyWaitDialog(this);
@@ -113,12 +113,12 @@ void PollyElmavenInterfaceDialog::goToPolly()
 
 void PollyElmavenInterfaceDialog::handleNewProject()
 {
-    if (stackedWidget->currentIndex() == PollyApp::FirstView) {
+    if (stackedWidget->currentIndex() == int(PollyApp::FirstView)) {
         firstViewNewProject->setEnabled(true);
         firstViewProjectList->setEnabled(false);
     }
     
-    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
+    if (stackedWidget->currentIndex() == int(PollyApp::Fluxomics)) {
         fluxNewProject->setEnabled(true);
         fluxProjectList->setEnabled(false);
     }
@@ -127,12 +127,12 @@ void PollyElmavenInterfaceDialog::handleNewProject()
 
 void PollyElmavenInterfaceDialog::handleSelectProject()
 {
-    if (stackedWidget->currentIndex() == PollyApp::FirstView) {
+    if (stackedWidget->currentIndex() == int(PollyApp::FirstView)) {
         firstViewNewProject->setEnabled(false);
         firstViewProjectList->setEnabled(true);
     }
     
-    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
+    if (stackedWidget->currentIndex() == int(PollyApp::Fluxomics)) {
         fluxNewProject->setEnabled(false);
         fluxProjectList->setEnabled(true);
     }
@@ -189,7 +189,7 @@ void PollyElmavenInterfaceDialog::call_login_form()
 
 void PollyElmavenInterfaceDialog::call_initial_EPI_form() 
 {
-    if (stackedWidget->currentIndex() == PollyApp::FirstView) {
+    if (stackedWidget->currentIndex() == int(PollyApp::FirstView)) {
         firstViewUpload->setEnabled(false);
         firstViewProjectList->clear();
     } else {
@@ -199,7 +199,7 @@ void PollyElmavenInterfaceDialog::call_initial_EPI_form()
     
     EPIWorkerThread *EPIworkerThread = new EPIWorkerThread();
     connect(EPIworkerThread, SIGNAL(resultReady(QVariantMap)), this, SLOT(handleResults(QVariantMap)));
-    connect(EPI workerThread, SIGNAL(authentication_result(QString)), this, SLOT(handleAuthentication(QString)));
+    connect(EPIworkerThread, SIGNAL(authentication_result(QString)), this, SLOT(handleAuthentication(QString)));
     connect(EPIworkerThread, &EPIWorkerThread::finished, EPIworkerThread, &QObject::deleteLater);
     EPIworkerThread->state = "initial_setup";
     EPIworkerThread->start();
@@ -235,8 +235,8 @@ void PollyElmavenInterfaceDialog::handleResults(QVariantMap projectnamesIdMap)
 
 void PollyElmavenInterfaceDialog::setFluxPage()
 {
-    stackedWidget->setCurrentIndex(PollyApp::Fluxomics);
-    workflowMenu->setCurrentRow(PollyApp::Fluxomics);
+    stackedWidget->setCurrentIndex(int(PollyApp::Fluxomics));
+    workflowMenu->setCurrentRow(int(PollyApp::Fluxomics));
 }
 
 void PollyElmavenInterfaceDialog::setUiElementsFlux()
@@ -332,7 +332,7 @@ void PollyElmavenInterfaceDialog::uploadDataToPolly()
     QLineEdit* newProject = firstViewNewProject;
     QComboBox* projectList = firstViewProjectList;
 
-    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
+    if (stackedWidget->currentIndex() == int(PollyApp::Fluxomics)) {
         uploadButton = fluxUpload;
         statusUpdate = fluxStatus;
         newProject = fluxNewProject;
@@ -443,7 +443,7 @@ void PollyElmavenInterfaceDialog::postUpload(QStringList patchId, QString upload
     QLabel* statusUpdate = firstViewStatus;
     QPushButton* redirectButton = pollyButton;
 
-    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
+    if (stackedWidget->currentIndex() == int(PollyApp::Fluxomics)) {
         statusUpdate = fluxStatus;
         redirectButton = fluxButton;
     }
@@ -468,13 +468,13 @@ QString PollyElmavenInterfaceDialog::getRedirectionUrl(QString datetimestamp, QS
 {
     QString redirectionUrl;
     //redirect to firstView
-    if (stackedWidget->currentIndex() == PollyApp::FirstView) {
+    if (stackedWidget->currentIndex() == int(PollyApp::FirstView)) {
         redirectionUrl = QString("https://polly.elucidata.io/main#project=%1&auto-redirect=%2&elmavenTimestamp=%3").arg(uploadProjectIdThread).arg("firstview").arg(datetimestamp);
         return redirectionUrl;
     }
     
     //redirect to fluxomics
-    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) { 
+    if (stackedWidget->currentIndex() == int(PollyApp::Fluxomics)) { 
         QString landingPage = QString("relative_lcms_elmaven");
         QString workflowRequestId = _pollyIntegration->createWorkflowRequest(uploadProjectIdThread);
         
@@ -503,7 +503,7 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir, QString
     QComboBox* tableList = firstViewTableList;
     QLabel* statusUpdate = firstViewStatus;
 
-    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
+    if (stackedWidget->currentIndex() == int(PollyApp::Fluxomics)) {
         tableList = fluxTableList;
         statusUpdate = fluxStatus;
     }
@@ -555,7 +555,7 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir, QString
                             + "_Peaks_information_json_Elmaven_Polly.json";
     peakTable->exportJsonToPolly(writableTempDir, json_filename);
     
-    if (stackedWidget->currentIndex() == PollyApp::Fluxomics) {
+    if (stackedWidget->currentIndex() == int(PollyApp::Fluxomics)) {
         fluxStatus->setStyleSheet("QLabel {color : green; }");
         fluxStatus->setText("Preparing sample cohort file..");
         QCoreApplication::processEvents();

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -45,18 +45,19 @@ EPIWorkerThread::EPIWorkerThread()
     
 };
 
-void EPIWorkerThread::run(){
-    if (state=="initial_setup"){
-        qDebug()<<"starting thread to authenticate and fetch project info from polly";
+void EPIWorkerThread::run()
+{
+    if (state == "initial_setup"){
+        qDebug() << "starting thread to authenticate and fetch project info from polly";
         QString statusInside = _pollyintegration->authenticateLogin("","");
         emit authentication_result(statusInside);
-        if (statusInside=="ok"){
+        if (statusInside == "ok") {
             QVariantMap projectNamesId = _pollyintegration->getUserProjects();
             emit resultReady(projectNamesId);
         }
     }
-    else if (state=="upload_files"){
-        qDebug()<<"starting thread for uploading files to polly..";
+    else if (state == "upload_files") {
+        qDebug() << "starting thread for uploading files to polly..";
         //re-login to polly may be required because the token expires after 30 minutes..
         QString statusInside = _pollyintegration->authenticateLogin("","");
         QStringList patchId  = _pollyintegration->exportData(filesToUpload, uploadProjectIdThread);
@@ -111,7 +112,8 @@ void PollyElmavenInterfaceDialog::goToPolly()
     QDesktopServices::openUrl(pollyURL);
 }
 
-void PollyElmavenInterfaceDialog::handleNewProject(){
+void PollyElmavenInterfaceDialog::handleNewProject()
+{
     if (stackedWidget->currentIndex() == firstView) {
         firstViewNewProject->setEnabled(true);
         firstViewProjectList->setEnabled(false);
@@ -124,7 +126,8 @@ void PollyElmavenInterfaceDialog::handleNewProject(){
     QCoreApplication::processEvents();
 }
 
-void PollyElmavenInterfaceDialog::handleSelectProject(){
+void PollyElmavenInterfaceDialog::handleSelectProject()
+{
     if (stackedWidget->currentIndex() == firstView) {
         firstViewNewProject->setEnabled(false);
         firstViewProjectList->setEnabled(true);
@@ -137,7 +140,8 @@ void PollyElmavenInterfaceDialog::handleSelectProject(){
     QCoreApplication::processEvents();
 }
 
-void PollyElmavenInterfaceDialog::showAdvanceSettings() {
+void PollyElmavenInterfaceDialog::showAdvanceSettings() 
+{
     advancedSettingsFlag = true;
     _advancedSettings = new AdvancedSettings();
     _advancedSettings->initialSetup();
@@ -164,8 +168,7 @@ void PollyElmavenInterfaceDialog::initialSetup()
                 msgBox.exec();
         }
         return;
-    }
-    else {
+    } else {
         try {
             call_initial_EPI_form();
         } catch(...) {
@@ -178,13 +181,15 @@ void PollyElmavenInterfaceDialog::initialSetup()
     }
 }
 
-void PollyElmavenInterfaceDialog::call_login_form() {
+void PollyElmavenInterfaceDialog::call_login_form()
+{
     _loginform = new LoginForm(this);
     _loginform->setModal(true);
     _loginform->show();
 }
 
-void PollyElmavenInterfaceDialog::call_initial_EPI_form() {
+void PollyElmavenInterfaceDialog::call_initial_EPI_form() 
+{
     if (stackedWidget->currentIndex() == firstView) {
         firstViewUpload->setEnabled(false);
         firstViewProjectList->clear();
@@ -212,19 +217,20 @@ void PollyElmavenInterfaceDialog::call_initial_EPI_form() {
     QCoreApplication::processEvents();
 }
 
-void PollyElmavenInterfaceDialog::handleAuthentication(QString status) {
+void PollyElmavenInterfaceDialog::handleAuthentication(QString status)
+{
     if (status == "ok") {
         _loadingDialog->statusLabel->setText("Fetching your projects..");
         QCoreApplication::processEvents();
-    }
-    else {
-            _loadingDialog->statusLabel->setText("Authentication failed. Please login again.");
-            QCoreApplication::processEvents();
-            logout();
+    } else {
+        _loadingDialog->statusLabel->setText("Authentication failed. Please login again.");
+        QCoreApplication::processEvents();
+        logout();
     }
 }
 
-void PollyElmavenInterfaceDialog::handleResults(QVariantMap projectnamesIdMap){
+void PollyElmavenInterfaceDialog::handleResults(QVariantMap projectnamesIdMap)
+{
     projectNamesId = projectnamesIdMap;
     startupDataLoad();
 }
@@ -431,7 +437,8 @@ void PollyElmavenInterfaceDialog::showErrorMessage(QString title, QString messag
     errorBox.exec();
 }
 
-void PollyElmavenInterfaceDialog::postUpload(QStringList patchId, QString uploadProjectIdThread, QString datetimestamp){
+void PollyElmavenInterfaceDialog::postUpload(QStringList patchId, QString uploadProjectIdThread, QString datetimestamp)
+{
     QCoreApplication::processEvents();
     
     //set UI elements
@@ -449,8 +456,7 @@ void PollyElmavenInterfaceDialog::postUpload(QStringList patchId, QString upload
         qDebug() << "redirection_url     - " << redirection_url;
         pollyURL.setUrl(redirection_url);
         redirectButton->setVisible(true);
-    }
-    else {
+    } else {
         statusUpdate->setStyleSheet("QLabel {color : red; }");
         statusUpdate->setText("Error!");
         
@@ -518,9 +524,8 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir, QString
     
     QCoreApplication::processEvents();
 
-    if (advancedSettingsFlag){
+    if (advancedSettingsFlag)
         handle_advanced_settings(datetimestamp, peakTable);
-    }
     
     if (!advancedSettingsFlag || !_advancedSettings->getUploadCompoundDB()) {
         // Now uploading the Compound DB that was used for peak detection.
@@ -532,10 +537,13 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir, QString
         mainwindow->ligandWidget->saveCompoundList(writableTempDir + QDir::separator() + datetimestamp + "_Compound_DB_Elmaven.csv", compoundDb);
     }
 
-    qDebug()<< "Now uploading all groups, needed for firstview app..";
+    qDebug() << "Now uploading all groups, needed for firstview app..";
     peakTable->wholePeakSet();
     peakTable->treeWidget->selectAll();
-    peakTable->prepareDataForPolly(writableTempDir,"Groups Summary Matrix Format Comma Delimited (*.csv)",datetimestamp+"_Peak_table_all_");
+    peakTable->prepareDataForPolly(writableTempDir,
+                "Groups Summary Matrix Format Comma Delimited (*.csv)",
+                datetimestamp
+                + "_Peak_table_all_");
     
     //Preparing the json file
     statusUpdate->setStyleSheet("QLabel {color : green; }");
@@ -543,8 +551,11 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir, QString
     
     QCoreApplication::processEvents();
  
-    QString json_filename = writableTempDir+QDir::separator()+datetimestamp+"_Peaks_information_json_Elmaven_Polly.json";
-    peakTable->exportJsonToPolly(writableTempDir,json_filename);
+    QString json_filename = writableTempDir
+                            + QDir::separator()
+                            + datetimestamp
+                            + "_Peaks_information_json_Elmaven_Polly.json";
+    peakTable->exportJsonToPolly(writableTempDir, json_filename);
     
     if (stackedWidget->currentIndex() == fluxomics) {
         fluxStatus->setStyleSheet("QLabel {color : green; }");
@@ -557,7 +568,11 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir, QString
     }
     
     //Saving settings file
-    QByteArray ba = (writableTempDir + QDir::separator() + datetimestamp + "_maven_analysis_settings" + ".xml").toLatin1();
+    QByteArray ba = (writableTempDir
+                    + QDir::separator()
+                    + datetimestamp
+                    + "_maven_analysis_settings"
+                    + ".xml").toLatin1();
     const char *save_path = ba.data();
     mainwindow->mavenParameters->saveSettings(save_path);
     qDebug() << "settings saved now";
@@ -565,15 +580,15 @@ QStringList PollyElmavenInterfaceDialog::prepareFilesToUpload(QDir qdir, QString
     qdir.setFilter(QDir::Files | QDir::NoSymLinks);
     QFileInfoList file_list = qdir.entryInfoList();
     
-    for (int i = 0; i < file_list.size(); ++i){
-        QFileInfo fileInfo = file_list.at(i);
-        QString tmp_filename = writableTempDir+QDir::separator()+fileInfo.fileName();
+    for (auto fileInfo : file_list) {
+        QString tmp_filename = writableTempDir + QDir::separator() + fileInfo.fileName();
         filenames.append(tmp_filename);
     }
     return filenames;
 }
 
-void PollyElmavenInterfaceDialog::handle_advanced_settings(QString datetimestamp, TableDockWidget* peakTable){
+void PollyElmavenInterfaceDialog::handle_advanced_settings(QString datetimestamp, TableDockWidget* peakTable)
+{
         QVariantMap advanced_ui_elements = _advancedSettings->getUIElements();
 
         QString exportOption = advanced_ui_elements["export_option"].toString();
@@ -582,13 +597,13 @@ void PollyElmavenInterfaceDialog::handle_advanced_settings(QString datetimestamp
         QString compoundDb = advanced_ui_elements["compound_db"].toString();
         QString userCompoundDBName = advanced_ui_elements["user_compound_DB_name"].toString();
         
-        if (userFilename==""){
+        if (userFilename == "") {
             userFilename = "intensity_file.csv";
         }
-        if (userCompoundDBName==""){
+        if (userCompoundDBName == "") {
             userCompoundDBName = "compounds";
         }
-        if (_advancedSettings->getUploadCompoundDB()){
+        if (_advancedSettings->getUploadCompoundDB()) {
             mainwindow->ligandWidget->saveCompoundList(writableTempDir + QDir::separator()
                                                         + datetimestamp
                                                         + "_Compound_DB_"
@@ -596,19 +611,16 @@ void PollyElmavenInterfaceDialog::handle_advanced_settings(QString datetimestamp
                                                         + ".csv", compoundDb );
         }
         
-        if (_advancedSettings->getUploadPeakTable()){
-            if (exportOption=="Export Selected"){
+        if (_advancedSettings->getUploadPeakTable()) {
+            if (exportOption == "Export Selected") {
                 peakTable->selectedPeakSet();
-            }
-            else if(exportOption=="Export Good"){
+            } else if (exportOption == "Export Good") {
                 peakTable->goodPeakSet();
                 peakTable->treeWidget->selectAll();
-            }
-            else if(exportOption=="Export All Groups"){
+            } else if (exportOption == "Export All Groups") {
                 peakTable->wholePeakSet();
                 peakTable->treeWidget->selectAll();
-            }
-            else if(exportOption=="Export Bad"){
+            } else if(exportOption == "Export Bad") {
                 peakTable->badPeakSet();
                 peakTable->treeWidget->selectAll();
             }
@@ -623,12 +635,14 @@ void PollyElmavenInterfaceDialog::handle_advanced_settings(QString datetimestamp
 
 }
 
-void PollyElmavenInterfaceDialog::cancel() {
+void PollyElmavenInterfaceDialog::cancel()
+{
     advancedSettingsFlag = false;
     close();   
 }
 
-void PollyElmavenInterfaceDialog::logout() {
+void PollyElmavenInterfaceDialog::logout()
+{
     advancedSettingsFlag = false;
     _pollyIntegration->logout();
     credentials = QStringList();
@@ -636,7 +650,8 @@ void PollyElmavenInterfaceDialog::logout() {
     close();   
 }
 
-void PollyElmavenInterfaceDialog::performPostUploadTasks(bool uploadSuccessful) {
+void PollyElmavenInterfaceDialog::performPostUploadTasks(bool uploadSuccessful)
+{
     firstViewUpload->setEnabled(true);
     fluxUpload->setEnabled(true);
 }

--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -34,7 +34,7 @@ class PollyElmavenInterfaceDialog : public QDialog, public Ui_PollyElmavenInterf
                 * @brief credentials required to connect to polly..
                 */
                 QStringList credentials;
-                QString upload_project_id;
+                QString uploadProjectId;
                 QStringList organisationSpecificCompoundDB;
                 /**
                 * @brief constructor with mainwindow pointer..
@@ -49,6 +49,7 @@ class PollyElmavenInterfaceDialog : public QDialog, public Ui_PollyElmavenInterf
                  * @brief json object which contains the mapping of project names with their IDs
                  */
                 QVariantMap projectNamesId;
+                enum pollyApp { firstView = 0, fluxomics = 1 };
                 bool advancedSettingsFlag;
                 /**
                  * @brief json object which contains the mapping of project names with thier uploaded files
@@ -78,6 +79,7 @@ class PollyElmavenInterfaceDialog : public QDialog, public Ui_PollyElmavenInterf
                 void setUiElementsFlux();
                 void setUiElementsFV();
                 QMap<QString, TableDockWidget*> tableNameMapping;
+                void showErrorMessage(QString title, QString message);
                 QString writableTempDir = QStandardPaths::writableLocation(
                                                 QStandardPaths::QStandardPaths::GenericConfigLocation)
                                                 + QDir::separator()

--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -79,6 +79,7 @@ class PollyElmavenInterfaceDialog : public QDialog, public Ui_PollyElmavenInterf
                 void setUiElementsFlux();
                 void setUiElementsFV();
                 QMap<QString, TableDockWidget*> tableNameMapping;
+                QString getProjectId(QComboBox* projectList, QLineEdit* newProject);
                 void showErrorMessage(QString title, QString message);
                 QString writableTempDir = QStandardPaths::writableLocation(
                                                 QStandardPaths::QStandardPaths::GenericConfigLocation)

--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -49,7 +49,7 @@ class PollyElmavenInterfaceDialog : public QDialog, public Ui_PollyElmavenInterf
                  * @brief json object which contains the mapping of project names with their IDs
                  */
                 QVariantMap projectNamesId;
-                enum pollyApp { firstView = 0, fluxomics = 1 };
+                enum class PollyApp { FirstView = 0, Fluxomics = 1 };
                 bool advancedSettingsFlag;
                 /**
                  * @brief json object which contains the mapping of project names with thier uploaded files


### PR DESCRIPTION
Following changes in this PR
- Changed flow of code for better readability
- Made the code more modular
- Changes to follow code styling guidelines
- Use enums instead of integers
- Use common qt objects to avoid changing between stackwidget pages