### PR TITLE
[Fix] Resolve crash in merging tables

### DIFF
--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -2636,9 +2636,9 @@ void BookmarkTableDockWidget::mergeGroupsIntoPeakTable(QAction *action)
 
     int initialSize = peakTable->allgroups.size();
     int finalSize = allgroups.size() + initialSize;
-    for (unsigned int i = 0; i < allgroups.size(); i++) {
-        allgroups[i].groupId = ++initialSize;
-        peakTable->allgroups.append(allgroups[i]);
+    for (auto group : allgroups) {
+        group.groupId = ++initialSize;
+        peakTable->allgroups.append(group);
     }
 
     deleteAll();

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -2602,37 +2602,53 @@ void BookmarkTableDockWidget::showMsgBox(bool check, int tableNo) {
   msgBox->open();
 }
 
-void BookmarkTableDockWidget::mergeGroupsIntoPeakTable(QAction *action) {
+void BookmarkTableDockWidget::mergeGroupsIntoPeakTable(QAction *action)
+{
+    QList<QPointer<TableDockWidget>> peaksTableList = _mainwindow->getPeakTableList();
+    int j = mergeAction.value(action, -1);
 
-  QList<QPointer<TableDockWidget>> peaksTableList =
-      _mainwindow->getPeakTableList();
-  int n = peaksTableList.size();
-  int j = mergeAction.value(action, -1);
+    //check if action exists
+    if (j == -1) {
+        showMsgBox(false, j);
+        return;
+    }
 
-  if (j == -1) {
-    showMsgBox(false, j);
-    return;
-  }
+    //return if no bookmarked groups or peak tables
+    if (allgroups.isEmpty() || peaksTableList.isEmpty()) {
+        showMsgBox(true, j);
+        return;
+    }
 
-  if (!allgroups.size() || !n) {
-    showMsgBox(true, j);
-    return;
-  }
-  int sz = peaksTableList[j - 1]->allgroups.size();
-  int total = allgroups.size() + sz;
-  for (unsigned int i = 0; i < allgroups.size(); i++) {
-    allgroups[i].groupId = ++sz;
-    peaksTableList[j - 1]->allgroups.append(allgroups[i]);
-  }
+    //find table to merge with
+    TableDockWidget* peakTable;
+    for (auto table : peaksTableList) {
+        if (table->tableId == j) {
+            peakTable = table;
+            break;
+        }
+    }
 
-  deleteAll();
-  peaksTableList[j - 1]->showAllGroups();
-  showAllGroups();
+    //return if peak table not found
+    if (!peakTable) {
+        showMsgBox(false, j);
+        return;
+    }
 
-  if (total == peaksTableList[j - 1]->allgroups.size())
-    showMsgBox(true, j);
-  else
-    showMsgBox(false, j);
+    int initialSize = peakTable->allgroups.size();
+    int finalSize = allgroups.size() + initialSize;
+    for (unsigned int i = 0; i < allgroups.size(); i++) {
+        allgroups[i].groupId = ++initialSize;
+        peakTable->allgroups.append(allgroups[i]);
+    }
+
+    deleteAll();
+    peakTable->showAllGroups();
+    showAllGroups();
+
+    if (finalSize == peakTable->allgroups.size())
+        showMsgBox(true, j);
+    else
+        showMsgBox(false, j);
 }
 
 void BookmarkTableDockWidget::acceptGroup() {

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -338,6 +338,12 @@ public:
 public Q_SLOTS:
   void showMergeTableOptions();
   void showMsgBox(bool check, int tableNo);
+  /**
+   * @brief This method moves the bookmarked groups to the selected peak table
+   * @details Merges bookmark and peak tables and then displays a success or error
+   * message
+   * @param pointer to QAction that stores the selected peak table
+   */
   void mergeGroupsIntoPeakTable(QAction *action);
 
   /**


### PR DESCRIPTION
Merging the bookmarked groups to a peak table led to the app crashing if any peak table had been deleted during the session.
The merging code was working on the assumption that the table id and the peakList indices will remain in sync.
Deleting a peak table led to an index out of range error.
This has been resolved by searching for the correct Id

Steps to reproduce the crash on develop:
- Create and Delete any peak table
- Bookmark a peak
- Create another peak table
- Merge bookmark table with this new table
- App crashes