### PR TITLE
[Fix] Exit peakdetector CLI when compound db is empty

### DIFF
--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -547,32 +547,32 @@ void PeakDetectorCLI::loadClassificationModel(string clsfModelFilename) {
 	mavenParameters->clsf->loadModel(clsfModelFilename);
 }
 
-void PeakDetectorCLI::loadCompoundsFile() {
-
-	//load compound list
-	if (!mavenParameters->ligandDbFilename.empty()) {
-		mavenParameters->processAllSlices = false;
-		cout << "\nLoading ligand database" << endl;
-		int loadCount = DB.loadCompoundCSVFile(mavenParameters->ligandDbFilename);
-		mavenParameters->compounds = DB.compoundsDB;
-		if (loadCount == 0) {
-			cerr << "Warning: Given compound database is empty!" << endl;
-		} else if (DB.invalidRows.size() == 0) {
-			cout << "Total Compounds Loaded : " << loadCount << endl;
-		} else {
-			cout << "Total Compounds Loaded : " << loadCount << endl;
-			cout << "The following compounds had insufficient information for peak detection, and were not loaded:" << endl;
-			for (auto compoundID: DB.invalidRows) {
-				cout << " - " << compoundID << endl;
-			}
-		}
-	}
-	 else {
-		cerr << "\nPlease provide a compound database file to proceed with targeted analysis."
-		     << "Use the '-h' argument to see all available options." << endl;
-		exit(0);
-	}
-
+void PeakDetectorCLI::loadCompoundsFile()
+{
+    //load compound list
+    if (!mavenParameters->ligandDbFilename.empty()) {
+        mavenParameters->processAllSlices = false;
+        cout << "\nLoading ligand database" << endl;
+        int loadCount = DB.loadCompoundCSVFile(mavenParameters->ligandDbFilename);
+        mavenParameters->compounds = DB.compoundsDB;
+        if (loadCount == 0) {
+            cerr << "Warning: Given compound database is empty!" << endl;
+            exit(1);
+        } else {
+            cout << "Total Compounds Loaded : " << loadCount << endl;
+            if (DB.invalidRows.size() > 0) {
+                cout << "The following compounds had insufficient information for peak detection, and were not loaded:"
+                     << endl;
+                for (auto compoundID : DB.invalidRows) {
+                    cout << " - " << compoundID << endl;
+                }
+            }
+        }
+    } else {
+        cerr << "\nPlease provide a compound database file to proceed with targeted analysis."
+             << "Use the '-h' argument to see all available options." << endl;
+        exit(0);
+    }
 }
 
 void PeakDetectorCLI::loadSamples(vector<string>&filenames) {

--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -549,30 +549,35 @@ void PeakDetectorCLI::loadClassificationModel(string clsfModelFilename) {
 
 void PeakDetectorCLI::loadCompoundsFile()
 {
-    //load compound list
-    if (!mavenParameters->ligandDbFilename.empty()) {
-        mavenParameters->processAllSlices = false;
-        cout << "\nLoading ligand database" << endl;
-        int loadCount = DB.loadCompoundCSVFile(mavenParameters->ligandDbFilename);
-        mavenParameters->compounds = DB.compoundsDB;
-        if (loadCount == 0) {
-            cerr << "Warning: Given compound database is empty!" << endl;
-            exit(1);
-        } else {
-            cout << "Total Compounds Loaded : " << loadCount << endl;
-            if (DB.invalidRows.size() > 0) {
-                cout << "The following compounds had insufficient information for peak detection, and were not loaded:"
-                     << endl;
-                for (auto compoundID : DB.invalidRows) {
-                    cout << " - " << compoundID << endl;
-                }
-            }
-        }
-    } else {
+    //exit if no db file has been provided
+    if (mavenParameters->ligandDbFilename.empty()) {
         cerr << "\nPlease provide a compound database file to proceed with targeted analysis."
              << "Use the '-h' argument to see all available options." << endl;
         exit(0);
     }
+    
+    //load compound list
+    mavenParameters->processAllSlices = false;
+    cout << "\nLoading ligand database" << endl;
+    int loadCount = DB.loadCompoundCSVFile(mavenParameters->ligandDbFilename);
+    mavenParameters->compounds = DB.compoundsDB;
+
+    //exit if db is empty
+    if (loadCount == 0) {
+        cerr << "Warning: Given compound database is empty!" << endl;
+        exit(1);
+    }
+    
+    //check for invalid compounds
+    if (DB.invalidRows.size() > 0) {
+        cout << "The following compounds had insufficient information for peak detection, and were not loaded:"
+             << endl;
+        for (auto compoundID : DB.invalidRows) {
+            cout << " - " << compoundID << endl;
+        }
+    }
+    
+    cout << "Total Compounds Loaded : " << loadCount << endl;
 }
 
 void PeakDetectorCLI::loadSamples(vector<string>&filenames) {

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -142,7 +142,12 @@ class PeakDetectorCLI {
 		void loadClassificationModel(string clsfModelFilename);
 
 
-		void loadCompoundsFile();
+        /**
+        * @brief load user provided compound database
+        * @details load the compound database from mavenparameters and give 
+        * appropriate warnings or exit
+        */
+        void loadCompoundsFile();
 
 		/**
 		* [loadSamples description]


### PR DESCRIPTION
Execution of the CLI command should stop in case of an empty compound db during targeted analysis