### PR TITLE
Use more portable command to obtain number of processors

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,8 @@ while true; do
         * ) echo "Please answer yes or no.";;
     esac
 done
-make -j $(nproc)
+
+make -j $(getconf _NPROCESSORS_ONLN)
 
 
 if [ -f tests/MavenTests/test.xml ]; then


### PR DESCRIPTION
The `$(nproc)` command is not available on Mac OS and this makes the build script misbehave. A command available on both Linux and Mac OS systems will now be used to figure out the number of processors available on a system.