### PR TITLE
Fix missing ratio change and p-value change

### DIFF
--- a/src/gui/mzroll/scatterplot.cpp
+++ b/src/gui/mzroll/scatterplot.cpp
@@ -133,7 +133,7 @@ void ScatterPlot::setTable(TableDockWidget* peakTable) {
     Q_FOREACH (PeakGroup *group, groups) {
         _table->addPeakGroup(group);
     }
-    compareSamplesDialog->setTableWidget(peakTable);
+    compareSamplesDialog->setTableWidget(_table);
 }
 
 QSet<PeakGroup*> ScatterPlot::getGroupsInRect(QPointF from, QPointF to) {


### PR DESCRIPTION
Another fallout of the TableDockWidget refactoring. This trivial patch fixes the issue of missing ratio change and p-value change from scatterplot peak table, and consequently fixes the volcano plot being useless having clustered data points and wierd axes.