### PR TITLE
Enable OpenMp on MacOS

### DIFF
--- a/build.pro
+++ b/build.pro
@@ -1,8 +1,5 @@
 TEMPLATE = subdirs
 CONFIG += ordered qt thread
 
-macx{
-#    QMAKE_CXX = /usr/local/opt/llvm@3.7/lib/llvm-3.7/bin/clang++
-}
 
 SUBDIRS += 3rdparty src tests/MavenTests CrashReporter

--- a/mzroll.pri
+++ b/mzroll.pri
@@ -11,6 +11,12 @@ CONFIG(debug, debug|release){
 
 QT += sql core  xml gui opengl
 
+macx {
+
+    QMAKE_CXX = /usr/local/Cellar/llvm/6.0.1/bin/clang++
+    QMAKE_CC = /usr/local/Cellar/llvm/6.0.1/bin/clang
+}
+
 CONFIG += silent exceptions
 
 # this is important. Used in mzUtils to make use of correct mkdir function

--- a/src/cli/peakdetector/peakdetector.pro
+++ b/src/cli/peakdetector/peakdetector.pro
@@ -20,7 +20,11 @@ QMAKE_LFLAGS  +=  -L$$top_builddir/libs/
 
 LIBS +=  -lmaven -lpugixml -lneural -lcsvparser -lpls -lErrorHandling -lLogger -lcdfread -lnetcdf -lz -lobiwarp -lpollyCLI
 macx {
-	LIBS -= -lnetcdf -lcdfread
+    QMAKE_CXXFLAGS += -fopenmp
+    INCLUDEPATH += /usr/local/Cellar/llvm/6.0.1/lib/clang/6.0.1/include/
+    QMAKE_LFLAGS +=-L/usr/local/Cellar/llvm/6.0.1/lib/
+    LIBS += -lomp
+    LIBS -= -lnetcdf -lcdfread
 }
 
 SOURCES	= 	PeakDetectorCLI.cpp  \

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -29,31 +29,23 @@ vector<EIC*> PeakDetector::pullEICs(mzSlice* slice,
 
         vector<EIC*> eics;
         vector<mzSample*> vsamples;
-        #ifndef __APPLE__
         #pragma omp parallel default(shared)
-        #endif
         {
 
-                #ifndef __APPLE__
                 #pragma omp for
-                #endif
                 for (unsigned int i = 0; i < samples.size(); i++) {
                         if (samples[i] == NULL)
                                 continue;
                         if (samples[i]->isSelected == false)
                                 continue;
-                        #ifndef __APPLE__
                         #pragma omp critical
-                        #endif
                         vsamples.push_back(samples[i]);
                 }
 
                 // single threaded version - getting EICs of selected samples.
                 // #pragma omp parallel for ordered
 
-                #ifndef __APPLE__
                 #pragma omp for
-                #endif
                 for (unsigned int i = 0; i < vsamples.size(); i++) {
                 //Samples been selected
                 mzSample* sample = vsamples[i];
@@ -89,9 +81,7 @@ vector<EIC*> PeakDetector::pullEICs(mzSlice* slice,
                         //smoohing over
 
                         //push eic to all eics vector
-                        #ifndef __APPLE__
                         #pragma omp critical
-                        #endif
                         eics.push_back(e);
                 }
                 }

--- a/src/core/libmaven/PeakDetector.h
+++ b/src/core/libmaven/PeakDetector.h
@@ -18,9 +18,7 @@
 #include <boost/bind.hpp>
 #include <boost/signals2.hpp>
 
-#ifndef __APPLE__
 #include <omp.h>
-#endif
 
 #include "mzUtils.h"
 #include "Compound.h"

--- a/src/core/libmaven/libmaven.pro
+++ b/src/core/libmaven/libmaven.pro
@@ -13,8 +13,7 @@ QMAKE_CXXFLAGS +=  -std=c++11
 QMAKE_CXXFLAGS += -DOMP_PARALLEL
 linux: QMAKE_CXXFLAGS += -Ofast -ffast-math
 win32: QMAKE_CXXFLAGS += -Ofast -ffast-math
-!macx: QMAKE_CXXFLAGS += -fopenmp
-!macx: LIBS += -fopenmp
+QMAKE_CXXFLAGS += -fopenmp
 
 TARGET = maven
 
@@ -27,14 +26,16 @@ INCLUDEPATH +=  $$top_srcdir/3rdparty/pugixml/src/ \
                 $$top_srcdir/3rdparty/libcsvparser \
                 $$top_srcdir/3rdparty/libdate/ \
                 $$top_srcdir/3rdparty/ErrorHandling \
-                $$top_srcdir/3rdparty/obiwarp
+                $$top_srcdir/3rdparty/obiwarp \
 
 QMAKE_LFLAGS += -L$$top_builddir/libs
+
 LIBS += -lobiwarp
 
 macx{
 
-    INCLUDEPATH += /usr/local/include/
+    INCLUDEPATH += /usr/local/include/ \
+                   /usr/local/Cellar/llvm/6.0.1/lib/clang/6.0.1/include/
     QMAKE_LFLAGS += -L/usr/local/lib/
     LIBS +=  -lboost_signals
 }

--- a/src/core/libmaven/mzMassSlicer.h
+++ b/src/core/libmaven/mzMassSlicer.h
@@ -6,9 +6,8 @@
 #include "mzUtils.h"
 #include "Matrix.h"
 
-#ifndef __APPLE__
 #include <omp.h>
-#endif
+
 
 #include <boost/signals2.hpp>
 #include <boost/bind.hpp>

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -2,9 +2,7 @@
 #include <QStringList>
 #include <QTextStream>
 
-#ifndef __APPLE__
 #include <omp.h>
-#endif
 
 #include <MavenException.h>
 #include <errorcodes.h>
@@ -567,18 +565,14 @@ void mzFileIO::fileImport(void) {
     qDebug() << "uploadMultiprocessing: " <<  uploadMultiprocessing << endl;
     if (uploadMultiprocessing) {
         int iter = 0;
-        #ifndef __APPLE__
         #pragma omp parallel for shared(iter)
-        #endif
         for (int i = 0; i < samples.size(); i++) {
             QString filename = samples.at(i);
             mzSample* sample = loadSample(filename);
             if (sample && sample->scans.size() > 0)
                 emit addNewSample(sample);
 
-            #ifndef __APPLE__
             #pragma omp atomic
-            #endif
             iter++;
 
             Q_EMIT (updateProgressBar( tr("Importing file %1").arg(filename), iter, samples.size()));

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -12,9 +12,8 @@ QMAKE_CXXFLAGS +=  -std=c++11
 QMAKE_CXXFLAGS += -DOMP_PARALLEL
 linux: QMAKE_CXXFLAGS += -Ofast -ffast-math
 win32: QMAKE_CXXFLAGS += -Ofast -ffast-math
-!macx: QMAKE_CXXFLAGS += -fopenmp
+QMAKE_CXXFLAGS += -fopenmp
 !macx: LIBS += -fopenmp
-
 
 QMAKE_STRIP=echo
 PRECOMPILED_HEADER  = stable.h
@@ -48,11 +47,13 @@ win32 {
 }
 
 mac {
-    INCLUDEPATH  += $$top_srcdir/3rdparty/google-breakpad/src/
-    QMAKE_LFLAGS += -L$$top_builddir/libs/
+    QMAKE_CXXFLAGS += -fopenmp
+    INCLUDEPATH  += $$top_srcdir/3rdparty/google-breakpad/src/ /usr/local/Cellar/llvm/6.0.1/lib/clang/6.0.1/include/
+    QMAKE_LFLAGS += -L$$top_builddir/libs/ -L/usr/local/Cellar/llvm/6.0.1/lib/
     LIBS += /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
     LIBS += /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
     LIBS += -lgoogle-breakpad -lobjc -pthread
+    LIBS += -lomp
 }
 
 INCLUDEPATH +=  /usr/include/x86_64-linux-gnu/qt5/QtXml/ /usr/include/x86_64-linux-gnu/qt5/QtSql

--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -15,7 +15,7 @@ CONFIG += qtestlib warn_off
 
 QMAKE_CXXFLAGS +=  -std=c++11
 QMAKE_CXXFLAGS += -DOMP_PARALLEL
-!macx: QMAKE_CXXFLAGS += -fopenmp
+QMAKE_CXXFLAGS += -fopenmp
 
 INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  $$top_srcdir/3rdparty/pugixml/src $$top_srcdir/3rdparty/libneural $$top_srcdir/3rdparty/libpls \
 				$$top_srcdir/3rdparty/libcsvparser $$top_srcdir/src/cli/peakdetector $$top_srcdir/3rdparty/libdate $$top_srcdir/3rdparty/libcdfread \
@@ -28,7 +28,10 @@ LIBS += -lmaven -lpugixml -lneural -lcsvparser -lpls -lErrorHandling -lLogger -l
 !macx: LIBS += -fopenmp
 
 macx {
-LIBS -= -lnetcdf -lcdfread
+    INCLUDEPATH += /usr/local/Cellar/llvm/6.0.1/lib/clang/6.0.1/include/
+    QMAKE_LFLAGS +=-L/usr/local/Cellar/llvm/6.0.1/lib/
+    LIBS += -lomp
+    LIBS -= -lnetcdf -lcdfread
 }
 
 


### PR DESCRIPTION
QMake by default uses Clang that comes bundled with XCode. That version
of Clang does not have OpenMp support. In order to use Clang which comes
with OpenMp support we need to use:
1. LLVM's clang(https://clang.llvm.org/)
2. Version >= 3.8

This PR makes the following changes:
1. Removes all '#ifndef' directives that stops Mac from
using OpenMp
2. Adds proper linker and compiler flags that are required to
use the right Clang vesion