### PR TITLE
[Fix] Add missing rows in tabledockwidget

### DIFF
--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -113,7 +113,7 @@ void TableDockWidget::setupPeakTable() {
 
   QStringList colNames;
 
-  // Add a coulmn to the Peaks Table
+  // Add common coulmns to the Table
   colNames << "#";
   colNames << "ID";
   colNames << "Observed m/z";
@@ -122,7 +122,7 @@ void TableDockWidget::setupPeakTable() {
 
   if (viewType == groupView) {
 
-    // Add a coulmn to the Peaks Table
+    // Add group view columns to the peak table
     colNames << "rt delta";
     colNames << "#peaks";
     colNames << "#good";
@@ -130,10 +130,12 @@ void TableDockWidget::setupPeakTable() {
     colNames << "Max AreaTop";
     colNames << "Max S/N";
     colNames << "Max Quality";
+    colNames << "Rank";
   } else if (viewType == peakView) {
     vector<mzSample *> vsamples = _mainwindow->getVisibleSamples();
     sort(vsamples.begin(), vsamples.end(), mzSample::compSampleOrder);
     for (unsigned int i = 0; i < vsamples.size(); i++) {
+      // Add peak view columns to the table
       colNames << QString(vsamples[i]->sampleName.c_str());
     }
   }
@@ -2878,7 +2880,7 @@ void ScatterplotTableDockWidget::setupPeakTable() {
 
   QStringList colNames;
 
-  // Add a coulmn to the Peaks Table
+  // Add common columns to the table
   colNames << "#";
   colNames << "ID";
   colNames << "Observed m/z";
@@ -2887,7 +2889,7 @@ void ScatterplotTableDockWidget::setupPeakTable() {
 
   if (viewType == groupView) {
 
-    // Add a coulmn to the Peaks Table
+    // Add group view columns to the table
     colNames << "rt delta";
     colNames << "#peaks";
     colNames << "#good";
@@ -2895,15 +2897,16 @@ void ScatterplotTableDockWidget::setupPeakTable() {
     colNames << "Max AreaTop";
     colNames << "Max S/N";
     colNames << "Max Quality";
-
-    // Add a coulmn to the Peaks Table
     colNames << "Rank";
+
+    // add scatterplot table columns
     colNames << "Ratio Change";
     colNames << "P-value";
   } else if (viewType == peakView) {
     vector<mzSample *> vsamples = _mainwindow->getVisibleSamples();
     sort(vsamples.begin(), vsamples.end(), mzSample::compSampleOrder);
     for (unsigned int i = 0; i < vsamples.size(); i++) {
+      // Add peak view columns to the table
       colNames << QString(vsamples[i]->sampleName.c_str());
     }
   }

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -98,7 +98,7 @@ public Q_SLOTS:
   void updateCompoundWidget();
   PeakGroup *addPeakGroup(PeakGroup *group);
   void sortChildrenAscending(QTreeWidgetItem *item);
-  void setupPeakTable();
+  virtual void setupPeakTable();
   PeakGroup *getSelectedGroup();
   QList<PeakGroup *> getSelectedGroups();
   void showNotification();
@@ -159,8 +159,8 @@ public Q_SLOTS:
   void updateItem(QTreeWidgetItem *item);
   void updateStatus();
 
-  void markGroupBad();
-  void markGroupGood();
+  virtual void markGroupBad();
+  virtual void markGroupGood();
   bool checkLabeledGroups();
   void markGroupIgnored();
   void showAllGroups();
@@ -180,8 +180,8 @@ public Q_SLOTS:
 
   void showConsensusSpectra();
 
-  void deleteGroups();
-  void deleteGroup(PeakGroup *groupX);
+  virtual void deleteGroups();
+  virtual void deleteGroup(PeakGroup *groupX);
 
   void sortBy(int);
   void align();


### PR DESCRIPTION
This PR adds the following missing rows:
1. "Rank" field in all instances of peak tables.
2. "Ratio Change" and "P-value" in scatterplot peak tables.

These rows accidentally went missing from the last refactoring of `TableDockWidget` set of classes.