### PR TITLE
Fix: Inconsistent CSV output format

### DIFF
--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -365,9 +365,12 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
         if(group->label !='g') return;
     } else if (selectionFlag == 3) {
         if(group->label !='b') return;
-    } else {
-
     }
+
+    // sort the peaks in the group according to the sample names using a comparison function
+    // this ensures that the order in which the peaks are written is same across different systems.
+    std::sort(group->peaks.begin(), group->peaks.end(), Peak::compSampleName);
+
     for (unsigned int j = 0; j < group->peaks.size(); j++) {
         Peak& peak = group->peaks[j];
         mzSample* sample = peak.getSample();

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -279,7 +279,7 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
     tagString = sanitizeString(tagString.c_str()).toStdString();
     char label[2];
     sprintf(label, "%c", group->label);
-    groupReport << label << SEP << setprecision(7) << parentGroup->groupId << SEP
+    groupReport << label << SEP << fixed << setprecision(6) << parentGroup->groupId << SEP
             << groupId << SEP << group->goodPeakCount << SEP << group->meanMz
             << SEP << group->meanRt << SEP << group->maxQuality << SEP
             << tagString;
@@ -333,6 +333,9 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         groupReport << SEP << group->meanMz;
     }
 
+    // for intensity values, we only write two digits of floating point precision
+    // since these values are supposed to be large (in the order of > 10^3).
+    groupReport << setprecision(2);
     for (unsigned int j = 0; j < samples.size(); j++){
         for(int i=0;i<group->samples.size();++i){
             if(samples[j]->sampleName==group->samples[i]->sampleName){
@@ -385,29 +388,32 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
         }
 
 
-        peakReport << setprecision(8)
-                << group->groupId << SEP
-                << compoundName << SEP
-                << compoundID << SEP
-                << formula << SEP
-                << sampleName << SEP
-                << peak.peakMz <<  SEP
-                << peak.medianMz <<  SEP
-                << peak.baseMz <<  SEP
-                << setprecision(3)
-                << peak.rt <<  SEP
-                << peak.rtmin <<  SEP
-                << peak.rtmax <<  SEP
-                << peak.quality << SEP
-                << peak.peakIntensity << SEP
-                << peak.peakArea <<  SEP
-                << peak.peakSplineArea <<  SEP                
-                << peak.peakAreaTop <<  SEP
-                << peak.peakAreaCorrected <<  SEP
-                << peak.peakAreaTopCorrected << SEP
-                << peak.noNoiseObs <<  SEP
-                << peak.signalBaselineRatio <<  SEP
-                << peak.fromBlankSample << endl;
+        peakReport << fixed << setprecision(6)
+                   << group->groupId << SEP
+                   << compoundName << SEP
+                   << compoundID << SEP
+                   << formula << SEP
+                   << sampleName << SEP
+                   << peak.peakMz <<  SEP
+                   << peak.medianMz <<  SEP
+                   << peak.baseMz <<  SEP
+                   << setprecision(3)
+                   << peak.rt <<  SEP
+                   << peak.rtmin <<  SEP
+                   << peak.rtmax <<  SEP
+                   << peak.quality << SEP
+                   // for intensity values, we only write two digits of floating point precision
+                   // since these values are supposed to be large (in the order of > 10^3).
+                   << setprecision(2)
+                   << peak.peakIntensity << SEP
+                   << peak.peakArea <<  SEP
+                   << peak.peakSplineArea <<  SEP
+                   << peak.peakAreaTop <<  SEP
+                   << peak.peakAreaCorrected <<  SEP
+                   << peak.peakAreaTopCorrected << SEP
+                   << peak.noNoiseObs <<  SEP
+                   << peak.signalBaselineRatio <<  SEP
+                   << peak.fromBlankSample << endl;
     }
 }
 


### PR DESCRIPTION
While testing #871, we discovered some inconsistent behavior in our group summary and peak detailed formats across different operating systems. While there might be more variable behavior which we have not yet encountered (or recorded) yet, this PR should aims to fix two of them:

1. **Order of peak export**: For peak detailed format, it seems that the order in which each peak is exported for different samples can be different. This might be due to the order in which each sample is loaded and thus their peaks are pushed to a group's peak vector in that fashion. To correct this, the peak vector is sorted according to the name's of the sample before it is iterated upon to write output.
2. **Precision of floating point values**: Until now we have not been enforcing any type (fixed or scientific) or precision for the floating point values that are exported in CSV files. This led to different formats for fractional values in different systems (tried in Mac vs Ubuntu), probably because the default state of output streams responsible for writing these values are in different states or have different rules of formatting floating values. To solve this issue, we will now exactly define precision and type for the output stream writing to CSV files.

These changes should ideally be pushed only with proper tests, but the current state of CSV report testing is too poor to cover these scenarios. The tests in #871 should be sufficient for the changes but they themselves depend on consistency of output to pass CI check. Therefore, #871 can only be merged after this PR has been merged.