### PR TITLE
Fix: set "rt" precision in group summary report to 3

### DIFF
--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -224,10 +224,15 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
     tagString = sanitizeString(tagString.c_str()).toStdString();
     char label[2];
     sprintf(label, "%c", group->label);
-    groupReport << label << SEP << fixed << setprecision(6) << parentGroup->groupId << SEP
-            << groupId << SEP << group->goodPeakCount << SEP << group->meanMz
-            << SEP << group->meanRt << SEP << group->maxQuality << SEP
-            << tagString;
+    groupReport << label << SEP
+                << parentGroup->groupId << SEP
+                << groupId << SEP
+                << group->goodPeakCount << SEP
+                << fixed
+                << setprecision(6) << group->meanMz << SEP
+                << setprecision(3) << group->meanRt << SEP
+                << setprecision(6) << group->maxQuality << SEP
+                << tagString << SEP;
 
     string compoundName = "";
     string compoundID = "";
@@ -270,17 +275,16 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         compoundID = compoundName;
     }
 
-    groupReport << SEP << compoundName;
-    groupReport << SEP << compoundID;
-    groupReport << SEP << formula;
-    //groupReport << SEP << categoryString;
-    groupReport << SEP << expectedRtDiff;
-    groupReport << SEP << ppmDist;
+    groupReport << compoundName << SEP
+                << compoundID << SEP
+                << formula << SEP
+                << setprecision(3) << expectedRtDiff << SEP
+                << setprecision(6) << ppmDist << SEP;
 
     if (group->parent != NULL) {
-        groupReport << SEP << group->parent->meanMz;
+        groupReport << group->parent->meanMz << SEP;
     } else {
-        groupReport << SEP << group->meanMz;
+        groupReport << group->meanMz;
     }
 
     // for intensity values, we only write two digits of floating point precision

--- a/tests/MavenTests/testCSVReports.cpp
+++ b/tests/MavenTests/testCSVReports.cpp
@@ -240,7 +240,7 @@ void TestCSVReports::verifyUntargetedGroupReport(vector<mzSample*>& samplesToLoa
     QVERIFY(parentValues[8] == "210.150269@16.714417");
     QVERIFY(parentValues[9] == "210.150269@16.714417");
     QVERIFY(parentValues[10] == "");
-    QVERIFY(parentValues[11] == "0.000000");
+    QVERIFY(parentValues[11] == "0.000");
     QVERIFY(parentValues[12] == "0.000000");
     // QVERIFY(parentValues[13] == "210.150269");
     // QVERIFY(parentValues[14] == "1234094464.00");


### PR DESCRIPTION
Retention time for compounds are mostly differentiated on the order
of milliseconds. Peak report already exports CSV files with "rt"
precision of 10^(-3) and the same should be used for group summary
report as well.