### PR TITLE
Fix group summary report having shifted sample values

### DIFF
--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -224,15 +224,15 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
     tagString = sanitizeString(tagString.c_str()).toStdString();
     char label[2];
     sprintf(label, "%c", group->label);
-    groupReport << label << SEP
-                << parentGroup->groupId << SEP
-                << groupId << SEP
-                << group->goodPeakCount << SEP
+    groupReport << label
+                << SEP << parentGroup->groupId
+                << SEP << groupId
+                << SEP << group->goodPeakCount
                 << fixed
-                << setprecision(6) << group->meanMz << SEP
-                << setprecision(3) << group->meanRt << SEP
-                << setprecision(6) << group->maxQuality << SEP
-                << tagString << SEP;
+                << SEP << setprecision(6) << group->meanMz
+                << SEP << setprecision(3) << group->meanRt
+                << SEP << setprecision(6) << group->maxQuality
+                << SEP << tagString;
 
     string compoundName = "";
     string compoundID = "";
@@ -275,16 +275,16 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         compoundID = compoundName;
     }
 
-    groupReport << compoundName << SEP
-                << compoundID << SEP
-                << formula << SEP
-                << setprecision(3) << expectedRtDiff << SEP
-                << setprecision(6) << ppmDist << SEP;
+    groupReport << SEP << compoundName
+                << SEP << compoundID
+                << SEP << formula
+                << SEP << setprecision(3) << expectedRtDiff
+                << SEP << setprecision(6) << ppmDist;
 
     if (group->parent != NULL) {
-        groupReport << group->parent->meanMz << SEP;
+        groupReport << SEP << group->parent->meanMz;
     } else {
-        groupReport << group->meanMz;
+        groupReport << SEP << group->meanMz;
     }
 
     // for intensity values, we only write two digits of floating point precision
@@ -348,31 +348,31 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
 
 
         peakReport << fixed << setprecision(6)
-                   << group->groupId << SEP
-                   << compoundName << SEP
-                   << compoundID << SEP
-                   << formula << SEP
-                   << sampleName << SEP
-                   << peak.peakMz <<  SEP
-                   << peak.medianMz <<  SEP
-                   << peak.baseMz <<  SEP
+                   << group->groupId
+                   << SEP << compoundName
+                   << SEP << compoundID
+                   << SEP << formula
+                   << SEP << sampleName
+                   << SEP << peak.peakMz
+                   << SEP << peak.medianMz
+                   << SEP << peak.baseMz
                    << setprecision(3)
-                   << peak.rt <<  SEP
-                   << peak.rtmin <<  SEP
-                   << peak.rtmax <<  SEP
-                   << peak.quality << SEP
+                   << SEP << peak.rt
+                   << SEP << peak.rtmin
+                   << SEP << peak.rtmax
+                   << SEP << peak.quality
                    // for intensity values, we only write two digits of floating point precision
                    // since these values are supposed to be large (in the order of > 10^3).
                    << setprecision(2)
-                   << peak.peakIntensity << SEP
-                   << peak.peakArea <<  SEP
-                   << peak.peakSplineArea <<  SEP
-                   << peak.peakAreaTop <<  SEP
-                   << peak.peakAreaCorrected <<  SEP
-                   << peak.peakAreaTopCorrected << SEP
-                   << peak.noNoiseObs <<  SEP
-                   << peak.signalBaselineRatio <<  SEP
-                   << peak.fromBlankSample << endl;
+                   << SEP << peak.peakIntensity
+                   << SEP << peak.peakArea
+                   << SEP << peak.peakSplineArea
+                   << SEP << peak.peakAreaTop
+                   << SEP << peak.peakAreaCorrected
+                   << SEP << peak.peakAreaTopCorrected
+                   << SEP << peak.noNoiseObs
+                   << SEP << peak.signalBaselineRatio
+                   << SEP << peak.fromBlankSample << endl;
     }
 }
 

--- a/tests/MavenTests/testCSVReports.cpp
+++ b/tests/MavenTests/testCSVReports.cpp
@@ -160,6 +160,7 @@ void TestCSVReports::verifyTargetedGroupReport(vector<mzSample*>& samplesToLoad,
     // check if parent group values are correctly written
     vector<std::string> parentValues;
     mzUtils::splitNew(parentString, "," , parentValues);
+    QVERIFY(parentValues.size() == 16);
     QVERIFY(parentValues[0] == "");
     QVERIFY(parentValues[1] == "1");
     QVERIFY(parentValues[2] == "1");
@@ -180,6 +181,7 @@ void TestCSVReports::verifyTargetedGroupReport(vector<mzSample*>& samplesToLoad,
     // check if labelled child values are correctly written
     vector<std::string> childValues;
     mzUtils::splitNew(labelString, "," , childValues);
+    QVERIFY(childValues.size() == 16);
     QVERIFY(childValues[0] == "");
     QVERIFY(childValues[1] == "1");
     QVERIFY(childValues[2] == "2");
@@ -229,6 +231,7 @@ void TestCSVReports::verifyUntargetedGroupReport(vector<mzSample*>& samplesToLoa
     // check if group values are correctly written
     vector<std::string> parentValues;
     mzUtils::splitNew(parentString, "," , parentValues);
+    QVERIFY(parentValues.size() == 16);
     QVERIFY(parentValues[0] == "");
     QVERIFY(parentValues[1] == "15");
     QVERIFY(parentValues[2] == "1");
@@ -278,6 +281,7 @@ void TestCSVReports::verifyTargetedPeakReport(vector<mzSample*>& samplesToLoad,
     // check if parent group values are correctly written
     vector<std::string> peakValues1;
     mzUtils::splitNew(peakString1, "," , peakValues1);
+    QVERIFY(peakValues1.size() == 21);
     QVERIFY(peakValues1[0] == "1");
     QVERIFY(peakValues1[1] == "Stachyose");
     QVERIFY(peakValues1[2] == "HMDB03553");
@@ -303,6 +307,7 @@ void TestCSVReports::verifyTargetedPeakReport(vector<mzSample*>& samplesToLoad,
     // check if labelled child values are correctly written
     vector<std::string> peakValues2;
     mzUtils::splitNew(peakString2, "," , peakValues2);
+    QVERIFY(peakValues2.size() == 21);
     QVERIFY(peakValues2[0] == "1");
     QVERIFY(peakValues2[1] == "Stachyose");
     QVERIFY(peakValues2[2] == "HMDB03553");
@@ -357,6 +362,7 @@ void TestCSVReports::verifyUntargetedPeakReport(vector<mzSample*>& samplesToLoad
     // check if parent group values are correctly written
     vector<std::string> peakValues1;
     mzUtils::splitNew(peakString1, "," , peakValues1);
+    QVERIFY(peakValues1.size() == 21);
     QVERIFY(peakValues1[0] == "15");
     QVERIFY(peakValues1[1] == "210.150269@16.714417");
     QVERIFY(peakValues1[2] == "210.150269@16.714417");
@@ -382,6 +388,7 @@ void TestCSVReports::verifyUntargetedPeakReport(vector<mzSample*>& samplesToLoad
     // check if labelled child values are correctly written
     vector<std::string> peakValues2;
     mzUtils::splitNew(peakString2, "," , peakValues2);
+    QVERIFY(peakValues2.size() == 21);
     QVERIFY(peakValues2[0] == "15");
     QVERIFY(peakValues2[1] == "210.150269@16.714417");
     QVERIFY(peakValues2[2] == "210.150269@16.714417");


### PR DESCRIPTION
An extra separator was being added for labelled groups in group summary report. This patch fixes this issue and add some basic tests to check for these kinds of error.