### PR TITLE
[Fix] Check for empty line in compound db

### DIFF
--- a/bin/methods/compoundlist.csv
+++ b/bin/methods/compoundlist.csv
@@ -1,9 +1,12 @@
 mz,rt,charge,name,formula,id
+
 588.07523818,14.14,-1,ADP-D-glucose,C16H25N5O15P2,C00498
 0,15.5,0,acetoacetyl-CoA,C25H40N7O18P3S,
 101.03767,15.46,-2,acetyl-CoA,,
 507.99277,15.46,-1,dGTP,,
+
 ,1,-1,YourFavoriteCompound1,,
 120.0433,2,-2,YourFavoriteCompound2,,
 ,,0,YourFavoriteCompound3,C4H9O4R,
 120.0433,,,YourFavoriteCompound4,,
+

--- a/src/core/libmaven/databases.cpp
+++ b/src/core/libmaven/databases.cpp
@@ -20,9 +20,13 @@ int Databases::loadCompoundCSVFile(string filename) {
     while (getline(myfile,line)) {
         //This is used to write commands
         if (!line.empty() && line[0] == '#') continue;
-        
+
         //trim spaces on the left
-        line.erase(line.find_last_not_of(" \n\r\t")+1);
+        size_t found = line.find_last_not_of(" \n\r\t");
+        if (found != string::npos)
+            line.erase(found+1);
+        else continue;
+        
         lineCount++;
 
         vector<string> fields;

--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -465,10 +465,12 @@ int Database::loadCompoundCSVFile(string filename){
     invalidRows.clear();
     //cerr << filename << " sep=" << sep << endl;
     while(!myFile.atEnd()) {
-        string line = QString(myFile.readLine()).toStdString();
+        //remove whitespace from the start and end
+        QString tempLine = myFile.readLine().trimmed();
+        if (tempLine.isEmpty()) continue;
+
+        string line = tempLine.toStdString();
         if (!line.empty() && line[0] == '#') continue;
-        //trim spaces on the left
-        line.erase(line.find_last_not_of(" \n\r\t")+1);
         lineCount++;
 
         vector<string>fields;


### PR DESCRIPTION
Stray newline characters from editing csv files in general editors are very common. Empty lines in the compound db led to unexpected crashes.

This crash has now been resolved.