### PR TITLE
[Fix] Allow all labels to go to Polly

### DIFF
--- a/src/cli/peakdetector/PeakDetectorCLI.cpp
+++ b/src/cli/peakdetector/PeakDetectorCLI.cpp
@@ -680,10 +680,7 @@ QString PeakDetectorCLI::isReadyForPolly(){
 		qDebug()<<"json file is required for Elmaven-Polly-Integration, overriding existing settings to save EIC json file.";
 		saveJsonEIC = true;
 	}
-	if (!mavenParameters->C13Labeled_BPE || mavenParameters->S34Labeled_BPE || mavenParameters->N15Labeled_BPE || mavenParameters->D2Labeled_BPE){
-		message = "As of now, Polly allows only carbon label studies..Please use -f 0001 in CLI command ";
-		return message;
-	}
+	
 	return message;
 }
 

--- a/src/cli/peakdetector/PeakDetectorCLI.h
+++ b/src/cli/peakdetector/PeakDetectorCLI.h
@@ -199,7 +199,13 @@ class PeakDetectorCLI {
 		void makeSampleCohortFile(QString sample_cohort_filename, QStringList loadedSamples);
 		bool send_user_email(QMap<QString, QString> creds, QString redirection_url);
 		QMap<QString, QString> readCredentialsFromXml(QString filename);
+		
+		/**
+		 * @brief checks if data is not compatible with Polly
+		 * @return QString message/warning regarding incompatibility
+		*/
 		QString isReadyForPolly();
+		
 		int prepareCompoundDbForPolly(QString fileName);
 		
 		/**


### PR DESCRIPTION
This check was added to ensure that user only sends C13 labeled data to PollyPhi as Polly was not compatible with other labels

This has been fixed on Polly and therefore this check is not required.