### PR TITLE
[Ftr] SQLite based project

### DIFF
--- a/mzroll.pri
+++ b/mzroll.pri
@@ -35,6 +35,8 @@ unix: {
     LIBS +=  -lboost_signals -lErrorHandling -lobiwarp
 }
 
+LIBS += -lboost_system -lboost_filesystem -lsqlite3
+
 #INSTALL_LIBDIR = $$(INSTALL_LIBDIR)
 #unix {
 #  !mac {

--- a/mzroll.pri
+++ b/mzroll.pri
@@ -35,8 +35,6 @@ unix: {
     LIBS +=  -lboost_signals -lErrorHandling -lobiwarp
 }
 
-LIBS += -lboost_system -lboost_filesystem -lsqlite3
-
 #INSTALL_LIBDIR = $$(INSTALL_LIBDIR)
 #unix {
 #  !mac {

--- a/src/core/libmaven/Compound.cpp
+++ b/src/core/libmaven/Compound.cpp
@@ -12,11 +12,16 @@ Compound::Compound(string id, string name, string formula, int charge ) {
     */
     this->mass =  MassCalculator::computeNeutralMass(formula);
     this->expectedRt = -1;
+    this->logP = 0;
 
     precursorMz=0;
     productMz=0;
     collisionEnergy=0;
     _groupUnlinked=false;
+
+    virtualFragmentation = false;
+    isDecoy = false;
+    ionizationMode = 0;
 }
 
 float Compound::adjustedMass(int charge) { 

--- a/src/core/libmaven/Compound.h
+++ b/src/core/libmaven/Compound.h
@@ -58,6 +58,10 @@ class Compound{
         string pubchem_id;      /**@param  -  pubchem_id -    PubChem id*/
         string hmdb_id;         /**@param  -  hmdb_id-    Human Metabolome Database id */
         string alias;       /**@param   -  alias name of compound   */
+
+        // TODO: from MAVEN (upstream), find out what this is
+        string smileString;
+
         /**
         *@param -  srmId will hold filterLine string from mzxml file which represent type of
         *mass spec and ionization is used and other info as well
@@ -73,6 +77,17 @@ class Compound{
         float precursorMz;	/**@param  -  QQQ parent ion  mz value   */
         float productMz;    /**@param  -  QQQ child ion   mz value */
         float collisionEnergy; /**@param  -   QQQ collision energy of this compound   */
+        float logP; // TODO: find out what value this is.
+
+        // TODO: from MAVEN (upstream), find out what this is
+        bool virtualFragmentation;
+
+        // TODO: from MAVEN (upstream) decoy compound?
+        bool isDecoy;
+
+        // TODO: from MAVEN (upstream). Can this be derived somehow.
+        // Also maybe use an enum.
+        int ionizationMode;
 
         string db;			/**@param -   name of database for example KEGG, ECOCYC.. etc..    */
 

--- a/src/core/libmaven/Fragment.cpp
+++ b/src/core/libmaven/Fragment.cpp
@@ -1,4 +1,5 @@
 #include "Fragment.h"
+#include "Scan.h"
 
 #include "PeptideRecord.h"
 

--- a/src/core/libmaven/Fragment.h
+++ b/src/core/libmaven/Fragment.h
@@ -2,7 +2,7 @@
 #define FRAGMENT_H
 #include <vector>
 #include "Peptide.hpp"
-#include "Scan.h"
+
 class PeptideRecord;
 class Scan;
 
@@ -95,4 +95,92 @@ class Scan;
         bool operator<(const Fragment* b) const;
         bool operator==(const Fragment* b) const;
     };
+
+    // TODO: from MAVEN (upstream). find our what this is.
+    struct FragmentationMatchScore {
+        double fractionMatched;
+        double spearmanRankCorrelation;
+        double ticMatched;
+        double numMatches;
+        double ppmError;
+        double mzFragError;
+        double mergedScore;
+        double dotProduct;
+        double weightedDotProduct;
+        double dotProductShuffle;
+        double hypergeomScore;
+        double mvhScore;
+        double ms2purity;
+        vector<double> matchedQuantiles;
+
+        static vector<string> getScoringAlgorithmNames()
+        {
+            vector<string> names;
+            names.push_back("HyperGeomScore");
+            names.push_back("MVH");
+            names.push_back("DotProduct");
+            names.push_back("WeightedDotProduct");
+            names.push_back("SpearmanRank");
+            names.push_back("TICMatched");
+            names.push_back("NumMatches");
+            return names;
+        }
+
+        double getScoreByName(string scoringAlgorithm)
+        {
+            if (scoringAlgorithm == "HyperGeomScore")
+                return hypergeomScore;
+            else if (scoringAlgorithm == "MVH")
+                return mvhScore;
+            else if (scoringAlgorithm == "DotProduct")
+                return dotProduct;
+            else if (scoringAlgorithm == "SpearmanRank")
+                return spearmanRankCorrelation;
+            else if (scoringAlgorithm == "TICMatched")
+                return ticMatched;
+            else if (scoringAlgorithm == "WeightedDotProduct")
+                return weightedDotProduct;
+            else if (scoringAlgorithm == "NumMatches")
+                return numMatches;
+            else
+                return hypergeomScore;
+        }
+
+        FragmentationMatchScore()
+        {
+            fractionMatched = 0;
+            spearmanRankCorrelation = 0;
+            ticMatched = 0;
+            numMatches = 0;
+            ppmError = 1000;
+            mzFragError = 1000;
+            mergedScore = 0;
+            dotProduct = 0;
+            weightedDotProduct = 0;
+            hypergeomScore = 0;
+            mvhScore = 0;
+            ms2purity = 0;
+            dotProductShuffle = 0;
+        }
+
+        FragmentationMatchScore& operator=(const FragmentationMatchScore& b)
+        {
+            fractionMatched = b.fractionMatched;
+            spearmanRankCorrelation = b.spearmanRankCorrelation;
+            ticMatched = b.ticMatched;
+            numMatches = b.numMatches;
+            ppmError = b.ppmError;
+            mzFragError = b.mzFragError;
+            mergedScore = b.mergedScore;
+            dotProduct = b.dotProduct;
+            weightedDotProduct = b.weightedDotProduct;
+            hypergeomScore = b.hypergeomScore;
+            mvhScore = b.mvhScore;
+            ms2purity = b.ms2purity;
+            matchedQuantiles = b.matchedQuantiles;
+            dotProductShuffle = b.dotProductShuffle;
+            return *this;
+        }
+    };
+
 #endif

--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -20,6 +20,8 @@ PeakGroup::PeakGroup()  {
     meanMz=0;
     expectedMz=0;
 
+    ms2EventCount = 0;
+
     blankMax=0;
     blankSampleCount=0;
     blankMean=0;
@@ -54,7 +56,10 @@ PeakGroup::PeakGroup()  {
     maxMz=0;
 
     parent = NULL;
-    //adduct = NULL;
+
+    // TODO: MAVEN (upstream) strikes again. Why was it commented out?
+    adduct = NULL;
+
     compound = NULL;
 
     isFocused=false;
@@ -87,6 +92,9 @@ void PeakGroup::copyObj(const PeakGroup& o)  {
     meanRt=o.meanRt;
     meanMz=o.meanMz;
     expectedMz=o.expectedMz;
+
+    fragMatchScore = o.fragMatchScore;
+    adduct = o.adduct;
 
     blankMax=o.blankMax;
     blankSampleCount=o.blankSampleCount;
@@ -417,7 +425,7 @@ double PeakGroup::getExpectedMz(int charge) {
 
     float mz = 0;
 
-    if (isIsotope() && childCount() == 0 && compound && !compound->formula.empty() && compound->mass > 0) { 
+    if (isIsotope() && childCount() == 0 && compound && !compound->formula.empty() && compound->mass > 0) {
         return expectedMz;
     }
     else if (!isIsotope() && compound && compound->mass > 0) {

--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -6,6 +6,7 @@
 #include <limits>
 #include <map>
 #include "EIC.h"
+#include "Fragment.h"
 #include "Peak.h"
 #include "Scan.h"
 #include "mzSample.h"
@@ -58,14 +59,22 @@ class PeakGroup{
         PeakGroup* parent;
         Compound* compound;
 
+        // have to do this since `GroupType` enum also has an Adduct.
+        // In future use "enum class" instead. Also from MAVEN (upstream).
+        class Adduct* adduct;
+
         vector<Peak> peaks;
         vector<PeakGroup> children;
         vector<PeakGroup> childrenBarPlot;
         vector<PeakGroup> childrenIsoWidget;
-        vector<mzSample*> samples;  //this varibale will hold only those sample which has been 
+        vector<mzSample*> samples;  //this varibale will hold only those sample which has been
                                     //used for peak detection
         string srmId;
         string tagString;
+
+        // Stores the name of Peak Table this group belongs to.
+        string searchTableName;
+
         /** classification label */
         char label;
         /**
@@ -97,6 +106,12 @@ class PeakGroup{
         float meanMz;
         float expectedMz;
         int totalSampleCount;
+
+        // TODO: from MAVEN (upstream), what is an MS2 event?
+        int  ms2EventCount;
+
+        // TODO: from MAVEN(upstream), see FragmentMatchScore from Fragment.h
+        FragmentationMatchScore fragMatchScore;
 
         //isotopic information
         float expectedAbundance;

--- a/src/core/libmaven/Scan.cpp
+++ b/src/core/libmaven/Scan.cpp
@@ -538,3 +538,8 @@ vector<int> Scan::assignCharges(MassCutoff *massCutoffTolr) {
     }
     return parentPeaks;
 }
+
+double Scan::getPrecursorPurity(float ppm=10.0) {
+    // Just a stub for now. See Eugene's maven_core for actual implementation.
+    return 0.0;
+}

--- a/src/core/libmaven/Scan.h
+++ b/src/core/libmaven/Scan.h
@@ -33,13 +33,22 @@ class Scan
      * @brief Obtain the smallest m/z value stored.
      * @return Fractional m/z value.
      */
-    inline float minMz()  { if(nobs() > 0) return mz[0]; return 0; }
+    inline float minMz() {
+        if(nobs() > 0)
+            return *(std::min_element(begin(mz),
+                                      end(mz)));
+        return 0.0f;
+    }
 
     /**
      * @brief Obtain the largest m/z value stored.
      * @return Fractional m/z value.
      */
-    inline float maxMz()  { if(nobs() > 0) return mz[nobs()-1]; return 0; }
+    inline float maxMz() {
+        if(nobs() > 0)
+            return *(std::max_element(begin(mz),
+                                      end(mz)));
+        return 0.0f; }
 
     /**
     *@brief return the corresponding sample

--- a/src/core/libmaven/Scan.h
+++ b/src/core/libmaven/Scan.h
@@ -29,6 +29,17 @@ class Scan
     */
     inline unsigned int nobs() const { return mz.size(); }
 
+    /**
+     * @brief Obtain the smallest m/z value stored.
+     * @return Fractional m/z value.
+     */
+    inline float minMz()  { if(nobs() > 0) return mz[0]; return 0; }
+
+    /**
+     * @brief Obtain the largest m/z value stored.
+     * @return Fractional m/z value.
+     */
+    inline float maxMz()  { if(nobs() > 0) return mz[nobs()-1]; return 0; }
 
     /**
     *@brief return the corresponding sample
@@ -144,6 +155,9 @@ class Scan
     * @brief removes intensities from scan that are  lower than minQuantile
     */
     void quantileFilter(int minQuantile);
+
+    // TODO: from MAVEN (upstream). What for? Always returns 0.0  for now.
+    double getPrecursorPurity(float ppm);
 
     /**
     *@brief print the info present in a scan

--- a/src/core/libmaven/mzMassCalculator.cpp
+++ b/src/core/libmaven/mzMassCalculator.cpp
@@ -6,6 +6,9 @@ using namespace mzUtils;
 using namespace std;
 
 MassCalculator::IonizationType MassCalculator::ionizationType = MassCalculator::ESI;
+Adduct* MassCalculator::PlusHAdduct  = new Adduct("[M-H]+",  PROTON , 1, 1);
+Adduct* MassCalculator::MinusHAdduct = new Adduct("[M-H]-", -PROTON, -1, 1);
+Adduct* MassCalculator::ZeroMassAdduct = new Adduct("[M]",0 ,1, 1);
 ElementMass MassCalculator::elementMass;
 
 double MassCalculator::getElementMass(string elmnt) {

--- a/src/core/libmaven/mzMassCalculator.cpp
+++ b/src/core/libmaven/mzMassCalculator.cpp
@@ -6,8 +6,8 @@ using namespace mzUtils;
 using namespace std;
 
 MassCalculator::IonizationType MassCalculator::ionizationType = MassCalculator::ESI;
-Adduct* MassCalculator::PlusHAdduct  = new Adduct("[M-H]+",  PROTON , 1, 1);
-Adduct* MassCalculator::MinusHAdduct = new Adduct("[M-H]-", -PROTON, -1, 1);
+Adduct* MassCalculator::PlusHAdduct  = new Adduct("[M-H]+",  PROTON_MASS , 1, 1);
+Adduct* MassCalculator::MinusHAdduct = new Adduct("[M-H]-", -PROTON_MASS, -1, 1);
 Adduct* MassCalculator::ZeroMassAdduct = new Adduct("[M]",0 ,1, 1);
 ElementMass MassCalculator::elementMass;
 

--- a/src/core/libmaven/mzMassCalculator.h
+++ b/src/core/libmaven/mzMassCalculator.h
@@ -38,6 +38,11 @@ class MassCalculator {
     public:
         enum IonizationType { ESI=0, EI=1};
         static IonizationType ionizationType;
+
+        // TODO: We only need these declarations so as to be compatible with
+        // MAVEN's projectDB exports. Once our "Database" and "Databases"
+        // classes are merged we will be able to use all "findSpeciesBy_X" type
+        // of methods from there itself, and remove this.
         static Adduct* PlusHAdduct;
         static Adduct* MinusHAdduct;
         static Adduct* ZeroMassAdduct;

--- a/src/core/libmaven/mzMassCalculator.h
+++ b/src/core/libmaven/mzMassCalculator.h
@@ -11,6 +11,7 @@
 #include "mzSample.h"
 #include "mzUtils.h"
 
+class Adduct;
 class Compound;
 class Isotope;
 
@@ -37,6 +38,9 @@ class MassCalculator {
     public:
         enum IonizationType { ESI=0, EI=1};
         static IonizationType ionizationType;
+        static Adduct* PlusHAdduct;
+        static Adduct* MinusHAdduct;
+        static Adduct* ZeroMassAdduct;
 
         typedef struct {
             std::string name;

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -12,7 +12,7 @@ int mzSample::filter_mslevel = 0;
 mzSample::mzSample()
 	: _setName(""), injectionOrder(0)
 {
-	id = 0;
+    _id = -1;
 	maxMz = maxRt = 0;
 	minMz = minRt = 0;
 	isBlank = false;

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -465,6 +465,18 @@ class mzSample
     inline unsigned int scanCount() const { return (scans.size()); }
 
     /**
+     * @brief Obtain the unique sample ID for the sample.
+     * @return Sample ID as an integer.
+     */
+    inline int getSampleId() { return _id; }
+
+    /**
+     * @brief Set the sample ID for this sample.
+     * @param id An integer which is not an ID for another sample.
+     */
+    inline void setSampleId(const int id) { _id = id; }
+
+    /**
                           * [get Sample Name]
                           * @method getSampleName
                           * @return [name of the sample]
@@ -656,7 +668,6 @@ class mzSample
 
     vector<float> getIntensityDistribution(int mslevel);
 
-    unsigned int id;
     deque<Scan *> scans;
     string sampleName;
     string fileName;
@@ -701,6 +712,7 @@ class mzSample
     vector<double> polynomialAlignmentTransformation; //parameters for polynomial transform
 
   private:
+    int _id;
     void sampleNaming(const char *filename);
     void checkSampleBlank(const char *filename);
 
@@ -851,6 +863,14 @@ class Adduct
         charge = 1;
         nmol = 1;
     }
+
+    Adduct(string name, float mass, int charge, int nmol){
+        this->name=name;
+        this->mass=mass;
+        this->charge=charge;
+        this->nmol=nmol;
+    }
+
     string name;
     int nmol;
     float mass;
@@ -858,9 +878,16 @@ class Adduct
     bool isParent;
 
     //given adduct mass compute parent ion mass
-    inline float computeParentMass(float mz) { return (mz * abs(charge) - mass) / nmol; }
+    inline float computeParentMass(float mz)
+    {
+        return (mz * abs(charge) - mass) / nmol;
+    }
+
     //given perent compute adduct mass
-    inline float computeAdductMass(float pmz) { return (pmz * nmol + mass) / abs(charge); }
+    inline float computeAdductMass(float pmz)
+    {
+        return (pmz * nmol + mass) / abs(charge);
+    }
 };
 
 /**

--- a/src/core/libmaven/mzUtils.h
+++ b/src/core/libmaven/mzUtils.h
@@ -38,11 +38,6 @@
 #define ISINF(x) (!isnan(x) && (x >= FLT_MAX || x <= FLT_MIN))
 #define FLOATROUND(x, sd) (int(x * sd + 0.5) / sd)
 
-//TODO: Kiran-Sahil, Added while merging spectrahitstable
-#define EMASS  0.00054857971f  //(6.022141×10^23 ⋅ 9.10938×10^-28 )
-#define HMASS  1.007825032f
-#define PROTON HMASS - EMASS
-
 #if defined _WIN32 && !defined __CYGWIN__
 /* Use Windows separators on all _WIN32 defining
  *       environments, except Cygwin. */

--- a/src/core/libmaven/mzUtils.h
+++ b/src/core/libmaven/mzUtils.h
@@ -39,7 +39,9 @@
 #define FLOATROUND(x, sd) (int(x * sd + 0.5) / sd)
 
 //TODO: Kiran-Sahil, Added while merging spectrahitstable
-#define EMASS 		 0.00054857971 //(6.022141×10^23 ⋅ 9.10938×10^-28 )
+#define EMASS  0.00054857971f  //(6.022141×10^23 ⋅ 9.10938×10^-28 )
+#define HMASS  1.007825032f
+#define PROTON HMASS - EMASS
 
 #if defined _WIN32 && !defined __CYGWIN__
 /* Use Windows separators on all _WIN32 defining

--- a/src/gui/mzroll/adductwidget.cpp
+++ b/src/gui/mzroll/adductwidget.cpp
@@ -160,7 +160,7 @@ void AdductWidget::addLinks(float centerMz,int recursionLevel) {
     for(int i=0; i < DB.adductsDB.size(); i++ ) {
     	if ( SIGN(DB.adductsDB[i]->charge) != SIGN(ionizationMode) ) continue;
         float parentMass=DB.adductsDB[i]->computeParentMass(centerMz);
-		parentMass += ionizationMode*HMASS;   //adjusted mass
+        parentMass += ionizationMode * H_MASS;   //adjusted mass
 		cerr << DB.adductsDB[i]->name << " " << DB.adductsDB[i]->charge << " " << parentMass << endl;
         if( abs(parentMass-centerMz)>0.1 && scan->hasMz(parentMass,massCutoff)) {
 			QString noteText = tr("Possible Parent %1").arg(QString(DB.adductsDB[i]->name.c_str()));
@@ -182,7 +182,7 @@ void AdductWidget::addLinks(float centerMz,int recursionLevel) {
 	//adduct check
     for(int i=0; i < DB.adductsDB.size(); i++ ) {
     	if ( SIGN(DB.adductsDB[i]->charge) != SIGN(ionizationMode) ) continue;
-		float parentMass = centerMz-ionizationMode*HMASS;   //adjusted mass
+        float parentMass = centerMz-ionizationMode * H_MASS;   //adjusted mass
         float adductMass=DB.adductsDB[i]->computeAdductMass(parentMass);
 
         if( abs(adductMass-centerMz)>0.1 && scan->hasMz(adductMass,massCutoff)) {

--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -1,3 +1,4 @@
+#include "constants.h"
 #include "database.h"
 #include <QFile>
 
@@ -405,7 +406,7 @@ void Database::loadAdducts(string filename) {
 		a->nmol = nmol;
 		a->charge = charge;
 		a->isParent = false;
-		if (abs(abs(a->mass)-HMASS)< 0.01) a->isParent=true;
+        if (abs(abs(a->mass) - H_MASS)< 0.01) a->isParent=true;
 		adductsDB.push_back(a);
 	}
 	myfile.close();

--- a/src/gui/mzroll/database.h
+++ b/src/gui/mzroll/database.h
@@ -5,7 +5,7 @@
 #include "mzSample.h"
 #include "mzUtils.h"
 #include "stable.h"
-#define HMASS 1.007825032
+
 class Molecule2D {
        public:
 	Molecule2D() {}

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2342,12 +2342,14 @@ void MainWindow::closeEvent(QCloseEvent* event)
 
     QMessageBox msgBox(this);
     msgBox.setText("Please wait. Your project is being saved…");
+    msgBox.setStandardButtons(QMessageBox::NoButton);
     msgBox.open();
 
     writeSettings();
 
     // wait until autosave has finished
-    while(autosave->isRunning());
+    while(autosave->isRunning())
+        QApplication::processEvents();
 
     event->accept();
 }

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1507,7 +1507,7 @@ void MainWindow::open()
         this,
         "Select projects, peaks, samples to open:",
         dir,
-        tr("All Known Formats(*.mzroll *.mzrollDB *.mzPeaks *.mzXML *.mzxml "
+        tr("All Known Formats(*.mzroll *.emDB *.mzPeaks *.mzXML *.mzxml "
            "*.mzdata *.mzData *.mzData.xml *.cdf *.nc *.mzML);;")
             + tr("mzXML Format(*.mzXML *.mzxml);;")
             + tr("mzData Format(*.mzdata *.mzData *.mzData.xml);;")
@@ -1515,7 +1515,7 @@ void MainWindow::open()
             + tr("NetCDF Format(*.cdf *.nc);;")
             + tr("Thermo (*.raw);;")  // TODO: Sahil-Kiran, Added while merging
                                       // mainwindow
-            + tr("Maven Project File (*.mzroll *.mzrollDB);;")
+            + tr("Maven Project File (*.mzroll *.emDB);;")
             + tr("Maven Peaks File (*.mzPeaks);;")
             + tr("Peptide XML(*.pep.xml *.pepXML);;")
             + tr("Peptide idpDB(*.idpDB);;") + tr("All Files(*.*)"));
@@ -2245,7 +2245,7 @@ void MainWindow::createMenus() {
     QMenu* saveProjectFile = new QMenu(tr("Save Project As…"), this);
 
     // add option to save as a database
-    QAction* saveProjectAsSQLite = new QAction(tr("El-MAVEN Project (.mzrollDB)"),
+    QAction* saveProjectAsSQLite = new QAction(tr("El-MAVEN Database Format (.emDB)"),
                                                this);
     connect(saveProjectAsSQLite,
             SIGNAL(triggered()),

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -132,7 +132,7 @@ public:
 	vector<mzSample*> samples;		//list of loaded samples
 	static mzSample* loadSample(QString filename);
 	int peaksMarked = 0;
-	int noOfPeakTables = 0;
+    int lastPeakTableId = 0;
 	int totalCharge = 0;
 	bool allPeaksMarked = false;
 	bool aligned = false;
@@ -400,6 +400,7 @@ public Q_SLOTS:
 
 	//Added when merging with Maven776 - Kiran
     void removePeaksTable(TableDockWidget*);
+    void removeAllPeakTables();
 	BackgroundPeakUpdate* newWorkerThread(QString funcName);
 	QWidget* eicWidgetController();
 	QWidget* pathwayWidgetController();

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -411,6 +411,7 @@ public Q_SLOTS:
     void loadSettings();
     void showNotification(TableDockWidget* table);
     void explicitSave();
+    void threadSave(QString filename);
 
 private Q_SLOTS:
 	void createMenus();
@@ -444,7 +445,9 @@ private Q_SLOTS:
 		settings->beginWriteArray("crashTables");
 		settings->endArray();
 		settings->sync();
-	};
+    };
+
+    void _setStatusString(QString);
 
 private:
 	int m_value;

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -111,10 +111,11 @@ class AutoSave : public QThread
 
 public:
     AutoSave(MainWindow*);
-    void saveProjectWorker();
+    void saveProjectWorker(bool tablesOnly=false);
     MainWindow* _mainwindow;
 
 private:
+    bool saveTablesOnly;
     void run();
 };
 
@@ -284,8 +285,9 @@ public:
 	// bool isSampleFileType(QString filename);
 	// bool isProjectFileType(QString filename);
 	bool askAutosave();
-    void saveProject();
-	bool doAutosave;
+    void saveProject(bool explicitSave=false);
+    void saveProjectForFilename(bool tablesOnly=false);
+    bool doAutosave;
 	int askAutosaveMain;
 	void loadPollySettings(QString fileName);
 Q_SIGNALS:
@@ -407,7 +409,8 @@ public Q_SLOTS:
 	QWidget* pathwayWidgetController();
     void saveSettings();
     void loadSettings();
-	void showNotification(TableDockWidget* table);
+    void showNotification(TableDockWidget* table);
+    void explicitSave();
 
 private Q_SLOTS:
 	void createMenus();
@@ -464,7 +467,7 @@ private:
 	QString fileName;
     QString newFileName;
     void _setProjectFilenameIfEmpty();
-    void _saveProjectForFilename();
+    void _setProjectFilenameFromProjectDockWidget();
     void _saveMzRollList(QString projectFileName);
     void _saveAllTablesAsMzRoll();
     void checkCorruptedSampleInjectionOrder();

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -105,16 +105,15 @@ extern Database DB;
 //Added when merged with Maven776 - Kiran
 class RemoteSpectraHandler;
 
-class AutoSave: public QThread {
-Q_OBJECT
-
-// public Q_SLOTS:
-// 	void saveMzRollWorker();
+class AutoSave : public QThread
+{
+    Q_OBJECT
 
 public:
-	AutoSave(MainWindow*);
-	void saveMzRollWorker();
-	MainWindow* _mainwindow;
+    AutoSave(MainWindow*);
+    void saveProjectWorker();
+    MainWindow* _mainwindow;
+
 private:
     void run();
 };
@@ -143,7 +142,7 @@ public:
 	}
 
 	AutoSave* autosave;
-	QSet<QString> SaveMzrollListvar;
+    QSet<QString> pendingMzRollSaves;
 	MavenParameters* mavenParameters;
 	QSqlDatabase localDB;					//local database
 	QDoubleSpinBox *massCutoffWindowBox;
@@ -250,7 +249,9 @@ public:
 	void autoSaveSignal();
 	void normalizeIsotopicMatrix(MatrixXf &MM);
 
-	void savePeaksTable(TableDockWidget* peaksTable, QString fileName, QString tableName);
+    void savePeakTableAsMzRoll(TableDockWidget* peaksTable,
+                               QString fileName,
+                               QString tableName);
 
     mzSample* getSampleByName(QString sampleName); //TODO: Sahil, Added this while merging mzfile
 	void setIsotopicPlotStyling();
@@ -277,13 +278,13 @@ public:
 
 	void saveSettingsToLog();
 
-	bool updateSamplePathinMzroll(QStringList filelist);
+    bool updateSamplePathinMzroll(QStringList filelist);
 	void setValue(int value);
 	//TODO: Sahil - Kiran, removed while merging mainwindow
 	// bool isSampleFileType(QString filename);
 	// bool isProjectFileType(QString filename);
 	bool askAutosave();
-	void saveMzRoll();
+    void saveProject();
 	bool doAutosave;
 	int askAutosaveMain;
 	void loadPollySettings(QString fileName);
@@ -307,7 +308,7 @@ public Q_SLOTS:
 	void showAlignmetErrorDialog(QString errorMessage);
 	void setMassCutoffType(QString massCutoffType);
 	void printvalue();
-	void autosaveMzRoll();
+    void autosaveProject();
 	QDockWidget* createDockWidget(QString title, QWidget* w);
 	void showPeakInfo(Peak*);
 	void setProgressBar(QString, int step, int totalSteps);
@@ -419,7 +420,7 @@ private Q_SLOTS:
  		qDebug() << "Performing application reboot...";
 		QString rep = QDir::cleanPath(QCoreApplication::applicationFilePath());
    		QStringList arguments;
-		Q_FOREACH( QString newFileName, this->SaveMzrollListvar) {
+        Q_FOREACH( QString newFileName, this->pendingMzRollSaves) {
 			arguments << newFileName;
 		}
    		QProcess *myProcess = new QProcess();
@@ -461,9 +462,11 @@ private:
 
 	QToolButton* addDockWidgetButton(QToolBar*, QDockWidget*, QIcon, QString);
 	QString fileName;
-	QString newFileName;
-	void saveMzRollList(QString MzrollFileName);
-	void saveMzRollAllTables();
+    QString newFileName;
+    void _setProjectFilenameIfEmpty();
+    void _saveProjectForFilename();
+    void _saveMzRollList(QString projectFileName);
+    void _saveAllTablesAsMzRoll();
     void checkCorruptedSampleInjectionOrder();
     void warningForInjectionOrders(QMap<int, QList<mzSample*>>, QList<mzSample*>);
 

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -552,6 +552,7 @@ void mzFileIO::fileImport(void) {
             if(rxtable.exactMatch(filename)) {
                 Q_EMIT(createPeakTableSignal(filename));
             } else {
+                _mainwindow->projectDockWidget->setLastOpenedProject(filename);
                 auto groups = readGroupsXML(filename);
                 for (auto group : groups) {
                     _mainwindow->bookmarkedPeaks->addPeakGroup(group);

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -688,12 +688,21 @@ void mzFileIO::closeSQLiteProject()
     _currentProject = nullptr;
 }
 
-int mzFileIO::writeBookmarkedGroup(PeakGroup* group)
+void mzFileIO::writeGroups(QList<PeakGroup*> groups, QString tableName)
 {
-    if (_currentProject)
-        return _currentProject->saveGroupAndPeaks(group, 0, "Bookmarks");
-    else
-        return -1;
+    set<Compound*> compoundSet;
+    if (_currentProject) {
+        _currentProject->deleteTableGroups(tableName.toStdString());
+        for (auto group : groups) {
+            // assuming all groups are parent groups.
+            _currentProject->saveGroupAndPeaks(group,
+                                               0,
+                                               tableName.toStdString());
+            if (group->compound)
+                compoundSet.insert(group->compound);
+        }
+        _currentProject->saveCompounds(compoundSet);
+    }
 }
 
 bool mzFileIO::writeSQLiteProject(QString filename)

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -82,7 +82,7 @@ mzSample* mzFileIO::loadSample(const QString& filename){
         sample->sampleName = string( sampleName.toLatin1().data() );
         
         mtxSampleId.lock();
-        sample->id = ++sampleId;
+        sample->setSampleId(++sampleId);
         mtxSampleId.unlock();
 
         return sample;

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -19,6 +19,7 @@ mzFileIO::mzFileIO(QWidget*) {
             SIGNAL(sampleLoaded()),
             this,
             SLOT(_postSampleLoadOperations()));
+    _sqliteDBLoadInProgress = false;
 }
 
 void mzFileIO::setMainWindow(MainWindow* mw) {

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -705,17 +705,17 @@ void mzFileIO::closeSQLiteProject()
 
 void mzFileIO::writeGroups(QList<PeakGroup*> groups, QString tableName)
 {
+    vector<PeakGroup*> groupVector;
     set<Compound*> compoundSet;
     if (_currentProject) {
         _currentProject->deleteTableGroups(tableName.toStdString());
         for (auto group : groups) {
             // assuming all groups are parent groups.
-            _currentProject->saveGroupAndPeaks(group,
-                                               0,
-                                               tableName.toStdString());
+            groupVector.push_back(group);
             if (group->compound)
                 compoundSet.insert(group->compound);
         }
+        _currentProject->saveGroups(groupVector, tableName.toStdString());
         _currentProject->saveCompounds(compoundSet);
     }
 }
@@ -743,6 +743,7 @@ bool mzFileIO::writeSQLiteProject(QString filename)
         _currentProject->saveSamples(sampleSet);
         _currentProject->saveAlignment(sampleSet);
 
+        vector<PeakGroup*> groupVector;
         set<Compound*> compoundSet;
         int topLevelGroupCount = 0;
         auto allTablesList = _mainwindow->getPeakTableList();
@@ -751,12 +752,13 @@ bool mzFileIO::writeSQLiteProject(QString filename)
             for (PeakGroup* group : peakTable->getGroups()) {
                 topLevelGroupCount++;
                 string tableName = peakTable->windowTitle().toStdString();
-                _currentProject->saveGroupAndPeaks(group,
-                                                   0,
-                                                   tableName);
+                groupVector.push_back(group);
                 if (group->compound)
                     compoundSet.insert(group->compound);
             }
+            _currentProject->saveGroups(groupVector,
+                                        peakTable->windowTitle().toStdString());
+            groupVector.clear();
         }
         _currentProject->saveCompounds(compoundSet);
         return true;

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -668,7 +668,7 @@ bool mzFileIO::isMzRollProject(QString filename)
 
 bool mzFileIO::isSQLiteProject(QString filename)
 {
-    if (filename.endsWith("mzrollDB", Qt::CaseInsensitive))
+    if (filename.endsWith("emDB", Qt::CaseInsensitive))
         return true;
     return false;
 }

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -795,8 +795,6 @@ void mzFileIO::readAllPeakTablesSQLite(const vector<mzSample*> newSamples)
     if (!_currentProject)
         return;
 
-    Q_EMIT(updateProgressBar(tr("Loading peak tables and groups…"), 0, 1));
-
     // set of compound databases that need to be communicated with ligand widget
     set<QString> dbNames;
 

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -717,6 +717,10 @@ void mzFileIO::writeGroups(QList<PeakGroup*> groups, QString tableName)
         }
         _currentProject->saveGroups(groupVector, tableName.toStdString());
         _currentProject->saveCompounds(compoundSet);
+        Q_EMIT(updateStatusString(QString("Saved %1 groups from %2 to project")
+                                  .arg(QString::number(groups.size()))
+                                  .arg(tableName))
+        );
     }
 }
 
@@ -761,9 +765,13 @@ bool mzFileIO::writeSQLiteProject(QString filename)
             groupVector.clear();
         }
         _currentProject->saveCompounds(compoundSet);
+        qDebug() << "finished writing to project" << filename;
+        Q_EMIT(updateStatusString(
+            QString("Project successfully saved to %1").arg(filename)
+        ));
         return true;
     }
-    qDebug() << "Error: Cannot write to closed project" << filename;
+    qDebug() << "cannot write to closed project" << filename;
     return false;
 }
 

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -699,7 +699,7 @@ bool mzFileIO::writeSQLiteProject(QString filename)
 {
     if (filename.isEmpty())
         return false;
-    qDebug() << "Debug: saving SQLite project " << filename << endl;
+    qDebug() << "saving SQLite project " << filename << endl;
 
     std::vector<mzSample*> sampleSet = _mainwindow->getSamples();
     if (sampleSet.size() == 0)
@@ -707,9 +707,9 @@ bool mzFileIO::writeSQLiteProject(QString filename)
 
     if (_currentProject
             and _currentProject->projectName() == filename.toStdString()) {
-        qDebug() << "Debug: Saving in existing project…";
+        qDebug() << "saving in existing project…";
     } else {
-        qDebug() << "Debug: Creating new project to save…";
+        qDebug() << "creating new project to save…";
         _currentProject = new ProjectDatabase(filename.toStdString());
     }
 

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -6,8 +6,9 @@
 #include "mainwindow.h"
 #include "mzAligner.h"
 
-
+class ProjectDatabase;
 class ProjectDockWidget;
+
 /**
  * @class mzPoint
  * @ingroup mzroll
@@ -74,8 +75,18 @@ Q_OBJECT
         bool isSpectralHitType(QString filename);
         bool isPeakListType(QString filename);
 
+        bool isMzRollProject(QString filename);
+        bool isSQLiteProject(QString filename);
 
+        bool sqliteProjectIsOpen();
+        void closeSQLiteProject();
+        int writeBookmarkedGroup(PeakGroup* group);
+        bool writeSQLiteProject(QString filename);
+        bool readSQLiteProject(QString filename);
+        void readAllPeakTablesSQLite(const vector<mzSample*> newSamples);
 
+    private Q_SLOTS:
+        void _postSampleLoadOperations();
 
     public Q_SLOTS:
         void readThermoRawFileImport();
@@ -127,8 +138,7 @@ Q_OBJECT
          * @brief to make updating sampleId thread safe
          */
         mutex mtxSampleId;
-
-
+        ProjectDatabase* _currentProject;
 };
 
 #endif // MZFILEIO_H

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -103,13 +103,12 @@ Q_OBJECT
         void closeSQLiteProject();
 
         /**
-         * @brief Write a single bookmarked PeakGroup into the currently open
-         * SQLite project.
-         * @param group The PeakGroup to be written as a bookamrk.
-         * @return The unique integer ID assigned to `group` in the database,
-         * after being written. If the operation fails, -1 is returned.
+         * @brief Write a set of parent groups with the name of table they
+         * belong to.
+         * @param groups A list of PeakGroup pointers that need to be saved.
+         * @param tableName Name of peak table to which groups belong.
          */
-        int writeBookmarkedGroup(PeakGroup* group);
+        void writeGroups(QList<PeakGroup*> groups, QString tableName);
 
         /**
          * @brief Write current session data into a SQLite database.

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -246,6 +246,12 @@ Q_OBJECT
         ProjectDatabase* _currentProject;
 
         bool _sqliteDBLoadInProgress;
+
+        /**
+         * @brief A vector containing names of samples that were not found, and
+         * whose paths need to be explicitly specified by the user.
+         */
+        vector<string> _missingSamples;
 };
 
 #endif // MZFILEIO_H

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -123,12 +123,12 @@ Q_OBJECT
         bool writeSQLiteProject(QString filename);
 
         /**
-         * @brief Read session data from a SQLite database previously saved
+         * @brief Read samples data from a SQLite database previously saved
          * using `writeSQLiteProject` method.
          * @param filename String name of SQLite database to be read.
-         * @return true if the read operation was successful, false otherwise.
+         * @return A vector of sample paths found in the database.
          */
-        bool readSQLiteProject(QString filename);
+        vector<string> readSamplesFromSQLiteProject(QString filename);
 
         /**
          * @brief For a given set of samples, load the peak groups and their
@@ -199,6 +199,7 @@ Q_OBJECT
      * @param int     [progress value]
      * @param int     [total value]
      */
+     void updateStatusString(QString);
      void updateProgressBar(QString,int,int);
      void sampleLoaded();
      void spectraLoaded();
@@ -206,6 +207,7 @@ Q_OBJECT
      void peaklistLoaded();
      void createPeakTableSignal(QString);
      void addNewSample(mzSample*);
+     void peakTablesPopulated();
 
     protected:
       /**
@@ -242,6 +244,8 @@ Q_OBJECT
          * a SQLite project, which data can be written to or read from.
          */
         ProjectDatabase* _currentProject;
+
+        bool _sqliteDBLoadInProgress;
 };
 
 #endif // MZFILEIO_H

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -75,14 +75,68 @@ Q_OBJECT
         bool isSpectralHitType(QString filename);
         bool isPeakListType(QString filename);
 
+        /**
+         * @brief Check whether the filename ends with a ".mzroll" extension.
+         * @param filename String name of the file to be checked.
+         * @return true if the filename ends with ".mzroll" extension, false
+         * otherwise.
+         */
         bool isMzRollProject(QString filename);
+
+        /**
+         * @brief Check whether the filename ends with a ".emDB" extension.
+         * @param filename String name of the file to be checked.
+         * @return true if the filename ends with ".emDB" extension, false
+         * otherwise
+         */
         bool isSQLiteProject(QString filename);
 
+        /**
+         * @brief Check if a SQLite project is currently open.
+         * @return true if a SQLite project is open, false otherwise.
+         */
         bool sqliteProjectIsOpen();
+
+        /**
+         * @brief Close the currently open SQLite project, if any.
+         */
         void closeSQLiteProject();
+
+        /**
+         * @brief Write a single bookmarked PeakGroup into the currently open
+         * SQLite project.
+         * @param group The PeakGroup to be written as a bookamrk.
+         * @return The unique integer ID assigned to `group` in the database,
+         * after being written. If the operation fails, -1 is returned.
+         */
         int writeBookmarkedGroup(PeakGroup* group);
+
+        /**
+         * @brief Write current session data into a SQLite database.
+         * @details The data saved include samples' metadata, peak groups,
+         * peaks, associated compounds and alignment data. Write operation
+         * happens into a newly created (or wiped, if already exists) SQLite
+         * database. This database also becomes the currently open project.
+         * @param filename String representing absolute path of the file to be
+         * treated as a SQLite database.
+         * @return true if the write operation was successful, false otherwise.
+         */
         bool writeSQLiteProject(QString filename);
+
+        /**
+         * @brief Read session data from a SQLite database previously saved
+         * using `writeSQLiteProject` method.
+         * @param filename String name of SQLite database to be read.
+         * @return true if the read operation was successful, false otherwise.
+         */
         bool readSQLiteProject(QString filename);
+
+        /**
+         * @brief For a given set of samples, load the peak groups and their
+         * peaks from the currently open SQLite database project.
+         * @param newSamples A vector of pointers to mzSample objects to which
+         * loaded peaks will be associated (according to their sample ID).
+         */
         void readAllPeakTablesSQLite(const vector<mzSample*> newSamples);
 
         /**
@@ -183,6 +237,11 @@ Q_OBJECT
          * @brief to make updating sampleId thread safe
          */
         mutex mtxSampleId;
+
+        /**
+         * @brief An instance of the ProjectData class acting as a proxy for
+         * a SQLite project, which data can be written to or read from.
+         */
         ProjectDatabase* _currentProject;
 };
 

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -85,7 +85,52 @@ Q_OBJECT
         bool readSQLiteProject(QString filename);
         void readAllPeakTablesSQLite(const vector<mzSample*> newSamples);
 
-    private Q_SLOTS:
+        /**
+         * @brief For making old mzroll compatible, this will act as a flag
+         * whether loaded mzroll file is old or new one. this will be set by
+         * class method <markv_0_1_5mzroll>
+         */
+        bool mzrollv_0_1_5;
+
+        /**
+         * @brief Mark varible <mzrollv_0_1_5> true or false
+         * @details This method marks varible <mzrollv_0_1_5> true if loaded
+         * mzroll file is of v0.1.5 or older otherwise false based on one
+         * attribute <SamplesUsed> which is introduced here.
+         */
+        void markv_0_1_5mzroll(QString fileName);
+
+        /**
+         * @brief Modify name appropriate for xml attribute naming
+         * @details This method makes sample name appropriate for using in
+         * attribute naming in mzroll file It is just replacing '#' with '_' and
+         * adding 's' for letting sample name start with english letter In
+         * future, if sample name has some other special character, we have to
+         * replace those also with appropriate character Error can be seen at
+         * compilation time
+         */
+        void cleanString(QString& name);
+
+        void writeGroupXML(QXmlStreamWriter& stream, PeakGroup* group);
+        void writeGroupsXML(QXmlStreamWriter& stream,
+                            vector<PeakGroup>& groups);
+
+        /**
+         * @brief It will add samples used to group being generated while
+         * creating from mzroll file
+         * @details This method will add all sample to group being
+         * created from mzroll file. It will read SamplesUsed attribute of a
+         * group and if it's value is "Used", then assign this mzSample to that
+         * group
+         */
+        void readSamplesXML(QXmlStreamReader& xml,
+                            PeakGroup* group,
+                            float mzrollVersion);
+        PeakGroup* readGroupXML(QXmlStreamReader& xml, PeakGroup* parent);
+        void readPeakXML(QXmlStreamReader& xml, PeakGroup* parent);
+        vector<PeakGroup*> readGroupsXML(QString infile);
+
+        private Q_SLOTS:
         void _postSampleLoadOperations();
 
     public Q_SLOTS:

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -103,6 +103,10 @@ macx {
   LIBS -= -lcdfread
 }
 
+QMAKE_LFLAGS += -L/usr/lib/x86_64-linux-gnu/
+
+LIBS += -lboost_system -lboost_filesystem -lsqlite3
+
 message($$LDFLAGS)
 
 INSTALLS += sources target

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -103,9 +103,14 @@ macx {
   LIBS -= -lcdfread
 }
 
-QMAKE_LFLAGS += -L/usr/lib/x86_64-linux-gnu/
+unix {
+    QMAKE_LFLAGS += -L/usr/lib/x86_64-linux-gnu/
+    LIBS += -lboost_system -lboost_filesystem -lsqlite3
+}
 
-LIBS += -lboost_system -lboost_filesystem -lsqlite3
+win32 {
+    LIBS += -lboost_system-mt -lboost_filesystem-mt -lsqlite3
+}
 
 message($$LDFLAGS)
 

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -71,7 +71,8 @@ INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  \
                 $$top_srcdir/3rdparty/libdate/ \
                 $$top_srcdir/3rdparty/ErrorHandling \
                 $$top_srcdir/3rdparty/Logger \
-                $$top_srcdir/src/pollyCLI
+                $$top_srcdir/src/pollyCLI \
+                $$top_srcdir/src/projectDB
 
 QMAKE_LFLAGS += -L$$top_builddir/libs/
 
@@ -82,7 +83,19 @@ win32 {
 }
 
 
-LIBS +=  -lmaven -lobiwarp -lpugixml -lneural -lcsvparser -lpls -lErrorHandling -lLogger -lcdfread -lnetcdf -lz -lpollyCLI               #64bit
+LIBS +=  -lmaven \
+         -lobiwarp \
+         -lpugixml \
+         -lneural \
+         -lcsvparser \
+         -lpls \
+         -lErrorHandling \
+         -lLogger \
+         -lcdfread \
+         -lnetcdf \
+         -lz \
+         -lpollyCLI \
+         -lprojectDB
 
 macx {
 

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -447,11 +447,11 @@ void PeakDetectionDialog::findPeaks() {
 
     QString title;
     if (_featureDetectionType == FullSpectrum)
-        title = "Peak Table " + QString::number(mainwindow->noOfPeakTables) + "\nDetected Features \n";
+        title = "Peak Table " + QString::number(mainwindow->lastPeakTableId) + "\nDetected Features \n";
     else if (_featureDetectionType == CompoundDB)
-        title = "Peak Table " + QString::number(mainwindow->noOfPeakTables) + "\nDB Search " + compoundDatabase->currentText();
+        title = "Peak Table " + QString::number(mainwindow->lastPeakTableId) + "\nDB Search " + compoundDatabase->currentText();
     else if (_featureDetectionType == QQQ)
-        title = "Peak Table " + QString::number(mainwindow->noOfPeakTables) + "\nQQQ DB Search " + compoundDatabase->currentText();
+        title = "Peak Table " + QString::number(mainwindow->lastPeakTableId) + "\nQQQ DB Search " + compoundDatabase->currentText();
 
     TableDockWidget* peaksTable = mainwindow->getBookmarkedPeaks();
     int peakTableIdx = outputTableComboBox->currentIndex();

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -705,7 +705,7 @@ void ProjectDockWidget::loadProject(QString fileName) {
                         _mainwindow->addSample(sample);
                         currentSample=sample;
                         if (!sname.isEmpty() ) sample->sampleName = sname.toStdString();
-                        if (id > 0) sample->id = id;
+                        if (id > 0) sample->setSampleId(id);
                         if (!setname.isEmpty() ) sample->setSetName(setname.toStdString());
                         if (!sampleOrder.isEmpty()) sample->setSampleOrder(sampleOrder.toInt());
                         if (!isSelected.isEmpty()) sample->isSelected = isSelected.toInt();
@@ -770,7 +770,7 @@ void ProjectDockWidget::saveProject(QString filename, TableDockWidget* peakTable
 
         stream.writeStartElement("sample");
         stream.writeAttribute("name",  sample->sampleName.c_str() );
-        stream.writeAttribute("id", QString::number(sample->id));
+        stream.writeAttribute("id", QString::number(sample->getSampleId()));
         stream.writeAttribute("filename",  sample->fileName.c_str() );
         stream.writeAttribute("sampleOrder", QString::number(sample->getSampleOrder()));
         stream.writeAttribute("setName", sample->getSetName().c_str());

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -635,7 +635,7 @@ void ProjectDockWidget::saveProjectAsSQLite()
             dir = ldir;
     }
     QString fileName = QFileDialog::getSaveFileName(
-        _mainwindow->projectDockWidget,
+        _mainwindow,
         "Save project as (.emDB)",
         dir,
         "emDB Project(*.emDB)"
@@ -668,11 +668,17 @@ void ProjectDockWidget::saveSQLiteProject()
     }
 }
 
-int ProjectDockWidget::saveBookmarkedGroup(PeakGroup* group)
+void ProjectDockWidget::savePeakTableInSQLite(TableDockWidget* table,
+                                              QString filename)
 {
-    if (!_mainwindow->fileLoader->sqliteProjectIsOpen())
-        saveSQLiteProject();
-    return _mainwindow->fileLoader->writeBookmarkedGroup(group);
+    if (!_mainwindow->fileLoader->sqliteProjectIsOpen()
+            && !filename.isEmpty()) {
+        saveSQLiteProject(filename);
+    } else {
+        auto groupList = table->getGroups();
+        auto tableName = table->windowTitle();
+        _mainwindow->fileLoader->writeGroups(groupList, tableName);
+    }
 }
 
 void ProjectDockWidget::loadSQLiteProject(QString filename)

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -601,13 +601,13 @@ void ProjectDockWidget::saveProjectAsSQLite()
     }
     QString fileName = QFileDialog::getSaveFileName(
         _mainwindow->projectDockWidget,
-        "Save project as (.mzrollDB)",
+        "Save project as (.emDB)",
         dir,
-        "mzrollDB Project(*.mzrollDB)"
+        "emDB Project(*.emDB)"
     );
 
-    if (!fileName.endsWith(".mzrollDB", Qt::CaseInsensitive))
-        fileName = fileName + ".mzrollDB";
+    if (!fileName.endsWith(".emDB", Qt::CaseInsensitive))
+        fileName = fileName + ".emDB";
 
     auto success = _mainwindow->fileLoader->writeSQLiteProject(fileName);
     if (success)

--- a/src/gui/mzroll/projectdockwidget.h
+++ b/src/gui/mzroll/projectdockwidget.h
@@ -67,12 +67,6 @@ public Q_SLOTS:
     void savePeakTableInSQLite(TableDockWidget* table, QString filename);
 
     /**
-     * @brief Load session data saved within an emDB SQLite project.
-     * @param filename String name of the emDB file to be loaded.
-     */
-    void loadSQLiteProject(QString filename);
-
-    /**
      * @brief Save any pending changes and close the currently open SQLite
      * (emDB) project.
      */

--- a/src/gui/mzroll/projectdockwidget.h
+++ b/src/gui/mzroll/projectdockwidget.h
@@ -15,7 +15,7 @@ class ProjectDockWidget : public QDockWidget
 public:
     explicit ProjectDockWidget(QMainWindow *parent = 0);
     boost::signals2::signal< void (const string&,unsigned int , int ) > boostSignal;
-    QString lastOpennedProject;
+    QString lastOpenedProject;
     QString lastSavedProject;
     QColor  lastUsedSampleColor;
     QMap<mzSample*, QColor> storeSampleColors;
@@ -31,10 +31,16 @@ public Q_SLOTS:
     void setInfo(vector<mzSample*>&samples);
     void changeSampleOrder();
     void updateSampleList();
-    void loadProject();
-    void saveProject();
-    void loadProject(QString filename);
-    void saveProject(QString filename, TableDockWidget* peakTable = 0);
+    void saveProjectAsSQLite();
+    void saveSQLiteProject();
+    int saveBookmarkedGroup(PeakGroup* group);
+    void loadSQLiteProject(QString filename);
+    void saveAndCloseCurrentSQLiteProject();
+    void clearSession();
+    void saveProjectAsMzRoll();
+    void saveMzRollProject();
+    void loadMzRollProject(QString filename);
+    void saveMzRollProject(QString filename, TableDockWidget* peakTable=nullptr);
     void setSampleColor(mzSample* sample, QColor color); //TODO: Sahil, Added while merging projectdockwidget
     void unloadSelectedSamples(); //TODO: Sahil, Added while merging projectdockwidget
     void sendBoostSignal( const string& progressText, unsigned int completed_samples, int total_samples)

--- a/src/gui/mzroll/projectdockwidget.h
+++ b/src/gui/mzroll/projectdockwidget.h
@@ -31,12 +31,49 @@ public Q_SLOTS:
     void setInfo(vector<mzSample*>&samples);
     void changeSampleOrder();
     void updateSampleList();
+
+    /**
+     * @brief Bring up a file dialog and allow the user to save current session
+     * as an emDB project.
+     */
     void saveProjectAsSQLite();
+
+    /**
+     * @brief Update saved data in the currently open emDB project.
+     */
     void saveSQLiteProject();
+
+    /**
+     * @brief Save a bookmarked PeakGroup in currently open emDB project.
+     * @param group The bookmarked PeakGroup to be saved.
+     * @return Unique integer ID of the saved bookmark if successful, -1
+     * otherwise.
+     */
     int saveBookmarkedGroup(PeakGroup* group);
+
+    /**
+     * @brief Load session data saved within an emDB SQLite project.
+     * @param filename String name of the emDB file to be loaded.
+     */
     void loadSQLiteProject(QString filename);
+
+    /**
+     * @brief Save any pending changes and close the currently open SQLite
+     * (emDB) project.
+     */
     void saveAndCloseCurrentSQLiteProject();
+
+    /**
+     * @brief Clear out structures before loading a new SQLite (emDB) project.
+     * @details This method tries to unload any loaded samples and deletes
+     * peak tables in the current session. Although it should be noted that
+     * this has historically not resulted in truly fresh session experience for
+     * users. Still something like this should ideally be available to
+     * developers for house cleaning before loading new projects into existing
+     * sessions.
+     */
     void clearSession();
+
     void saveProjectAsMzRoll();
     void saveMzRollProject();
     void loadMzRollProject(QString filename);

--- a/src/gui/mzroll/projectdockwidget.h
+++ b/src/gui/mzroll/projectdockwidget.h
@@ -57,12 +57,14 @@ public Q_SLOTS:
     void saveSQLiteProject();
 
     /**
-     * @brief Save a bookmarked PeakGroup in currently open emDB project.
-     * @param group The bookmarked PeakGroup to be saved.
-     * @return Unique integer ID of the saved bookmark if successful, -1
-     * otherwise.
+     * @brief Save all groups from a particular peak table into the current
+     * emDB project, otherwise creates new project from given filename.
+     * @param table Pointer to a TableDockWidget instance from which groups will
+     * be saved.
+     * @param filename A string path for filename of the SQLite project to be
+     * created (only if it does not exist already).
      */
-    int saveBookmarkedGroup(PeakGroup* group);
+    void savePeakTableInSQLite(TableDockWidget* table, QString filename);
 
     /**
      * @brief Load session data saved within an emDB SQLite project.

--- a/src/gui/mzroll/projectdockwidget.h
+++ b/src/gui/mzroll/projectdockwidget.h
@@ -15,12 +15,16 @@ class ProjectDockWidget : public QDockWidget
 public:
     explicit ProjectDockWidget(QMainWindow *parent = 0);
     boost::signals2::signal< void (const string&,unsigned int , int ) > boostSignal;
-    QString lastOpenedProject;
-    QString lastSavedProject;
     QColor  lastUsedSampleColor;
     QMap<mzSample*, QColor> storeSampleColors;
     QTreeWidget* getTreeWidget();
     void prepareSampleCohortFile(QString sampleCohortFileName);
+    QString getLastOpenedProject();
+    std::chrono::time_point<std::chrono::system_clock> getLastOpenedTime();
+    void setLastOpenedProject(QString filename);
+    QString getLastSavedProject();
+    std::chrono::time_point<std::chrono::system_clock> getLastSavedTime();
+    void setLastSavedProject(QString filename);
 
 Q_SIGNALS:
 
@@ -39,7 +43,16 @@ public Q_SLOTS:
     void saveProjectAsSQLite();
 
     /**
-     * @brief Update saved data in the currently open emDB project.
+     * @brief Write project data into given file as a SQLite database.
+     * @details If the file is already a project DB, all project tables are
+     * deleted and created anew.
+     * @param filename Name of the file to be saved as SQLite project on disk.
+     */
+    void saveSQLiteProject(QString filename);
+
+    /**
+     * @brief Update saved data in the currently open emDB project. If no
+     * project is currently open, prompts the user to create a new one.
      */
     void saveSQLiteProject();
 
@@ -76,8 +89,9 @@ public Q_SLOTS:
 
     void saveProjectAsMzRoll();
     void saveMzRollProject();
+    void saveMzRollProject(QString filename);
+    void saveMzRollTable(QString filename, TableDockWidget* peakTable=nullptr);
     void loadMzRollProject(QString filename);
-    void saveMzRollProject(QString filename, TableDockWidget* peakTable=nullptr);
     void setSampleColor(mzSample* sample, QColor color); //TODO: Sahil, Added while merging projectdockwidget
     void unloadSelectedSamples(); //TODO: Sahil, Added while merging projectdockwidget
     void sendBoostSignal( const string& progressText, unsigned int completed_samples, int total_samples)
@@ -114,12 +128,13 @@ private:
     MainWindow* _mainwindow;
     QTreeWidget* _treeWidget;
 
-
     QMap<QString, QColor> storeColor;
     QColor  usedColor;
 
-
-
+    QString _lastOpenedProject;
+    QString _lastSavedProject;
+    std::chrono::time_point<std::chrono::system_clock> _lastSave;
+    std::chrono::time_point<std::chrono::system_clock> _lastLoad;
 };
 
 #endif // PROJECTDOCKWIDGET_H

--- a/src/gui/mzroll/spectralhitstable.cpp
+++ b/src/gui/mzroll/spectralhitstable.cpp
@@ -496,7 +496,11 @@ void SpectralHitsDockWidget::loadPepXML(QString fileName) {
                     if(precursorMz and hit_rank < 2 and !decoy) {
                         SpectralHit* hit = new SpectralHit();
                         hit->scannum = scannum;
-                        hit->precursorMz = precursorMz; if (charge) hit->precursorMz = (precursorMz+charge*PROTON)/charge;
+                        hit->precursorMz = precursorMz;
+                        if (charge)
+                            hit->precursorMz = (precursorMz
+                                                + charge
+                                                * PROTON) / charge;
                         hit->charge = charge;
                         hit->decoy = decoy;
                         hit->rank = hit_rank;

--- a/src/gui/mzroll/spectralhitstable.cpp
+++ b/src/gui/mzroll/spectralhitstable.cpp
@@ -471,7 +471,6 @@ void SpectralHitsDockWidget::loadPepXML(QString fileName) {
 
     SpectralHit* lasthit=NULL;
     map<int,float> mods;
-    double PROTON = HMASS-EMASS;
     while (!xml.atEnd()) {
         xml.readNext();
         if (xml.isStartElement()) {

--- a/src/gui/mzroll/spectralhitstable.cpp
+++ b/src/gui/mzroll/spectralhitstable.cpp
@@ -500,7 +500,7 @@ void SpectralHitsDockWidget::loadPepXML(QString fileName) {
                         if (charge)
                             hit->precursorMz = (precursorMz
                                                 + charge
-                                                * PROTON) / charge;
+                                                * PROTON_MASS) / charge;
                         hit->charge = charge;
                         hit->decoy = decoy;
                         hit->rank = hit_rank;

--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -1180,7 +1180,7 @@ vector<mzLink> SpectraWidget::findLinks(float centerMz, Scan* scan, MassCutoff *
     for(int i=0; i < DB.adductsDB.size(); i++ ) {
     	if ( SIGN(DB.adductsDB[i]->charge) != SIGN(ionizationMode) ) continue;
         float parentMass=DB.adductsDB[i]->computeParentMass(centerMz);
-        parentMass += ionizationMode*HMASS;   //adjusted mass
+        parentMass += ionizationMode * H_MASS;   //adjusted mass
 
         if( abs(parentMass-centerMz)>0.1 && scan->hasMz(parentMass,massCutoff)) {
             cerr << DB.adductsDB[i]->name << " " << DB.adductsDB[i]->charge << " " << parentMass << endl;
@@ -1192,7 +1192,7 @@ vector<mzLink> SpectraWidget::findLinks(float centerMz, Scan* scan, MassCutoff *
     //adduct check
     for(int i=0; i < DB.adductsDB.size(); i++ ) {
     	if ( SIGN(DB.adductsDB[i]->charge) != SIGN(ionizationMode) ) continue;
-        float parentMass = centerMz-ionizationMode*HMASS;   //adjusted mass
+        float parentMass = centerMz-ionizationMode * H_MASS;   //adjusted mass
         float adductMass=DB.adductsDB[i]->computeAdductMass(parentMass);
         if( abs(adductMass-centerMz)>0.1 && scan->hasMz(adductMass,massCutoff)) {
             QString noteText = tr("Adduct %1").arg(QString(DB.adductsDB[i]->name.c_str()));

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -280,8 +280,9 @@ void TableDockWidget::addRow(PeakGroup *group, QTreeWidgetItem *root) {
     return;
   if (group->peakCount() == 0)
     return;
-  if (group->meanMz <= 0)
+  if (group->meanMz <= 0) {
     return;
+  }
 
   NumericTreeWidgetItem *item = new NumericTreeWidgetItem(root, 0);
   item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled |
@@ -1443,132 +1444,6 @@ void TableDockWidget::writeMascotGeneric(QString filename) {
   file.close();
 }
 
-void TableDockWidget::cleanString(QString &name) {
-  name.replace('#', '_');
-  name = 's' + name;
-}
-void TableDockWidget::writeGroupXML(QXmlStreamWriter &stream, PeakGroup *g) {
-  if (!g)
-    return;
-
-  stream.writeStartElement("PeakGroup");
-  stream.writeAttribute("groupId", QString::number(g->groupId));
-  stream.writeAttribute("tagString", QString(g->tagString.c_str()));
-  stream.writeAttribute("metaGroupId", QString::number(g->metaGroupId));
-  stream.writeAttribute("clusterId", QString::number(g->clusterId));
-  stream.writeAttribute("expectedRtDiff",
-                        QString::number(g->expectedRtDiff, 'f', 6));
-  stream.writeAttribute("groupRank", QString::number(g->groupRank, 'f', 6));
-  stream.writeAttribute("expectedMz", QString::number(g->expectedMz, 'f', 6));
-  stream.writeAttribute("label", QString::number(g->label));
-  stream.writeAttribute("type", QString::number((int)g->type()));
-  stream.writeAttribute("changeFoldRatio",
-                        QString::number(g->changeFoldRatio, 'f', 6));
-  stream.writeAttribute("changePValue",
-                        QString::number(g->changePValue, 'e', 6));
-  if (g->srmId.length())
-    stream.writeAttribute("srmId", QString(g->srmId.c_str()));
-
-  // for sample contrasts  ratio and pvalue
-  if (g->hasCompoundLink()) {
-    Compound *c = g->compound;
-    stream.writeAttribute("compoundId", QString(c->id.c_str()));
-    stream.writeAttribute("compoundDB", QString(c->db.c_str()));
-    stream.writeAttribute("compoundName", QString(c->name.c_str()));
-    stream.writeAttribute("formula", QString(c->id.c_str()));
-  }
-
-  stream.writeStartElement("SamplesUsed");
-  for (int i = 0; i < g->samples.size(); ++i) {
-    stream.writeStartElement("sample");
-    stream.writeAttribute("id", QString::number(g->samples[i]->getSampleId()));
-    stream.writeEndElement();
-  }
-  stream.writeEndElement();
-
-  for (int j = 0; j < g->peaks.size(); j++) {
-    Peak &p = g->peaks[j];
-    stream.writeStartElement("Peak");
-    stream.writeAttribute("pos", QString::number(p.pos, 'f', 6));
-    stream.writeAttribute("minpos", QString::number(p.minpos, 'f', 6));
-    stream.writeAttribute("maxpos", QString::number(p.maxpos, 'f', 6));
-    stream.writeAttribute("splineminpos",
-                          QString::number(p.splineminpos, 'f', 6));
-    stream.writeAttribute("splinemaxpos",
-                          QString::number(p.splinemaxpos, 'f', 6));
-    stream.writeAttribute("rt", QString::number(p.rt, 'f', 6));
-    stream.writeAttribute("rtmin", QString::number(p.rtmin, 'f', 6));
-    stream.writeAttribute("rtmax", QString::number(p.rtmax, 'f', 6));
-    stream.writeAttribute("mzmin", QString::number(p.mzmin, 'f', 6));
-    stream.writeAttribute("mzmax", QString::number(p.mzmax, 'f', 6));
-    stream.writeAttribute("scan", QString::number(p.scan));
-    stream.writeAttribute("minscan", QString::number(p.minscan));
-    stream.writeAttribute("maxscan", QString::number(p.maxscan));
-    stream.writeAttribute("peakArea", QString::number(p.peakArea, 'f', 6));
-    stream.writeAttribute("peakSplineArea",
-                          QString::number(p.peakSplineArea, 'f', 6));
-    stream.writeAttribute("peakAreaCorrected",
-                          QString::number(p.peakAreaCorrected, 'f', 6));
-    stream.writeAttribute("peakAreaTop",
-                          QString::number(p.peakAreaTop, 'f', 6));
-    stream.writeAttribute("peakAreaTopCorrected",
-                          QString::number(p.peakAreaTopCorrected, 'f', 6));
-    stream.writeAttribute("peakAreaFractional",
-                          QString::number(p.peakAreaFractional, 'f', 6));
-    stream.writeAttribute("peakRank", QString::number(p.peakRank, 'f', 6));
-    stream.writeAttribute("peakIntensity",
-                          QString::number(p.peakIntensity, 'f', 6));
-
-    stream.writeAttribute("peakBaseLineLevel",
-                          QString::number(p.peakBaseLineLevel, 'f', 6));
-    stream.writeAttribute("peakMz", QString::number(p.peakMz, 'f', 6));
-    stream.writeAttribute("medianMz", QString::number(p.medianMz, 'f', 6));
-    stream.writeAttribute("baseMz", QString::number(p.baseMz, 'f', 6));
-    stream.writeAttribute("quality", QString::number(p.quality, 'f', 6));
-    stream.writeAttribute("width", QString::number(p.width, 'f', 6));
-    stream.writeAttribute("gaussFitSigma",
-                          QString::number(p.gaussFitSigma, 'f', 6));
-    stream.writeAttribute("gaussFitR2", QString::number(p.gaussFitR2, 'f', 6));
-    stream.writeAttribute("groupNum", QString::number(p.groupNum));
-    stream.writeAttribute("noNoiseObs", QString::number(p.noNoiseObs));
-    stream.writeAttribute("noNoiseFraction",
-                          QString::number(p.noNoiseFraction, 'f', 6));
-    stream.writeAttribute("symmetry", QString::number(p.symmetry, 'f', 6));
-    stream.writeAttribute("signalBaselineRatio",
-                          QString::number(p.signalBaselineRatio, 'f', 6));
-    stream.writeAttribute("groupOverlap",
-                          QString::number(p.groupOverlap, 'f', 6));
-    stream.writeAttribute("groupOverlapFrac",
-                          QString::number(p.groupOverlapFrac, 'f', 6));
-    stream.writeAttribute("localMaxFlag", QString::number(p.localMaxFlag));
-    stream.writeAttribute("fromBlankSample",
-                          QString::number(p.fromBlankSample));
-    stream.writeAttribute("label", QString::number(p.label));
-    stream.writeAttribute("sample", QString(p.getSample()->sampleName.c_str()));
-    stream.writeEndElement();
-  }
-
-  if (g->childCount()) {
-    stream.writeStartElement("children");
-    for (int i = 0; i < g->children.size(); i++) {
-      PeakGroup *child = &(g->children[i]);
-      writeGroupXML(stream, child);
-    }
-    stream.writeEndElement();
-  }
-  stream.writeEndElement();
-}
-
-void TableDockWidget::writePeakTableXML(QXmlStreamWriter &stream) {
-
-  if (allgroups.size()) {
-    stream.writeStartElement("PeakGroups");
-    for (int i = 0; i < allgroups.size(); i++)
-      writeGroupXML(stream, &allgroups[i]);
-    stream.writeEndElement();
-  }
-}
-
 void TableDockWidget::align() {
   if (allgroups.size() > 0) {
     vector<PeakGroup *> groups;
@@ -1582,336 +1457,6 @@ void TableDockWidget::align() {
     aligner.doAlignment(groups);
     _mainwindow->getEicWidget()->replotForced();
     showSelectedGroup();
-  }
-}
-
-PeakGroup *TableDockWidget::readGroupXML(QXmlStreamReader &xml,
-                                         PeakGroup *parent) {
-  PeakGroup g;
-  PeakGroup *gp = NULL;
-
-  g.groupId = xml.attributes().value("groupId").toString().toInt();
-  g.tagString = xml.attributes().value("tagString").toString().toStdString();
-  g.metaGroupId = xml.attributes().value("metaGroupId").toString().toInt();
-  g.clusterId = xml.attributes().value("clusterId").toString().toInt();
-  g.expectedRtDiff =
-      xml.attributes().value("expectedRtDiff").toString().toFloat();
-  g.groupRank = xml.attributes().value("grouRank").toString().toFloat();
-  g.expectedMz = xml.attributes().value("expectedMz").toString().toFloat();
-  g.label = xml.attributes().value("label").toString().toInt();
-  g.setType(
-      (PeakGroup::GroupType)xml.attributes().value("type").toString().toInt());
-  g.changeFoldRatio =
-      xml.attributes().value("changeFoldRatio").toString().toFloat();
-  g.changePValue = xml.attributes().value("changePValue").toString().toFloat();
-
-  string compoundId =
-      xml.attributes().value("compoundId").toString().toStdString();
-  string compoundDB =
-      xml.attributes().value("compoundDB").toString().toStdString();
-  string compoundName =
-      xml.attributes().value("compoundName").toString().toStdString();
-
-  string srmId = xml.attributes().value("srmId").toString().toStdString();
-  if (!srmId.empty())
-    g.setSrmId(srmId);
-
-  if (!compoundName.empty() && !compoundDB.empty()) {
-    vector<Compound *> matches = DB.findSpeciesByName(compoundName, compoundDB);
-    if (matches.size() > 0)
-      g.compound = matches[0];
-  } else if (!compoundId.empty()) {
-    Compound *c = DB.findSpeciesById(compoundId, DB.ANYDATABASE);
-    if (c)
-      g.compound = c;
-  }
-
-  if (!g.compound) {
-    if (!compoundId.empty())
-      g.tagString = compoundId;
-    else if (!compoundName.empty())
-      g.tagString = compoundName;
-  }
-
-  if (parent) {
-    parent->addChild(g);
-    if (parent->children.size() > 0) {
-      gp = &(parent->children[parent->children.size() - 1]);
-    }
-  } else {
-    gp = addPeakGroup(&g);
-  }
-
-  return gp;
-}
-
-void TableDockWidget::readPeakXML(QXmlStreamReader &xml, PeakGroup *parent) {
-
-  Peak p;
-  p.pos = xml.attributes().value("pos").toString().toInt();
-  p.minpos = xml.attributes().value("minpos").toString().toInt();
-  p.maxpos = xml.attributes().value("maxpos").toString().toInt();
-  p.splineminpos = xml.attributes().value("splineminpos").toString().toInt();
-  p.splinemaxpos = xml.attributes().value("splinemaxpos").toString().toInt();
-  p.rt = xml.attributes().value("rt").toString().toDouble();
-  p.rtmin = xml.attributes().value("rtmin").toString().toDouble();
-  p.rtmax = xml.attributes().value("rtmax").toString().toDouble();
-  p.mzmin = xml.attributes().value("mzmin").toString().toDouble();
-  p.mzmax = xml.attributes().value("mzmax").toString().toDouble();
-  p.scan = xml.attributes().value("scan").toString().toInt();
-  p.minscan = xml.attributes().value("minscan").toString().toInt();
-  p.maxscan = xml.attributes().value("maxscan").toString().toInt();
-  p.peakArea = xml.attributes().value("peakArea").toString().toDouble();
-  p.peakSplineArea =
-      xml.attributes().value("peakSplineArea").toString().toDouble();
-  p.peakAreaCorrected =
-      xml.attributes().value("peakAreaCorrected").toString().toDouble();
-  p.peakAreaTop = xml.attributes().value("peakAreaTop").toString().toDouble();
-  p.peakAreaTopCorrected =
-      xml.attributes().value("peakAreaTopCorrected").toString().toDouble();
-  p.peakAreaFractional =
-      xml.attributes().value("peakAreaFractional").toString().toDouble();
-  p.peakRank = xml.attributes().value("peakRank").toString().toDouble();
-  p.peakIntensity =
-      xml.attributes().value("peakIntensity").toString().toDouble();
-  p.peakBaseLineLevel =
-      xml.attributes().value("peakBaseLineLevel").toString().toDouble();
-  p.peakMz = xml.attributes().value("peakMz").toString().toDouble();
-  p.medianMz = xml.attributes().value("medianMz").toString().toDouble();
-  p.baseMz = xml.attributes().value("baseMz").toString().toDouble();
-  p.quality = xml.attributes().value("quality").toString().toDouble();
-  p.width = xml.attributes().value("width").toString().toInt();
-  p.gaussFitSigma =
-      xml.attributes().value("gaussFitSigma").toString().toDouble();
-  p.gaussFitR2 = xml.attributes().value("gaussFitR2").toString().toDouble();
-  p.groupNum = xml.attributes().value("groupNum").toString().toInt();
-  p.noNoiseObs = xml.attributes().value("noNoiseObs").toString().toInt();
-  p.noNoiseFraction =
-      xml.attributes().value("noNoiseFraction").toString().toDouble();
-  p.symmetry = xml.attributes().value("symmetry").toString().toDouble();
-  p.signalBaselineRatio =
-      xml.attributes().value("signalBaselineRatio").toString().toDouble();
-  p.groupOverlap = xml.attributes().value("groupOverlap").toString().toDouble();
-  p.groupOverlapFrac =
-      xml.attributes().value("groupOverlapFrac").toString().toDouble();
-  p.localMaxFlag = xml.attributes().value("localMaxFlag").toString().toInt();
-  p.fromBlankSample =
-      xml.attributes().value("fromBlankSample").toString().toInt();
-  p.label = xml.attributes().value("label").toString().toInt();
-  string sampleName = xml.attributes().value("sample").toString().toStdString();
-  vector<mzSample *> samples = _mainwindow->getSamples();
-  for (int i = 0; i < samples.size(); i++) {
-    if (samples[i]->sampleName == sampleName) {
-      p.setSample(samples[i]);
-      break;
-    }
-  }
-
-  parent->addPeak(p);
-}
-
-void TableDockWidget::savePeakTable() {
-  _mainwindow->getAnalytics()->hitEvent("Peaks", "Save Peaks");
-  if (allgroups.size() == 0) {
-    QString msg = "Peaks Table is Empty";
-    QMessageBox::warning(this, tr("Error"), msg);
-    return;
-  }
-
-  QString dir = ".";
-  QSettings *settings = _mainwindow->getSettings();
-  if (settings->contains("lastDir"))
-    dir = settings->value("lastDir").value<QString>();
-
-  QString fileName = QFileDialog::getSaveFileName(
-      this, tr("Save to Project File"), dir, "Maven Project File(*.mzroll)");
-  if (fileName.isEmpty())
-    return;
-  if (!fileName.endsWith(".mzroll", Qt::CaseInsensitive))
-    fileName = fileName + ".mzroll";
-
-  _mainwindow->getProjectWidget()->saveProject(fileName, this);
-}
-
-void TableDockWidget::savePeakTable(QString fileName) {
-  QFile file(fileName);
-  if (!file.open(QFile::WriteOnly)) {
-    QErrorMessage errDialog(this);
-    errDialog.showMessage("File open " + fileName + " failed");
-    return; // error
-  }
-
-  QXmlStreamWriter stream(&file);
-  stream.setAutoFormatting(true);
-  writePeakTableXML(stream);
-  file.close();
-}
-
-void TableDockWidget::loadPeakTable() {
-  QString dir = ".";
-  QSettings *settings = _mainwindow->getSettings();
-  if (settings->contains("lastDir"))
-    dir = settings->value("lastDir").value<QString>();
-  QString selFilter;
-  QStringList filters;
-  filters << "Maven Project File(*.mzroll)"
-          << "mzPeaks XML(*.mzPeaks *.mzpeaks)"
-          << "XCMS peakTable Tab Delimited(*.tab *.csv *.txt *.tsv)";
-
-  QString fileName = QFileDialog::getOpenFileName(
-      this, "Load Saved Peaks", dir, filters.join(";;"), &selFilter);
-  if (fileName.isEmpty())
-    return;
-  if (selFilter == filters[2]) {
-    loadCSVFile(fileName, "\t");
-  } else {
-    loadPeakTable(fileName);
-  }
-
-  showAllGroups();
-}
-
-void TableDockWidget::readSamplesXML(QXmlStreamReader &xml,
-                                     PeakGroup *group,
-                                     float mzrollVersion) {
-
-  vector<mzSample *> samples = _mainwindow->getSamples();
-
-  if (mzrollVersion == 1) {
-    if (xml.name() == "SamplesUsed") {
-      xml.readNextStartElement();
-      while (xml.name() == "sample") {
-        unsigned int id = xml.attributes().value("id").toString().toInt();
-        for (int i = 0; i < samples.size(); ++i) {
-          mzSample *sample = samples[i];
-          if (id == sample->getSampleId()) {
-            group->samples.push_back(sample);
-          }
-        }
-        xml.readNextStartElement();
-      }
-    }
-  } else {
-
-    for (int i = 0; i < samples.size(); ++i) {
-      QString name = QString::fromStdString(samples[i]->sampleName);
-      cleanString(name);
-      if (xml.name() == "PeakGroup" && mzrollv_0_1_5 &&
-          samples[i]->isSelected) {
-        /**
-         * if mzroll is from old version, just insert sample in group from
-         * checking whether it is selected or not at time of exporting. This can
-         * give erroneous result for old version if at time of exporting mzroll
-         * user has selected diffrent samples from samples were used at time of
-         * peak finding which was inherent problem of old version of ElMaven.
-         */
-        group->samples.push_back(samples[i]);
-      } else if (xml.name() == "SamplesUsed" &&
-                 xml.attributes().value(name).toString() == "Used") {
-        /**
-         * if mzroll file is of new version, it's sample name will precede by
-         * 's' and has value of <Used> or <NotUsed>
-         */
-        group->samples.push_back(samples[i]);
-      }
-    }
-  }
-}
-
-void TableDockWidget::markv_0_1_5mzroll(QString fileName) {
-  mzrollv_0_1_5 = true;
-
-  QFile data(fileName);
-
-  if (!data.open(QFile::ReadOnly)) {
-    return;
-  }
-
-  QXmlStreamReader xml(&data);
-  while (!xml.atEnd()) {
-    xml.readNext();
-    if (xml.isStartElement()) {
-      if (xml.name() == "SamplesUsed") {
-        // mark false if <SamplesUsed> which is only in new version
-        mzrollv_0_1_5 = false;
-        break;
-      }
-    }
-  }
-
-  data.close();
-
-  return;
-}
-
-void TableDockWidget::loadPeakTable(QString fileName) {
-
-  markv_0_1_5mzroll(fileName);
-
-  QFile data(fileName);
-  if (!data.open(QFile::ReadOnly)) {
-    QErrorMessage errDialog(this);
-    errDialog.showMessage("File open: " + fileName + " failed");
-    return;
-  }
-  QXmlStreamReader xml(&data);
-
-  PeakGroup *group = NULL;
-  PeakGroup *parent = NULL;
-  QStack<PeakGroup *> stack;
-
-  float mzrollVersion = 0;
-
-  while (!xml.atEnd()) {
-    if (xml.isStartElement() && xml.name() == "project") {
-      mzrollVersion = xml.attributes().value("mzrollVersion").toFloat();
-    }
-    xml.readNext();
-    if (xml.hasError()) {
-      qDebug() << "Error in xml reading: " << xml.errorString();
-    }
-    if (xml.isStartElement()) {
-      if (xml.name() == "PeakGroup") {
-        group = readGroupXML(xml, parent);
-      }
-      if (xml.name() == "SamplesUsed" && group) {
-        readSamplesXML(xml, group, mzrollVersion);
-      }
-      if (xml.name() == "Peak" && group) {
-        readPeakXML(xml, group);
-      }
-      if (xml.name() == "children" && group) {
-        stack.push(group);
-        parent = stack.top();
-      }
-    }
-
-    if (xml.isEndElement()) {
-      if (xml.name() == "children") {
-        if (stack.size() > 0)
-          parent = stack.pop();
-        if (parent && parent->childCount()) {
-          for (int i = 0; i < parent->children.size(); i++) {
-            parent->children[i].minQuality =
-                _mainwindow->mavenParameters->minQuality;
-            parent->children[i].groupStatistics();
-          }
-        }
-        if (stack.size() == 0)
-          parent = NULL;
-      }
-      if (xml.name() == "PeakGroup") {
-        if (group) {
-          group->minQuality = _mainwindow->mavenParameters->minQuality;
-          group->groupStatistics();
-        }
-        group = NULL;
-      }
-    }
-  }
-  for (int i = 0; i < allgroups.size(); i++) {
-    allgroups[i].minQuality = _mainwindow->mavenParameters->minQuality;
-    allgroups[i].groupStatistics();
   }
 }
 
@@ -2229,13 +1774,13 @@ QWidget *TableToolBarWidgetAction::createWidget(QWidget *parent) {
     QFont font;
     font.setPointSize(14);
     td->titlePeakTable->setFont(font);
+    td->setStyleSheet("QLabel { margin: 0px 6px; }");
 
     if (td->tableId == 0)
-      td->titlePeakTable->setText(" Bookmark Table  ");
+      td->titlePeakTable->setText("Bookmark Table");
     else
       td->titlePeakTable->setText("Peak Table "
-                                  + QString::number(td->tableId)
-                                  + "  ");
+                                  + QString::number(td->tableId));
 
     td->titlePeakTable->setStyleSheet("font-weight: bold; color: black");
     td->setWindowTitle(td->titlePeakTable->text());
@@ -2323,14 +1868,6 @@ QWidget *TableToolBarWidgetAction::createWidget(QWidget *parent) {
     btnTrain->setToolTip("Train Neural Net");
     connect(btnTrain, SIGNAL(clicked()), td, SLOT(showTrainDialog()));
     return btnTrain;
-  } else if (btnName == "btnXML") {
-
-    QToolButton *btnXML = new QToolButton(parent);
-    btnXML->setIcon(QIcon(rsrcPath + "/exportxml.png"));
-    btnXML->setToolTip("Save Peaks");
-    connect(btnXML, SIGNAL(clicked()), td, SLOT(savePeakTable()));
-    connect(btnXML, SIGNAL(clicked()), td, SLOT(showNotification()));
-    return btnXML;
   } else if (btnName == "btnGood") {
 
     QToolButton *btnGood = new QToolButton(parent);
@@ -2377,9 +1914,15 @@ QWidget *TableToolBarWidgetAction::createWidget(QWidget *parent) {
   }
 }
 
-PeakTableDockWidget::PeakTableDockWidget(MainWindow *mw) : TableDockWidget(mw) {
+PeakTableDockWidget::PeakTableDockWidget(MainWindow *mw, const int peakTableId)
+  : TableDockWidget(mw) {
+
   _mainwindow = mw;
-  tableId = ++(mw->noOfPeakTables);
+
+  if (peakTableId > mw->lastPeakTableId)
+    tableId = mw->lastPeakTableId = peakTableId;
+  else
+    tableId = ++(mw->lastPeakTableId);
 
   toolBar = new QToolBar(this);
   toolBar->setFloatable(false);
@@ -2399,7 +1942,6 @@ PeakTableDockWidget::PeakTableDockWidget(MainWindow *mw) : TableDockWidget(mw) {
       new TableToolBarWidgetAction(toolBar, this, "btnCluster");
   QWidgetAction *btnTrain =
       new TableToolBarWidgetAction(toolBar, this, "btnTrain");
-  QWidgetAction *btnXML = new TableToolBarWidgetAction(toolBar, this, "btnXML");
   QWidgetAction *btnGood =
       new TableToolBarWidgetAction(toolBar, this, "btnGood");
   QWidgetAction *btnBad = new TableToolBarWidgetAction(toolBar, this, "btnBad");
@@ -2427,9 +1969,6 @@ PeakTableDockWidget::PeakTableDockWidget(MainWindow *mw) : TableDockWidget(mw) {
   toolBar->addAction(btnPDF);
   toolBar->addAction(btnGroupCSV);
   toolBar->addAction(btnSaveJson);
-
-  toolBar->addSeparator();
-  toolBar->addAction(btnXML);
 
   toolBar->addWidget(spacer);
   toolBar->addAction(btnMin);
@@ -2499,7 +2038,6 @@ BookmarkTableDockWidget::BookmarkTableDockWidget(MainWindow *mw) : TableDockWidg
       new TableToolBarWidgetAction(toolBar, this, "btnCluster");
   QWidgetAction *btnTrain =
       new TableToolBarWidgetAction(toolBar, this, "btnTrain");
-  QWidgetAction *btnXML = new TableToolBarWidgetAction(toolBar, this, "btnXML");
   QWidgetAction *btnGood =
       new TableToolBarWidgetAction(toolBar, this, "btnGood");
   QWidgetAction *btnBad = new TableToolBarWidgetAction(toolBar, this, "btnBad");
@@ -2528,9 +2066,6 @@ BookmarkTableDockWidget::BookmarkTableDockWidget(MainWindow *mw) : TableDockWidg
   toolBar->addAction(btnPDF);
   toolBar->addAction(btnGroupCSV);
   toolBar->addAction(btnSaveJson);
-
-  toolBar->addSeparator();
-  toolBar->addAction(btnXML);
 
   toolBar->addWidget(spacer);
   toolBar->addAction(btnMin);
@@ -2850,7 +2385,6 @@ ScatterplotTableDockWidget::ScatterplotTableDockWidget(MainWindow *mw) :
       new TableToolBarWidgetAction(toolBar, this, "btnCluster");
   QWidgetAction *btnTrain =
       new TableToolBarWidgetAction(toolBar, this, "btnTrain");
-  QWidgetAction *btnXML = new TableToolBarWidgetAction(toolBar, this, "btnXML");
   QWidgetAction *btnGood =
       new TableToolBarWidgetAction(toolBar, this, "btnGood");
   QWidgetAction *btnBad = new TableToolBarWidgetAction(toolBar, this, "btnBad");
@@ -2877,9 +2411,6 @@ ScatterplotTableDockWidget::ScatterplotTableDockWidget(MainWindow *mw) :
   toolBar->addAction(btnPDF);
   toolBar->addAction(btnGroupCSV);
   toolBar->addAction(btnSaveJson);
-
-  toolBar->addSeparator();
-  toolBar->addAction(btnXML);
 
   toolBar->addWidget(spacer);
   toolBar->addAction(btnMin);

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -1481,7 +1481,7 @@ void TableDockWidget::writeGroupXML(QXmlStreamWriter &stream, PeakGroup *g) {
   stream.writeStartElement("SamplesUsed");
   for (int i = 0; i < g->samples.size(); ++i) {
     stream.writeStartElement("sample");
-    stream.writeAttribute("id", QString::number(g->samples[i]->id));
+    stream.writeAttribute("id", QString::number(g->samples[i]->getSampleId()));
     stream.writeEndElement();
   }
   stream.writeEndElement();
@@ -1784,7 +1784,7 @@ void TableDockWidget::readSamplesXML(QXmlStreamReader &xml,
         unsigned int id = xml.attributes().value("id").toString().toInt();
         for (int i = 0; i < samples.size(); ++i) {
           mzSample *sample = samples[i];
-          if (id == sample->id) {
+          if (id == sample->getSampleId()) {
             group->samples.push_back(sample);
           }
         }

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -72,13 +72,6 @@ public:
   int tableId;
 
   /**
-   * for making old mzroll compatible, this will act as a flag whether loaded
-   * mzroll file is old or new one. this will be set by class method
-   * <markv_0_1_5mzroll>
-   */
-  bool mzrollv_0_1_5;
-
-  /**
    * @brief Update the name of the intensity type field in table
    * according to the quantity type currenly selected by the user.
    */
@@ -105,15 +98,6 @@ public Q_SLOTS:
   void showFocusedGroups();
   void clearFocusedGroups();
   void unhideFocusedGroups();
-
-  // input from xml
-  void loadPeakTable();
-  void loadPeakTable(QString infile);
-
-  // output to xml
-  void savePeakTable();
-  void savePeakTable(QString fileName);
-  void writePeakTableXML(QXmlStreamWriter &stream);
 
   // output to csv file
   void exportGroupsToSpreadsheet();
@@ -164,16 +148,6 @@ public Q_SLOTS:
   void markGroupIgnored();
   void showAllGroups();
   void showHeatMap();
-
-  /**
-   * @brief  modify name appropriate for xml attribute naming
-   * @detail This method makes sample name appropriate for using in attribute
-   * naming in mzroll file It is just replacing '#' with '_' and adding 's' for
-   * letting sample name start with english letter In future, if sample name has
-   * some other special character, we have to replace those also with
-   * appropriate character Error can be seen at compilation time
-   */
-  void cleanString(QString &name);
   void showScatterPlot();
   void setClipboard();
 
@@ -221,28 +195,6 @@ private:
   QPalette pal;
   void addRow(PeakGroup *group, QTreeWidgetItem *root);
   void heatmapBackground(QTreeWidgetItem *item);
-  PeakGroup *readGroupXML(QXmlStreamReader &xml, PeakGroup *parent);
-  void writeGroupXML(QXmlStreamWriter &stream, PeakGroup *g);
-  void readPeakXML(QXmlStreamReader &xml, PeakGroup *parent);
-
-  /**
-   * @brief- it will add samples used to group being generated while creating
-   * from mzroll file
-   * @detail This method will add all sample to group being
-   * created from mzroll file. It will read SamplesUsed attribute of a group
-   * and if it's value is "Used", then assign this mzSample to that group
-   */
-  void readSamplesXML(QXmlStreamReader &xml,
-                      PeakGroup *group,
-                      float mzrollVersion);
-
-  /**
-   * @brief-mark varible <mzrollv_0_1_5> true or false
-   * @details  this method marks varible <mzrollv_0_1_5> true if loaded mzroll
-   * file is of v0.1.5 or older otherwise false based on one attribute
-   * <SamplesUsed> which is introduced here.
-   */
-  void markv_0_1_5mzroll(QString fileName);
 
   // TODO: investigate and remove this dialog if not being used
   void setupFiltersDialog();
@@ -261,7 +213,7 @@ class PeakTableDockWidget : public TableDockWidget {
   Q_OBJECT
 
 public:
-  PeakTableDockWidget (MainWindow *mw);
+  PeakTableDockWidget (MainWindow *mw, const int tableId=-1);
   ~PeakTableDockWidget();
 
 public Q_SLOTS:

--- a/src/projectDB/connection.cpp
+++ b/src/projectDB/connection.cpp
@@ -1,0 +1,65 @@
+#include "connection.h"
+#include "cursor.h"
+
+Connection::Connection(const std::string& dbPath)
+{
+    int errCode = sqlite3_open(dbPath.c_str(), &_database);
+    if (errCode) {
+        std::cerr << "Cannot open database at location \""
+                  << dbPath
+                  << "\", because of error: "
+                  << sqlite3_errmsg(_database);
+        _database = nullptr;
+        _dbPath = "";
+    } else {
+        _dbPath = dbPath;
+    }
+}
+
+Connection::~Connection()
+{
+    for (auto cursor: _cursors)
+        delete cursor;
+
+    if (_database != nullptr)
+        sqlite3_close_v2(_database);
+}
+
+bool Connection::begin()
+{
+    return prepare("BEGIN TRANSACTION")->execute();
+}
+
+bool Connection::commit()
+{
+    return prepare("COMMIT")->execute();
+}
+
+bool Connection::rollback()
+{
+    return prepare("ROLLBACK")->execute();
+}
+
+Cursor* Connection::prepare(const std::string& query)
+{
+    sqlite3_stmt* statement;
+    int status = sqlite3_prepare_v2(_database,
+                                    query.c_str(),
+                                    -1,
+                                    &statement,
+                                    nullptr);
+    auto cursor = new Cursor(statement);
+    _cursors.push_back(cursor);
+    return cursor;
+}
+
+int Connection::lastInsertId()
+{
+    int64_t lastRowId = sqlite3_last_insert_rowid(_database);
+    return static_cast<int>(lastRowId);
+}
+
+std::string Connection::dbPath()
+{
+    return _dbPath;
+}

--- a/src/projectDB/connection.h
+++ b/src/projectDB/connection.h
@@ -1,0 +1,124 @@
+#ifndef CONNECTION_H
+#define CONNECTION_H
+
+#include <iostream>
+#include <vector>
+#include <sqlite3.h>
+
+class Cursor;
+
+/**
+ * @brief The Connection class is a loose wrapper around the SQLite3 database
+ * connection object.
+ * @details SQLite3 being a C library requires the user to connect, close
+ * and ensure garbage collection for the central database object. This wrapper
+ * tries to handle these details for the user and tries to provide a C++ layer
+ * over the database connection C object.
+ */
+class Connection
+{
+public:
+    /**
+     * @brief Construct a connection object for the given SQLite database.
+     * @param dbPath Absolute path for SQLite database file as a string.
+     */
+    Connection(const std::string& dbPath);
+
+    /**
+     * @brief Close the connection to the database (if connected), destroy
+     * Cursors associated with it and finally destroy the object.
+     * @details The rationale behind deleting all Cursor objects (and thus
+     * finalizing the associated sqlite3_stmt objects) only when the
+     * Connection is being destroyed, is that doing any kind of operation on
+     * finalized statements, during the lifetime of an open DB connection, can
+     * result in segfaults and heap corruption. An extra set of conditions will
+     * be needed to be checked for every method on Cursor objects which would
+     * increase the complexity of these simple set of wrappers.
+     */
+    ~Connection();
+
+    /**
+     * @brief Start an explicit SQLite transaction.
+     * @details Transactions are automatically started whenever a user attempts
+     * to execute a database modification statement. However, if required, this
+     * method can be used to explicitly start one. It should be noted that this
+     * method does not allow the user to have nested transactions, for which
+     * they will need to use appropriate checkpoints using SQLite commands.
+     * @return True if a transaction was started successfully.
+     */
+    bool begin();
+
+    /**
+     * @brief Commit pending changes to the database.
+     * @details No modification operations are truly reflected in a SQLite
+     * database until a commit operation is performed. This method should be
+     * called after making any changes to the database, especially if the
+     * subsequent set of operations rely on these changes. Any outstanding
+     * modification that are left uncommitted are committed when their
+     * respective statements are finalized, something that happens whenever
+     * the Connection to the database is closed. This ensures that all changes
+     * made through a Connection during its lifetime are actually written to
+     * the database.
+     * @return True if the commit operation was executed successfully.
+     */
+    bool commit();
+
+    /**
+     * @brief Rollback any pending changes.
+     * @details This method effectively undoes any changes that have not been
+     * committed and are no longer desired. It should be noted that, while
+     * the SQLite library by default rolls back all pending changes when a DB
+     * connection is closed, this wrapper class will indirectly commit pending
+     * changes before closing the connection. So if any undesired changes are
+     * to be rolled back, they have to be explicitly done so before the
+     * destruction of a Connection object. Commits are a default over rollback
+     * because more often changes need to be committed than rolled back. The
+     * latter is assumed to be an active decision.
+     * @return True if the rollback operation was executed successfully.
+     */
+    bool rollback();
+
+    /**
+     * @brief Prepare a SQL statement and return a Cursor ready to be
+     * executed. See documentation of Cursor class for details.
+     * @param query A SQL query as a standard string.
+     * @return Pointer to a Cursor object that has to be executed/iterated upon.
+     */
+    Cursor* prepare(const std::string& query);
+
+    /**
+     * @brief Obtain the ROWID for the last row inserted.
+     * @details A ROWID in SQLite is available for all rows in a regular tables
+     * (except the ones created using the "WITHOUT ROWID" clause). This value
+     * is unique for each row in the table and if the table has a primary key
+     * integer column then that column becomes an alias for ROWID.
+     * @return An integer having the ROWID of last inserted row.
+     */
+    int lastInsertId();
+
+    /**
+     * @brief Obtain the absolute path to the connected database.
+     * @return Path as a string.
+     */
+    std::string dbPath();
+
+private:
+    /**
+     * @brief Stores absolute path for the connected SQLite database file.
+     */
+    std::string _dbPath;
+
+    /**
+     * @brief Pointer to the sqlite3 db object that this connection
+     * represents.
+     */
+    sqlite3* _database;
+
+    /**
+     * @brief A vector of Cursor objects that were created by this
+     * connection and therefore should be deleted when this object is destroyed.
+     */
+    std::vector<Cursor*> _cursors;
+};
+
+#endif // CONNECTION_H

--- a/src/projectDB/cursor.cpp
+++ b/src/projectDB/cursor.cpp
@@ -1,0 +1,109 @@
+#include "cursor.h"
+#include "connection.h"
+
+Cursor::Cursor(sqlite3_stmt* statement)
+{
+    _statement = statement;
+}
+
+Cursor::~Cursor()
+{
+    if (_statement)
+        sqlite3_finalize(_statement);
+}
+
+bool Cursor::execute()
+{
+    int status = sqlite3_step(_statement);
+    sqlite3_reset(_statement);
+    return status == SQLITE_DONE;
+}
+
+bool Cursor::next()
+{
+    int status = sqlite3_step(_statement);
+    _extractValues();
+    return status == SQLITE_ROW;
+}
+
+bool Cursor::bind(const std::string& param, int value)
+{
+    int index = sqlite3_bind_parameter_index(_statement, param.c_str());
+    return sqlite3_bind_int(_statement, index, value) == SQLITE_OK;
+}
+
+bool Cursor::bind(const std::string& param, double value)
+{
+    int index = sqlite3_bind_parameter_index(_statement, param.c_str());
+    return sqlite3_bind_double(_statement, index, value) == SQLITE_OK;
+}
+
+bool Cursor::bind(const std::string& param, float value)
+{
+    auto dval = static_cast<double>(value);
+    return this->bind(param, dval);
+}
+
+bool Cursor::bind(const std::string& param, const std::string value)
+{
+    int index = sqlite3_bind_parameter_index(_statement, param.c_str());
+    return sqlite3_bind_text(_statement,
+                             index,
+                             value.c_str(),
+                             -1,
+                             SQLITE_TRANSIENT) == SQLITE_OK;
+}
+
+int Cursor::integerValue(const std::string& param)
+{
+    auto val = _currentResult[param];
+    if (val.empty())
+        return 0;
+    return std::stoi(val);
+}
+
+double Cursor::doubleValue(const std::string& param)
+{
+    auto val = _currentResult[param];
+    if (val.empty())
+        return 0.0;
+    return std::stod(_currentResult[param]);
+}
+
+float Cursor::floatValue(const std::string& param)
+{
+    double dval = doubleValue(param);
+    return static_cast<float>(dval);
+}
+
+std::string Cursor::stringValue(const std::string& param)
+{
+    return _currentResult[param];
+}
+
+void Cursor::_extractValues()
+{
+    _currentResult.clear();
+    int valueCount = sqlite3_data_count(_statement);
+
+    while (valueCount) {
+        // column indexing goes from 0 to (valueCount - 1), so decrement first
+        --valueCount;
+
+        auto param =
+            reinterpret_cast<const char*>(sqlite3_column_name(_statement,
+                                                              valueCount));
+        // if param was pointing to NULL
+        if (!param)
+            param = "";
+
+        auto value =
+            reinterpret_cast<const char*>(sqlite3_column_text(_statement,
+                                                              valueCount));
+        // if value was pointing to NULL
+        if (!value)
+            value = "";
+
+        _currentResult[param] = value;
+    }
+}

--- a/src/projectDB/cursor.h
+++ b/src/projectDB/cursor.h
@@ -1,0 +1,150 @@
+#ifndef CURSOR_H
+#define CURSOR_H
+
+#include <iostream>
+#include <map>
+#include <sqlite3.h>
+
+class Connection;
+
+/**
+ * @brief The Cursor class is a convencience wrapper around the sqlite3_stmt
+ * structure of SQLite3 library.
+ * @details This class represents a SQL statement that can be executed on a
+ * database. It hides details of construction, execution, extraction of values
+ * and finalization of SQL statements in the SQLite library by providing a
+ * simpler C++ interface.
+ */
+class Cursor
+{
+    // To allow Connection class to create Cursors using the private constructor
+    friend class Connection;
+
+public:
+    /**
+     * @brief Execute a non returning SQL statement, such as update, delete,
+     * insert and create operations.
+     * @details The "step" function called within this function is the same as
+     * the one that is called in the `next` method for this object, although
+     * the return condition is different. The statement is reset with each
+     * `execute` call, making the statement callable again with different bound
+     * parameters. And this is also why `next` should be used for result
+     * returning statements over this method, since execution will keep coming
+     * back to the start of the result set with each call.
+     * @return True if statement execution finished successfully.
+     */
+    bool execute();
+
+    /**
+     * @brief Execute and move to the next row for select operations.
+     * @details While this method, like `execute` also uses the "step" SQLite
+     * function, its semantically meant to be used for iterating over rows
+     * returned from a suitable SQL operation (most commonly SELECT statements).
+     * Moreover, the `_extracValues` method is called to extract values stored
+     * in current row of the result set.
+     * @return True if the `next` method can be further called upon this Cursor.
+     */
+    bool next();
+
+    /**
+     * @brief Bind integer value for statement with named parameter.
+     * @param param Name of the parameter to be bound.
+     * @param value Value as an integer to be bound for the parameter.
+     * @return True if value was successfully bound.
+     */
+    bool bind(const std::string& param, int value);
+
+    /**
+     * @brief Bind double precision value for statement with named parameter.
+     * @param param Name of the parameter to be bound.
+     * @param value Value as a double to be bound for the parameter.
+     * @return True if value was successfully bound.
+     */
+    bool bind(const std::string& param, double value);
+
+    /**
+     * @brief Bind floating point value for statement with named parameter.
+     * @param param Name of the parameter to be bound.
+     * @param value Value as a floating point to be bound for the parameter.
+     * @return True if value was successfully bound.
+     */
+    bool bind(const std::string& param, float value);
+
+    /**
+     * @brief Bind string value for statement with given named parameter.
+     * @param param Name of the parameter to be bound.
+     * @param value String value to be bound for the parameter.
+     * @return True if value was successfully bound.
+     */
+    bool bind(const std::string& param, const std::string value);
+
+    /**
+     * @brief Obtain values for integers in the form of a int type.
+     * @param param Name of parameter whose value is needed.
+     * @return Value of parameter converted to integer.
+     */
+    int integerValue(const std::string& param);
+
+    /**
+     * @brief Obtain values for real numbers in the form of a double type.
+     * @param param Name of parameter whose value is needed.
+     * @return Value of parameter converted to double.
+     */
+    double doubleValue(const std::string& param);
+
+    /**
+     * @brief Obtain values for real numbers in the form of a float type.
+     * @param param Name of parameter whose value is needed.
+     * @return Value of parameter converted to float.
+     */
+    float floatValue(const std::string& param);
+
+    /**
+     * @brief Obtain textual values in the form of a string type.
+     * @param param Name of parameter whose value is needed.
+     * @return Value of parameter converted to string.
+     */
+    std::string stringValue(const std::string& param);
+
+private:
+    /**
+     * @brief A pointer to the sqlite3_stmt construct represented by the class.
+     */
+    sqlite3_stmt* _statement;
+
+    /**
+     * @brief A map storing values for the current result, in case the query
+     * is of a row returning type (i.e., "SELECT" statements).
+     */
+    std::map<std::string, std::string> _currentResult;
+
+    /**
+     * @brief Constructor that can only be accessed by friend classes.
+     * @details The constructor has been made private to prevent a Cursor object
+     * from being created without an associated connection object as that would
+     * break the abstraction.
+     * @param statement A pointer to sqlite3_stmt construct around which the
+     * Cursor object will be created.
+     */
+    Cursor(sqlite3_stmt* statement);
+
+    /**
+     * @brief Finalise the SQLite statement wrapped within this object and then
+     * destroy the object.
+     * @details The destructor for a Cursor should not be called if it was
+     * created in context to a Connection object. The Connection owning a
+     * Cursor will attempt to destruct it when it is itself destroyed.
+     */
+    ~Cursor();
+
+    /**
+     * @brief Extract values from the current iteration of result set and store
+     * it in `_currentResult` as a mapping of parameter names to their values
+     * as strings. These values are converted to the corresponding type when
+     * any of the `integerValue`, `doubleValue`, `floatValue` or `stringValue`
+     * methods are called.
+     */
+    void _extractValues();
+};
+
+#endif // CURSOR_H

--- a/src/projectDB/projectDB.pro
+++ b/src/projectDB/projectDB.pro
@@ -1,0 +1,25 @@
+TEMPLATE = lib
+
+OBJECTS_DIR = $$top_builddir/tmp/projectDB/
+DESTDIR = $$top_builddir/libs/
+TARGET = projectDB
+
+CONFIG += xml console staticlib warn_off
+
+QMAKE_CXXFLAGS += -std=c++11
+
+INCLUDEPATH += $$top_srcdir/src/core/libmaven \
+               /usr/local/include/
+
+QMAKE_LFLAGS += -L$$top_builddir/libs/
+
+LIBS += -lmaven \
+        -fopenmp \
+        -lboost_filesystem \
+        -lsqlite3
+
+macx {
+    LIBS -= -fopenmp
+}
+
+HEADERS += 	schema.h \

--- a/src/projectDB/projectDB.pro
+++ b/src/projectDB/projectDB.pro
@@ -37,7 +37,9 @@ macx {
 
 SOURCES	= connection.cpp \
           cursor.cpp \
+          projectdatabase.cpp
 
 HEADERS += 	schema.h \
             connection.h \
             cursor.h \
+            projectdatabase.h

--- a/src/projectDB/projectDB.pro
+++ b/src/projectDB/projectDB.pro
@@ -24,22 +24,11 @@ INCLUDEPATH += $$top_srcdir/src/core/libmaven \
                $$top_srcdir/src/pollyCLI \
                /usr/local/include/
 
-QMAKE_LFLAGS += -L$$top_builddir/libs/
-
-LIBS += -lmaven \
-        -fopenmp \
-        -lboost_filesystem \
-        -lsqlite3
-
-macx {
-    LIBS -= -fopenmp
-}
-
 SOURCES	= connection.cpp \
           cursor.cpp \
           projectdatabase.cpp
 
-HEADERS += 	schema.h \
+HEADERS +=  schema.h \
             connection.h \
             cursor.h \
             projectdatabase.h

--- a/src/projectDB/projectDB.pro
+++ b/src/projectDB/projectDB.pro
@@ -9,6 +9,19 @@ CONFIG += xml console staticlib warn_off
 QMAKE_CXXFLAGS += -std=c++11
 
 INCLUDEPATH += $$top_srcdir/src/core/libmaven \
+               $$top_srcdir/3rdparty/obiwarp   \
+               $$top_srcdir/3rdparty/pugixml/src \
+               $$top_srcdir/3rdparty/libneural \
+               $$top_srcdir/3rdparty/Eigen/ \
+               $$top_srcdir/3rdparty/libpls \
+               $$top_srcdir/3rdparty/libcsvparser \
+               $$top_srcdir/3rdparty/libcdfread \
+               $$top_srcdir/3rdparty/ \
+               $$top_srcdir/3rdparty/libpillow \
+               $$top_srcdir/3rdparty/libdate/ \
+               $$top_srcdir/3rdparty/ErrorHandling \
+               $$top_srcdir/3rdparty/Logger \
+               $$top_srcdir/src/pollyCLI \
                /usr/local/include/
 
 QMAKE_LFLAGS += -L$$top_builddir/libs/
@@ -22,4 +35,9 @@ macx {
     LIBS -= -fopenmp
 }
 
+SOURCES	= connection.cpp \
+          cursor.cpp \
+
 HEADERS += 	schema.h \
+            connection.h \
+            cursor.h \

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -431,13 +431,15 @@ void ProjectDatabase::saveScans(const vector<mzSample*>& sampleSet)
     _connection->commit();
 }
 
-vector<string> ProjectDatabase::loadSampleNames(const vector<mzSample*> loaded)
+pair<vector<string>, vector<string>>
+ProjectDatabase::getSampleNames(const vector<mzSample*> loaded)
 {
     string projectPath = this->projectPath();
     auto samplesQuery = _connection->prepare("SELECT filename \
                                                 FROM samples  ");
 
-    vector<string> sampleNames;
+    vector<string> sampleNamesFound;
+    vector<string> sampleNamesNotFound;
     while (samplesQuery->next()) {
         string filename = samplesQuery->stringValue("filename");
 
@@ -459,12 +461,15 @@ vector<string> ProjectDatabase::loadSampleNames(const vector<mzSample*> loaded)
         string filepath = _locateSample(filename, possiblePaths);
 
         if (!filepath.empty()) {
-            sampleNames.push_back(filepath);
+            sampleNamesFound.push_back(filepath);
             cerr << "Debug: Found sample: " << filepath << endl;
         } else {
+            sampleNamesNotFound.push_back(filename);
             cerr << "Error: Could not find sample: " << filename << endl;
         }
     }
+    pair<vector<string>, vector<string>> sampleNames(sampleNamesFound,
+                                                     sampleNamesNotFound);
     return sampleNames;
 }
 

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -967,7 +967,7 @@ string ProjectDatabase::projectPath()
 {
     string databaseFile = _connection->dbPath();
     boost::filesystem::path path(databaseFile);
-    return path.parent_path().native();
+    return path.parent_path().string();
 }
 
 string ProjectDatabase::projectName()
@@ -1068,7 +1068,7 @@ string ProjectDatabase::_getScanSignature(Scan* scan, int limitSize)
 }
 
 string ProjectDatabase::_locateSample(const string filepath,
-                     const vector<string>& pathlist)
+                                      const vector<string>& pathlist)
 {
     // found file, all is good
     boost::filesystem::path sampleFile(filepath);
@@ -1081,7 +1081,7 @@ string ProjectDatabase::_locateSample(const string filepath,
         boost::filesystem::path possiblePath(path);
         auto filepath = possiblePath / fileName;
         if (boost::filesystem::exists(filepath))
-            return filepath.native();
+            return filepath.string();
     }
     return "";
 }

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -863,10 +863,10 @@ void ProjectDatabase::deleteTableGroups(const string& tableName)
 {
     auto failure = false;
     auto peaksQuery = _connection->prepare(
-        "DELETE FROM peaks                                       \
-               WHERE group_id IN (SELECT group_id                \
-                                    FROM peakgroups              \
-                                   WHERE table_name = :table_name");
+        "DELETE FROM peaks                                        \
+               WHERE group_id IN (SELECT group_id                 \
+                                    FROM peakgroups               \
+                                   WHERE table_name = :table_name)");
     peaksQuery->bind(":table_name", tableName);
     if (!peaksQuery->execute()) {
         failure = true;
@@ -876,7 +876,7 @@ void ProjectDatabase::deleteTableGroups(const string& tableName)
 
     auto peakgroupsQuery = _connection->prepare(
         "DELETE FROM peakgroups             \
-               WHERE tableName = :table_name");
+               WHERE table_name = :table_name");
     peakgroupsQuery->bind(":table_name", tableName);
     if(!peakgroupsQuery->execute()) {
         failure = true;

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -1,0 +1,1073 @@
+#include <sstream>
+#include <boost/filesystem.hpp>
+#include "projectdatabase.h"
+#include "Compound.h"
+#include "connection.h"
+#include "cursor.h"
+#include "mzSample.h"
+#include "schema.h"
+
+ProjectDatabase::ProjectDatabase(const string& dbFilename)
+{
+    _connection = new Connection(dbFilename);
+}
+
+ProjectDatabase::~ProjectDatabase()
+{
+    delete _connection;
+}
+
+void ProjectDatabase::saveSamples(const vector<mzSample*>& samples)
+{
+    if (!_connection->prepare(CREATE_SAMPLES_TABLE)->execute()) {
+        cerr << "Error: failed to create samples table" << endl;
+        return;
+    }
+
+    // assign IDs before proceeding with save operation
+    _assignSampleIds(samples);
+
+    auto samplesQuery = _connection->prepare(
+        "REPLACE INTO samples         \
+               VALUES ( :sample_id    \
+                      , :name         \
+                      , :filename     \
+                      , :set_name     \
+                      , :sample_order \
+                      , :is_selected  \
+                      , :color_red    \
+                      , :color_green  \
+                      , :color_blue   \
+                      , :color_alpha  \
+                      , :norml_const  \
+                      , :transform_a0 \
+                      , :transform_a1 \
+                      , :transform_a2 \
+                      , :transform_a4 \
+                      , :transform_a5 )");
+
+    for (auto s : samples) {
+        samplesQuery->bind(":sample_id", s->getSampleId());
+        samplesQuery->bind(":name", s->getSampleName());
+        samplesQuery->bind(":filename", s->fileName);
+        samplesQuery->bind(":set_name", s->getSetName());
+        samplesQuery->bind(":sample_order", s->getSampleOrder());
+        samplesQuery->bind(":is_selected", s->isSelected);
+
+        samplesQuery->bind(":color_red", s->color[0]);
+        samplesQuery->bind(":color_green", s->color[1]);
+        samplesQuery->bind(":color_blue", s->color[2]);
+        samplesQuery->bind(":color_alpha", s->color[3]);
+
+        samplesQuery->bind(":normal_const", s->getNormalizationConstant());
+
+        samplesQuery->bind(":transform_a0", 0);
+        samplesQuery->bind(":transform_a1", 0);
+        samplesQuery->bind(":transform_a2", 0);
+        samplesQuery->bind(":transform_a4", 0);
+        samplesQuery->bind(":transform_a5", 0);
+
+        if (!samplesQuery->execute()) {
+            cerr << "Error: failed to save sample " << s->getSampleName()
+                 << endl;
+        }
+    }
+    _connection->commit();
+}
+
+void ProjectDatabase::saveGroups(const vector<PeakGroup*>& groups,
+                                 const string& tableName)
+{
+    for (const auto group : groups)
+        saveGroupAndPeaks(group, 0, tableName);
+}
+
+int ProjectDatabase::saveGroupAndPeaks(PeakGroup* group,
+                                       const int parentGroupId,
+                                       const string& tableName)
+{
+    if (!group)
+        return -1;
+
+    // skip deleted groups
+    if (group->deletedFlag)
+        return -1;
+
+    if (!_connection->prepare(CREATE_PEAK_GROUPS_TABLE)->execute()) {
+        cerr << "Error: failed to create peakgroups table" << endl;
+        return -1;
+    }
+
+    auto groupsQuery = _connection->prepare(
+        "INSERT INTO peakgroups            \
+              VALUES ( :group_id           \
+                     , :parent_group_id    \
+                     , :meta_group_id      \
+                     , :tag_string         \
+                     , :expected_mz        \
+                     , :expected_rt_diff   \
+                     , :expected_abundance \
+                     , :group_rank         \
+                     , :label              \
+                     , :type               \
+                     , :srm_id             \
+                     , :ms2_event_count    \
+                     , :ms2_score          \
+                     , :adduct_name        \
+                     , :compound_id        \
+                     , :compound_name      \
+                     , :compound_db        \
+                     , :table_name         )");
+
+    groupsQuery->bind(":parent_group_id", parentGroupId);
+    groupsQuery->bind(":meta_group_id", group->metaGroupId);
+    groupsQuery->bind(":tag_string", group->tagString);
+    groupsQuery->bind(":expected_mz", group->expectedMz);
+    groupsQuery->bind(":expected_rt_diff", group->expectedRtDiff);
+    groupsQuery->bind(":expected_abundance", group->expectedAbundance);
+    groupsQuery->bind(":group_rank", group->groupRank);
+    groupsQuery->bind(":label", string(1, group->label));
+    groupsQuery->bind(":type", group->type());
+    groupsQuery->bind(":srm_id", group->srmId);
+
+    groupsQuery->bind(":ms2_event_count", group->ms2EventCount);
+    groupsQuery->bind(":ms2_score", group->fragMatchScore.mergedScore);
+    groupsQuery->bind(":adduct_name", group->adduct ? group->adduct->name : "");
+
+    groupsQuery->bind(":compound_id",
+                      group->compound ? group->compound->id : "");
+    groupsQuery->bind(":compound_name",
+                      group->compound ? group->compound->name : "");
+    groupsQuery->bind(":compound_db",
+                      group->compound ? group->compound->db : "");
+
+    groupsQuery->bind(":table_name", tableName);
+
+    if (!groupsQuery->execute())
+        cerr << "Error: failed to save peak group" << endl;
+
+    int lastInsertedGroupId = _connection->lastInsertId();
+    saveGroupPeaks(group, lastInsertedGroupId);
+
+    for (auto child: group->children)
+        saveGroupAndPeaks(&child, lastInsertedGroupId, tableName);
+
+    _connection->commit();
+    return lastInsertedGroupId;
+}
+
+void ProjectDatabase::saveGroupPeaks(PeakGroup* group, const int groupId)
+{
+    if (!_connection->prepare(CREATE_PEAKS_TABLE)->execute()) {
+        cerr << "Error: failed to create peaks table" << endl;
+        return;
+    }
+
+    auto peaksQuery = _connection->prepare(
+        "INSERT INTO peaks                    \
+              VALUES ( :peak_id               \
+                     , :group_id              \
+                     , :sample_id             \
+                     , :pos                   \
+                     , :minpos                \
+                     , :maxpos                \
+                     , :rt                    \
+                     , :rtmin                 \
+                     , :rtmax                 \
+                     , :mzmin                 \
+                     , :mzmax                 \
+                     , :scan                  \
+                     , :minscan               \
+                     , :maxscan               \
+                     , :peak_area             \
+                     , :peak_area_corrected   \
+                     , :peak_area_top         \
+                     , :peak_area_fractional  \
+                     , :peak_rank             \
+                     , :peak_intensity        \
+                     , :peak_baseline_level   \
+                     , :peak_mz               \
+                     , :median_mz             \
+                     , :base_mz               \
+                     , :quality               \
+                     , :width                 \
+                     , :gauss_fit_sigma       \
+                     , :gauss_fit_r2          \
+                     , :no_noise_obs          \
+                     , :no_noise_fraction     \
+                     , :symmetry              \
+                     , :signal_baseline_ratio \
+                     , :group_overlap         \
+                     , :group_overlap_frac    \
+                     , :local_max_flag        \
+                     , :from_blank_sample     \
+                     , :label                 )");
+
+    for (Peak p : group->peaks) {
+        peaksQuery->bind(":group_id", groupId);
+        peaksQuery->bind(":sample_id", p.getSample()->getSampleId());
+        peaksQuery->bind(":pos", static_cast<int>(p.pos));
+        peaksQuery->bind(":minpos", static_cast<int>(p.minpos));
+        peaksQuery->bind(":maxpos", static_cast<int>(p.maxpos));
+        peaksQuery->bind(":rt", p.rt);
+        peaksQuery->bind(":rtmin", p.rtmin);
+        peaksQuery->bind(":rtmax", p.rtmax);
+        peaksQuery->bind(":mzmin", p.mzmin);
+        peaksQuery->bind(":mzmax", p.mzmax);
+        peaksQuery->bind(":scan", static_cast<int>(p.scan));
+        peaksQuery->bind(":minscan", static_cast<int>(p.minscan));
+        peaksQuery->bind(":maxscan", static_cast<int>(p.maxscan));
+        peaksQuery->bind(":peak_area", p.peakArea);
+        peaksQuery->bind(":peak_area_corrected", p.peakAreaCorrected);
+        peaksQuery->bind(":peak_area_top", p.peakAreaTop);
+        peaksQuery->bind(":peak_area_fractional", p.peakAreaFractional);
+        peaksQuery->bind(":peak_rank", p.peakRank);
+        peaksQuery->bind(":peak_intensity", p.peakIntensity);
+        peaksQuery->bind(":peak_baseline_level", p.peakBaseLineLevel);
+        peaksQuery->bind(":peak_mz", p.peakMz);
+        peaksQuery->bind(":median_mz", p.medianMz);
+        peaksQuery->bind(":base_mz", p.baseMz);
+        peaksQuery->bind(":quality", p.quality);
+        peaksQuery->bind(":width", static_cast<int>(p.width));
+        peaksQuery->bind(":gauss_fit_sigma", p.gaussFitSigma);
+        peaksQuery->bind(":gauss_fit_r2", p.gaussFitR2);
+        peaksQuery->bind(":no_noise_obs", static_cast<int>(p.noNoiseObs));
+        peaksQuery->bind(":no_noise_fraction", p.noNoiseFraction);
+        peaksQuery->bind(":symmetry", p.symmetry);
+        peaksQuery->bind(":signal_baseline_ratio", p.signalBaselineRatio);
+        peaksQuery->bind(":group_overlap", p.groupOverlap);
+        peaksQuery->bind(":group_overlap_frac", p.groupOverlapFrac);
+        peaksQuery->bind(":local_max_flag", p.localMaxFlag);
+        peaksQuery->bind(":from_blank_sample", p.fromBlankSample);
+        peaksQuery->bind(":label", string(1, p.label));
+
+        if (!peaksQuery->execute())
+            cerr << "Error: failed to write peak" << endl;
+    }
+
+    _connection->commit();
+}
+
+void ProjectDatabase::saveCompounds(const vector<PeakGroup>& groups)
+{
+    set<Compound*> seenCompounds;
+
+    //find linked compounds (store only unique ones)
+    for(auto group: groups) {
+        if (group.compound)
+            seenCompounds.insert(group.compound);
+    }
+
+    saveCompounds(seenCompounds);
+}
+
+void ProjectDatabase::saveCompounds(const set<Compound*>& seenCompounds)
+{
+    if (!_connection->prepare(CREATE_COMPOUNDS_TABLE)->execute()) {
+        cerr << "Error: failed to create compounds table" << endl;
+        return;
+    }
+
+    if (!_connection->prepare(CREATE_COMPOUNDS_DB_INDEX)->execute())
+        cerr << "Warning: failed to create index on compounds table" << endl;
+
+    auto compoundsQuery = _connection->prepare(
+        "REPLACE INTO compounds                \
+               VALUES ( :compound_id           \
+                      , :db_name               \
+                      , :name                  \
+                      , :formula               \
+                      , :smile_string          \
+                      , :srm_id                \
+                      , :mass                  \
+                      , :charge                \
+                      , :expected_rt           \
+                      , :precursor_mz          \
+                      , :product_mz            \
+                      , :collision_energy      \
+                      , :log_p                 \
+                      , :virtual_fragmentation \
+                      , :ionization_mode       \
+                      , :category              \
+                      , :fragment_mzs          \
+                      , :fragment_intensity    )");
+
+    for (Compound* c : seenCompounds) {
+        stringstream categories;
+        for (string s : c->category) {
+            categories << s.c_str() << ";";
+        }
+        string catStr = categories.str();
+        catStr = catStr.substr(0, catStr.size() - 1);
+
+        stringstream fragMz;
+        for (float f : c->fragment_mzs) {
+            fragMz << fixed << setprecision(5) << f << ";";
+        }
+        string fragMzStr = fragMz.str();
+        fragMzStr = fragMzStr.substr(0, fragMzStr.size() - 1);
+
+        stringstream fragIntensity;
+        for (float f : c->fragment_intensity) {
+            fragIntensity << fixed << setprecision(5) << f << ";";
+        }
+        string fragIntensityStr = fragIntensity.str();
+        fragIntensityStr = fragIntensityStr.substr(0,
+                                                   fragIntensityStr.size() - 1);
+
+        compoundsQuery->bind(":compound_id", c->id);
+        compoundsQuery->bind(":db_name", c->db);
+        compoundsQuery->bind(":name", c->name);
+        compoundsQuery->bind(":formula", c->formula);
+        compoundsQuery->bind(":smile_string", c->smileString);
+        compoundsQuery->bind(":srm_id", c->srmId);
+
+        compoundsQuery->bind(":mass", c->mass);
+        compoundsQuery->bind(":charge", c->charge);
+        compoundsQuery->bind(":expected_rt", c->expectedRt);
+        compoundsQuery->bind(":precursor_mz", c->precursorMz);
+        compoundsQuery->bind(":product_mz", c->productMz);
+
+        compoundsQuery->bind(":collision_energy", c->collisionEnergy);
+        compoundsQuery->bind(":log_p", c->logP);
+        compoundsQuery->bind(":virtual_fragmentation", c->virtualFragmentation);
+        compoundsQuery->bind(":ionization_mode", c->ionizationMode);
+
+        compoundsQuery->bind(":category", catStr);
+        compoundsQuery->bind(":fragment_mzs", fragMzStr);
+        compoundsQuery->bind(":fragment_intensity", fragIntensityStr);
+
+        if (!compoundsQuery->execute())
+            cerr << "Error: failed to save compound " << c->name << endl;
+    }
+
+    _connection->commit();
+}
+
+void ProjectDatabase::saveAlignment(const vector<mzSample*>& samples)
+{
+    deleteAllAlignmentData();
+
+    if (!_connection->prepare(CREATE_ALIGNMENT_TABLE)->execute())
+        cerr << "Error: failed to create alignment table" << endl;
+
+    // save new alignment
+    auto alignmentQuery = _connection->prepare(
+        "INSERT INTO alignment_rts  \
+              VALUES ( :sample_id   \
+                     , :scannum    \
+                     , :rt_original \
+                     , :rt_updated  )");
+
+    for (auto s : samples) {
+        for (auto scan : s->scans) {
+            float rt_original = scan->originalRt;
+            float rt_updated = scan->rt;
+            alignmentQuery->bind(":sample_id", s->getSampleId());
+            alignmentQuery->bind(":scannum", scan->scannum);
+            alignmentQuery->bind(":rt_original", rt_original);
+            alignmentQuery->bind(":rt_updated", rt_updated);
+
+            if (!alignmentQuery->execute())
+                cerr << "Error: failed to write alignment data" << endl;
+        }
+    }
+
+    _connection->commit();
+}
+
+void ProjectDatabase::saveScans(const vector<mzSample*>& sampleSet)
+{
+    deleteAllScans();
+
+    if(!_connection->prepare(CREATE_SCANS_TABLE)->execute()) {
+        cerr << "Error: failed to create scans table" << endl;
+        return;
+    }
+
+    auto scansQuery = _connection->prepare(
+        "INSERT INTO scans               \
+              VALUES ( :sample_id        \
+                     , :scan             \
+                     , :file_seek_start  \
+                     , :file_seek_end    \
+                     , :mslevel          \
+                     , :rt               \
+                     , :precursor_mz     \
+                     , :precursor_charge \
+                     , :precursor_ic     \
+                     , :precursor_purity \
+                     , :minmz            \
+                     , :maxmz            \
+                     , :data             )");
+
+    float ppm = 20;
+    for (auto s : sampleSet) {
+        for (auto scan : s->scans) {
+            if (scan->mslevel == 1)
+                continue;
+
+            string scanData = _getScanSignature(scan, 2000);
+
+            scansQuery->bind(":sample_id", s->getSampleId());
+            scansQuery->bind(":scan", scan->scannum);
+            scansQuery->bind(":file_seek_start", -1);
+            scansQuery->bind(":file_seek_end", -1);
+            scansQuery->bind(":mslevel", scan->mslevel);
+            scansQuery->bind(":rt", scan->rt);
+            scansQuery->bind(":precursor_mz", scan->precursorMz);
+            scansQuery->bind(":precursor_charge", scan->precursorCharge);
+            scansQuery->bind(":precursor_ic", scan->totalIntensity());
+            scansQuery->bind(":precursor_purity", scan->getPrecursorPurity(ppm));
+            scansQuery->bind(":minmz", scan->minMz());
+            scansQuery->bind(":maxmz", scan->maxMz());
+            scansQuery->bind(":data", scanData.c_str());
+
+            if (!scansQuery->execute())
+                cerr << "Error: failed to save scan" << endl;
+        }
+    }
+
+    _connection->commit();
+}
+
+vector<string> ProjectDatabase::loadSampleNames(const vector<mzSample*> loaded)
+{
+    string projectPath = this->projectPath();
+    auto samplesQuery = _connection->prepare("SELECT filename \
+                                                FROM samples  ");
+
+    vector<string> sampleNames;
+    while (samplesQuery->next()) {
+        string filename = samplesQuery->stringValue("filename");
+
+        // skip files that have been loaded already
+        bool isLoaded = false;
+        for (auto const loadedSample : loaded) {
+            if (loadedSample->fileName == filename) {
+                isLoaded = true;
+                break;
+            }
+        }
+        if (isLoaded)
+            continue;
+
+        vector<string> possiblePaths;
+        possiblePaths.push_back(projectPath);
+        possiblePaths.push_back("./");
+        possiblePaths.push_back("../");
+        string filepath = _locateSample(filename, possiblePaths);
+
+        if (!filepath.empty()) {
+            sampleNames.push_back(filepath);
+            cerr << "Debug: Found sample: " << filepath << endl;
+        } else {
+            cerr << "Error: Could not find sample: " << filename << endl;
+        }
+    }
+    return sampleNames;
+}
+
+void ProjectDatabase::updateSamples(const vector<mzSample*> freshlyLoaded)
+{
+    string projectPath = this->projectPath();
+    auto samplesQuery = _connection->prepare("SELECT *      \
+                                                FROM samples");
+
+    while (samplesQuery->next()) {
+        string sampleName = samplesQuery->stringValue("name");
+        string setName = samplesQuery->stringValue("set_name");
+        int sampleId = samplesQuery->integerValue("sample_id");
+
+        int sampleOrder = samplesQuery->integerValue("sample_order");
+        int isSelected = samplesQuery->integerValue("is_selected");
+        float color_red = samplesQuery->floatValue("color_red");
+        float color_blue = samplesQuery->floatValue("color_blue");
+        float color_green = samplesQuery->floatValue("color_green");
+        float color_alpha = samplesQuery->floatValue("color_alpha");
+        float norml_const = samplesQuery->floatValue("norml_const");
+
+        if (norml_const == 0.0f)
+            norml_const = 1.0f;
+
+        // find current sample based on its sample name
+        mzSample* sample = nullptr;
+        for (auto const loadedSample : freshlyLoaded) {
+            if (loadedSample->sampleName == sampleName) {
+                sample = loadedSample;
+                break;
+            }
+        }
+        if (sample) {
+            sample->setSampleId(sampleId);
+            sample->setSetName(setName);
+            sample->setSampleOrder(sampleOrder);
+            sample->isSelected = isSelected;
+            sample->color[0] = color_red;
+            sample->color[1] = color_green;
+            sample->color[2] = color_blue;
+            sample->color[3] = color_alpha;
+            sample->setNormalizationConstant(norml_const);
+        }
+    }
+}
+
+vector<PeakGroup*> ProjectDatabase::loadGroups(const vector<mzSample*>& loaded)
+{
+    _connection->prepare(CREATE_PEAKS_GROUP_INDEX)->execute();
+    auto groupsQuery = _connection->prepare("SELECT *         \
+                                               FROM peakgroups");
+
+    vector<PeakGroup*> groups;
+    map<PeakGroup*, int> childParentMap;
+    while (groupsQuery->next()) {
+        PeakGroup* group = new PeakGroup();
+        group->groupId = groupsQuery->integerValue("group_id");
+        int parentGroupId = groupsQuery->integerValue("parent_group_id");
+        group->tagString = groupsQuery->stringValue("tag_string");
+        group->metaGroupId = groupsQuery->integerValue("meta_group_id");
+        group->expectedMz = groupsQuery->floatValue("expected_mz");
+        group->expectedRtDiff = groupsQuery->floatValue("expected_rt_diff");
+        group->expectedAbundance =
+            groupsQuery->floatValue("expected_abundance");
+        group->groupRank = groupsQuery->floatValue("group_rank");
+        group->label = groupsQuery->stringValue("label")[0];
+        group->ms2EventCount = groupsQuery->integerValue("ms2_event_count");
+        group->fragMatchScore.mergedScore =
+            groupsQuery->doubleValue("ms2_score");
+        group->setType(PeakGroup::GroupType(groupsQuery->integerValue("type")));
+        group->searchTableName = groupsQuery->stringValue("table_name");
+
+        string compoundId = groupsQuery->stringValue("compound_id");
+        string compoundDB = groupsQuery->stringValue("compound_db");
+        string compoundName = groupsQuery->stringValue("compound_name");
+        string adductName = groupsQuery->stringValue("adduct_name");
+
+        string srmId = groupsQuery->stringValue("srm_id");
+        if (!srmId.empty())
+            group->setSrmId(srmId);
+
+        if (!adductName.empty())
+            group->adduct = _findAdductByName(adductName);
+
+        if (!compoundId.empty()) {
+            Compound* compound = _findSpeciesById(compoundId, compoundDB);
+            if (compound) {
+                group->compound = compound;
+            } else {
+                group->tagString = compoundName
+                                  + " | "
+                                  + adductName
+                                  + " | id="
+                                  + compoundId;
+            }
+        } else if (!compoundName.empty() && !compoundDB.empty()) {
+            vector<Compound*> matches = _findSpeciesByName(compoundName,
+                                                           compoundDB);
+            if (matches.size() > 0)
+                group->compound = matches[0];
+        }
+
+        loadGroupPeaks(group, loaded);
+        group->groupStatistics();
+
+        if (parentGroupId == 0) {
+            groups.push_back(group);
+        } else {
+            childParentMap[group] = parentGroupId;
+        }
+    }
+
+    // assign parents for child groups
+    for (auto pair : childParentMap) {
+        bool foundParent = false;
+        auto child = pair.first;
+        for (auto parent : groups) {
+            if (parent->groupId == pair.second) {
+                parent->addChild(*child);
+                foundParent = true;
+                break;
+            }
+        }
+        // failed to find a parent group, become a parent
+        if (!foundParent)
+            groups.push_back(child);
+    }
+
+
+    cerr << "Debug: Read in " << groups.size() << " groups" << endl;
+    return groups;
+}
+
+void ProjectDatabase::loadGroupPeaks(PeakGroup* parentGroup,
+                                     const vector<mzSample*>& loaded)
+{
+    auto peaksQuery = _connection->prepare(
+                "SELECT peaks.*                             \
+                      , samples.name AS sample_name         \
+                   FROM peaks                               \
+                      , samples                             \
+                  WHERE peaks.sample_id = samples.sample_id \
+                    AND peaks.group_id = :parent_group_id   ");
+    peaksQuery->bind(":parent_group_id", parentGroup->groupId);
+
+    while (peaksQuery->next()) {
+        Peak peak;
+        peak.pos = static_cast<unsigned int>(peaksQuery->integerValue("pos"));
+        peak.minpos =
+            static_cast<unsigned int>(peaksQuery->integerValue("minpos"));
+        peak.maxpos =
+            static_cast<unsigned int>(peaksQuery->integerValue("maxpos"));
+        peak.rt = peaksQuery->floatValue("rt");
+        peak.rtmin = peaksQuery->floatValue("rtmin");
+        peak.rtmax = peaksQuery->floatValue("rtmax");
+        peak.mzmin = peaksQuery->floatValue("mzmin");
+        peak.mzmax = peaksQuery->floatValue("mzmax");
+        peak.scan = static_cast<unsigned int>(peaksQuery->integerValue("scan"));
+        peak.minscan =
+            static_cast<unsigned int>(peaksQuery->integerValue("minscan"));
+        peak.maxscan =
+            static_cast<unsigned int>(peaksQuery->integerValue("maxscan"));
+        peak.peakArea = peaksQuery->floatValue("peak_area");
+        peak.peakAreaCorrected = peaksQuery->floatValue("peak_area_corrected");
+        peak.peakAreaTop = peaksQuery->floatValue("peak_area_top");
+        peak.peakAreaFractional =
+            peaksQuery->floatValue("peak_area_fractional");
+        peak.peakRank = peaksQuery->floatValue("peak_rank");
+        peak.peakIntensity = peaksQuery->floatValue("peak_intensity");
+        peak.peakBaseLineLevel = peaksQuery->floatValue("peak_baseline_level");
+        peak.peakMz = peaksQuery->floatValue("peak_mz");
+        peak.medianMz = peaksQuery->floatValue("median_mz");
+        peak.baseMz = peaksQuery->floatValue("base_mz");
+        peak.quality = peaksQuery->floatValue("quality");
+        peak.width =
+            static_cast<unsigned int>(peaksQuery->integerValue("width"));
+        peak.gaussFitSigma = peaksQuery->floatValue("gauss_fit_sigma");
+        peak.gaussFitR2 = peaksQuery->floatValue("gauss_fit_r2");
+        peak.groupNum = peaksQuery->integerValue("group_id");
+        peak.noNoiseObs =
+            static_cast<unsigned int>(peaksQuery->integerValue("no_noise_obs"));
+        peak.noNoiseFraction = peaksQuery->floatValue("no_noise_fraction");
+        peak.symmetry = peaksQuery->floatValue("symmetry");
+        peak.signalBaselineRatio =
+            peaksQuery->floatValue("signal_baseline_ratio");
+        peak.groupOverlap = peaksQuery->floatValue("group_overlap");
+        peak.groupOverlapFrac = peaksQuery->floatValue("group_overlap_frac");
+        peak.localMaxFlag = peaksQuery->integerValue("local_max_flag");
+        peak.fromBlankSample = peaksQuery->integerValue("from_blank_sample");
+        peak.label = peaksQuery->stringValue("label")[0];
+
+        string sampleName = peaksQuery->stringValue("sample_name");
+
+        for (auto sample : loaded) {
+            if (sample->sampleName == sampleName) {
+                peak.setSample(sample);
+                break;
+            }
+        }
+        parentGroup->addPeak(peak);
+    }
+}
+
+vector<Compound*> ProjectDatabase::loadCompounds(const string databaseName)
+{
+    vector<Compound*> compounds;
+    if (!databaseName.empty() && _compoundDatabaseLoaded(databaseName)) {
+        cerr << "Debug: already loaded database " << databaseName << endl;
+        return compounds;
+    }
+
+    string selectStatement = "SELECT *                      \
+                                FROM compounds              ";
+    if (!databaseName.empty())
+        selectStatement += "   WHERE db_name= :database_name";
+
+    auto compoundsQuery = _connection->prepare(selectStatement);
+    compoundsQuery->bind(":database_name", databaseName);
+
+    MassCalculator mcalc;
+    int loadCount = 0;
+    while (compoundsQuery->next()) {
+        string id = compoundsQuery->stringValue("compound_id");
+        string name = compoundsQuery->stringValue("name");
+        string formula = compoundsQuery->stringValue("formula");
+        int charge = compoundsQuery->integerValue("charge");
+        float mass = compoundsQuery->floatValue("mass");
+        string db = compoundsQuery->stringValue("db_name");
+        float expectedRt = compoundsQuery->floatValue("expected_rt");
+
+        // skip if compound already exists in internal database
+        if (_compoundIdMap.find(id + db) != end(_compoundIdMap))
+            continue;
+
+        // the neutral mass is computed automatically inside the constructor
+        Compound* compound = new Compound(id, name, formula, charge);
+        compound->db = db;
+        compound->expectedRt = expectedRt;
+
+        if (formula.empty()) {
+            if (mass > 0)
+                compound->mass = mass;
+        } else {
+            compound->mass =
+                    static_cast<float>(mcalc.computeNeutralMass(formula));
+        }
+
+        compound->precursorMz = compoundsQuery->floatValue("precursor_mz");
+        compound->productMz = compoundsQuery->floatValue("product_mz");
+        compound->collisionEnergy =
+                compoundsQuery->floatValue("collision_energy");
+        compound->smileString = compoundsQuery->stringValue("smile_string");
+
+        // mark compound as decoy if names contains DECOY string
+        if (compound->name.find("DECOY") > 0)
+            compound->isDecoy = true;
+
+        // lambda function to split a string using given delimiters
+        auto split = [](string str, const char delim) {
+            vector<string> separated;
+            stringstream ss(str);
+            string item;
+            while(getline(ss, item, delim))
+                separated.push_back(item);
+            return separated;
+        };
+
+        string categories = compoundsQuery->stringValue("category");
+        for (auto category : split(categories, ';')) {
+            if (!category.empty())
+                compound->category.push_back(category);
+        }
+
+        string fragment_mzs = compoundsQuery->stringValue("fragment_mzs");
+        for (string frag_mz : split(fragment_mzs, ';')) {
+            if (!frag_mz.empty())
+                compound->fragment_mzs.push_back(stof(frag_mz));
+        }
+
+        string fragment_intensities =
+                compoundsQuery->stringValue("fragment_intensity");
+        for (string frag_intensity : split(fragment_intensities, ';')) {
+            if (!frag_intensity.empty())
+                compound->fragment_intensity.push_back(stof(frag_intensity));
+        }
+
+        _compoundIdMap[compound->id + compound->db] = compound;
+        compounds.push_back(compound);
+        loadCount++;
+    }
+
+    sort(compounds.begin(), compounds.end(), Compound::compMass);
+    cerr << "Loaded: " << loadCount << " compounds" << endl;
+    if (loadCount > 0 and !databaseName.empty())
+        _loadedCompoundDatabases.push_back(databaseName);
+
+    return compounds;
+}
+
+void ProjectDatabase::loadAndPerformAlignment(const vector<mzSample*>& loaded)
+{
+    auto alignmentQuery = _connection->prepare(
+        "SELECT samples.name AS sample_name                \
+              , alignment_rts.*                            \
+           FROM alignment_rts                              \
+              , samples                                    \
+          WHERE samples.sample_id = alignment_rts.sample_id");
+
+    map<int, map<int, Scan*>> sampleScanMap;
+    for (auto sample : loaded) {
+        map<int, Scan*> scanMap;
+        for (auto scan : sample->scans) {
+            scanMap[scan->scannum] = scan;
+        }
+        sampleScanMap[sample->getSampleId()] = scanMap;
+    }
+
+    while (alignmentQuery->next()) {
+        string sampleName = alignmentQuery->stringValue("sample_name");
+        int sampleId = alignmentQuery->integerValue("sample_id");
+        if (!sampleScanMap.count(sampleId)) {
+            cerr << "Error: no sample with id " << sampleId << " found" << endl;
+            continue;
+        }
+
+        int scannum = alignmentQuery->integerValue("scannum");
+        auto scanMap = sampleScanMap[sampleId];
+        if (!scanMap.count(scannum)) {
+            cerr << "Error: no scan with scannum " << sampleId << endl;
+            continue;
+        }
+
+        Scan* scan = scanMap[scannum];
+        scan->rt = alignmentQuery->floatValue("rt_updated");
+        scan->originalRt = alignmentQuery->floatValue("rt_original");
+    }
+}
+
+void ProjectDatabase::deleteAll()
+{
+    deleteAllSamples();
+    deleteAllCompounds();
+    deleteAllGroupsAndPeaks();
+    deleteAllScans();
+    deleteAllAlignmentData();
+}
+
+void ProjectDatabase::deleteAllSamples()
+{
+    _connection->prepare("DROP TABLE samples")->execute();
+    _connection->commit();
+}
+
+void ProjectDatabase::deleteAllCompounds()
+{
+    _connection->prepare("DROP TABLE compounds")->execute();
+    _connection->commit();
+}
+
+void ProjectDatabase::deleteAllGroupsAndPeaks()
+{
+    _connection->prepare("DROP TABLE peaks")->execute();
+    _connection->prepare("DROP TABLE peakgroups")->execute();
+    _connection->commit();
+}
+
+void ProjectDatabase::deleteAllScans()
+{
+    _connection->prepare("DROP TABLE scans")->execute();
+    _connection->commit();
+}
+
+void ProjectDatabase::deleteAllAlignmentData()
+{
+    _connection->prepare("DROP TABLE alignment_rts")->execute();
+    _connection->commit();
+}
+
+void ProjectDatabase::deleteCompoundsForDB(const string& dbName)
+{
+    // create index based on database name.
+    _connection->prepare(CREATE_COMPOUNDS_DB_INDEX)->execute();
+
+    auto compoundsQuery = _connection->prepare(
+                "DELETE FROM compounds              \
+                       WHERE db_name = :database_name");
+    compoundsQuery->bind(":database_name", dbName);
+    if (!compoundsQuery->execute())
+        cerr << "Error: failed to delete compounds for db " << dbName << endl;
+
+    _connection->commit();
+}
+
+void ProjectDatabase::deleteTableGroups(const string& tableName)
+{
+    auto failure = false;
+    auto peaksQuery = _connection->prepare(
+        "DELETE FROM peaks                                       \
+               WHERE group_id IN (SELECT group_id                \
+                                    FROM peakgroups              \
+                                   WHERE table_name = :table_name");
+    peaksQuery->bind(":table_name", tableName);
+    if (!peaksQuery->execute()) {
+        failure = true;
+        cerr << "Error: failed to delete peaks for search table "
+             << tableName << endl;
+    }
+
+    auto peakgroupsQuery = _connection->prepare(
+        "DELETE FROM peakgroups             \
+               WHERE tableName = :table_name");
+    peakgroupsQuery->bind(":table_name", tableName);
+    if(!peakgroupsQuery->execute()) {
+        failure = true;
+        cerr << "Error: failed to delete peak groups for search table "
+             << tableName << endl;
+    }
+
+    // do not commit if peak or group deletion was unsuccessful
+    if (failure) {
+        _connection->rollback();
+        return;
+    }
+
+    _connection->commit();
+}
+
+void ProjectDatabase::deletePeakGroup(PeakGroup* group)
+{
+    if (!group)
+        return;
+
+    vector<int> selectedGroups;
+    selectedGroups.push_back(group->groupId);
+    for (const auto& child : group->children)
+        selectedGroups.push_back(child.groupId);
+
+    if (selectedGroups.size() == 0)
+        return;
+
+    auto peakgroupsQuery = _connection->prepare(
+                "DELETE FROM peakgroups          \
+                       WHERE group_id = :group_id");
+
+    auto peaksQuery = _connection->prepare(
+                "DELETE FROM peaks               \
+                       WHERE group_id = :group_id");
+
+    for (auto id : selectedGroups) {
+        peakgroupsQuery->bind(":group_id", id);
+        peaksQuery->bind(":group_id", id);
+
+        if (!peaksQuery->execute()) {
+            cerr << "Error: while deleting peaks" << endl;
+            _connection->rollback();
+            return;
+        }
+
+        if (!peakgroupsQuery->execute()) {
+            cerr << "Error: while deleting peakgroups" << endl;
+            _connection->rollback();
+            return;
+        }
+    }
+
+    _connection->commit();
+}
+
+vector<string> ProjectDatabase::getTableNames()
+{
+    auto query = _connection->prepare(
+        "SELECT DISTINCT table_name \
+                    FROM peakgroups ");
+
+    vector<string> dbNames;
+    while (query->next()) {
+        auto dbName = query->stringValue("table_name");
+        if (!dbName.empty())
+            dbNames.push_back(dbName);
+    }
+    return dbNames;
+}
+
+string ProjectDatabase::projectPath()
+{
+    string databaseFile = _connection->dbPath();
+    boost::filesystem::path path(databaseFile);
+    return path.parent_path().native();
+}
+
+string ProjectDatabase::projectName()
+{
+    string databaseFile = _connection->dbPath();
+    boost::filesystem::path path(databaseFile);
+    return path.filename().string();
+}
+
+void ProjectDatabase::_assignSampleIds(const vector<mzSample*>& samples) {
+    int maxSampleId = -1;
+    for (auto sample : samples)
+        if (sample->getSampleId() > maxSampleId)
+            maxSampleId = sample->getSampleId();
+
+    // this is the first sample to be assigned
+    if (maxSampleId == -1)
+        maxSampleId = 0;
+
+    for (auto sample : samples) {
+        if (sample->getSampleId() == -1)
+            sample->setSampleId(maxSampleId++);
+        cerr << "Debug: assigned "
+             << sample->sampleName
+             << "\t with ID "
+             << sample->getSampleId()
+             << endl;
+    }
+}
+
+Adduct* ProjectDatabase::_findAdductByName(string id)
+{
+    if (id == "[M+H]+")
+        return MassCalculator::PlusHAdduct;
+    else if (id == "[M-H]-")
+        return MassCalculator::MinusHAdduct;
+    else if (id == "[M]")
+        return MassCalculator::ZeroMassAdduct;
+    return nullptr;
+}
+
+Compound* ProjectDatabase::_findSpeciesById(string id, string databaseName)
+{
+    // load compounds from database if not already loaded.
+    if (!databaseName.empty() && !_compoundDatabaseLoaded(databaseName))
+        loadCompounds(databaseName);
+
+    if (_compoundIdMap.count(id + databaseName))
+        return _compoundIdMap[id + databaseName];
+    if (_compoundIdMap.count(id))
+        return _compoundIdMap[id];
+    return nullptr;
+}
+
+vector<Compound*> ProjectDatabase::_findSpeciesByName(string name,
+                                                      string databaseName)
+{
+    if (!databaseName.empty() && !_compoundDatabaseLoaded(databaseName))
+        loadCompounds(databaseName);
+
+    vector<Compound*> similarlyNamedCompounds;
+    for (const auto& key : _compoundIdMap) {
+        Compound* compound = key.second;
+        if (compound->name == name && compound->db == databaseName)
+            similarlyNamedCompounds.push_back(compound);
+    }
+    return similarlyNamedCompounds;
+}
+
+bool ProjectDatabase::_compoundDatabaseLoaded(string databaseName)
+{
+    auto beginning = begin(_loadedCompoundDatabases);
+    auto ending = end(_loadedCompoundDatabases);
+    if (find(beginning, ending, databaseName) != ending)
+        return true;
+    return false;
+}
+
+string ProjectDatabase::_getScanSignature(Scan* scan, int limitSize)
+{
+    stringstream signature;
+    map<int, bool> seen;
+    int mz_count = 0;
+    for (auto posIndex : scan->intensityOrderDesc()) {
+        size_t pos = static_cast<unsigned int>(posIndex);
+        int mzround = static_cast<int>(scan->mz[pos]);
+        if (!seen.count(mzround)) {
+            signature << "[" << setprecision(9)
+                      << scan->mz[pos] << ","
+                      << scan->intensity[pos] << "]";
+            seen[mzround] = true;
+        }
+
+        if (mz_count++ >= limitSize)
+            break;
+    }
+    return signature.str();
+}
+
+string ProjectDatabase::_locateSample(const string filepath,
+                     const vector<string>& pathlist)
+{
+    // found file, all is good
+    boost::filesystem::path sampleFile(filepath);
+    if (boost::filesystem::exists(sampleFile))
+        return filepath;
+
+    // search for file
+    string fileName = sampleFile.filename().string();
+    for (auto& path : pathlist) {
+        boost::filesystem::path possiblePath(path);
+        auto filepath = possiblePath.append(fileName);
+        if (boost::filesystem::exists(filepath))
+            return filepath.native();
+    }
+    return "";
+}

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -46,6 +46,8 @@ void ProjectDatabase::saveSamples(const vector<mzSample*>& samples)
                       , :transform_a4 \
                       , :transform_a5 )");
 
+    _connection->begin();
+
     for (auto s : samples) {
         samplesQuery->bind(":sample_id", s->getSampleId());
         samplesQuery->bind(":name", s->getSampleName());
@@ -78,8 +80,12 @@ void ProjectDatabase::saveSamples(const vector<mzSample*>& samples)
 void ProjectDatabase::saveGroups(const vector<PeakGroup*>& groups,
                                  const string& tableName)
 {
+    _connection->begin();
+
     for (const auto group : groups)
         saveGroupAndPeaks(group, 0, tableName);
+
+    _connection->commit();
 }
 
 int ProjectDatabase::saveGroupAndPeaks(PeakGroup* group,
@@ -152,7 +158,6 @@ int ProjectDatabase::saveGroupAndPeaks(PeakGroup* group,
     for (auto child: group->children)
         saveGroupAndPeaks(&child, lastInsertedGroupId, tableName);
 
-    _connection->commit();
     return lastInsertedGroupId;
 }
 
@@ -244,8 +249,6 @@ void ProjectDatabase::saveGroupPeaks(PeakGroup* group, const int groupId)
         if (!peaksQuery->execute())
             cerr << "Error: failed to write peak" << endl;
     }
-
-    _connection->commit();
 }
 
 void ProjectDatabase::saveCompounds(const vector<PeakGroup>& groups)
@@ -291,6 +294,8 @@ void ProjectDatabase::saveCompounds(const set<Compound*>& seenCompounds)
                       , :category              \
                       , :fragment_mzs          \
                       , :fragment_intensity    )");
+
+    _connection->begin();
 
     for (Compound* c : seenCompounds) {
         stringstream categories;
@@ -359,6 +364,8 @@ void ProjectDatabase::saveAlignment(const vector<mzSample*>& samples)
                      , :rt_original \
                      , :rt_updated  )");
 
+    _connection->begin();
+
     for (auto s : samples) {
         for (auto scan : s->scans) {
             float rt_original = scan->originalRt;
@@ -400,6 +407,8 @@ void ProjectDatabase::saveScans(const vector<mzSample*>& sampleSet)
                      , :minmz            \
                      , :maxmz            \
                      , :data             )");
+
+    _connection->begin();
 
     float ppm = 20;
     for (auto s : sampleSet) {

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -1070,7 +1070,7 @@ string ProjectDatabase::_locateSample(const string filepath,
     string fileName = sampleFile.filename().string();
     for (auto& path : pathlist) {
         boost::filesystem::path possiblePath(path);
-        auto filepath = possiblePath.append(fileName);
+        auto filepath = possiblePath / fileName;
         if (boost::filesystem::exists(filepath))
             return filepath.native();
     }

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -169,44 +169,45 @@ void ProjectDatabase::saveGroupPeaks(PeakGroup* group, const int groupId)
     }
 
     auto peaksQuery = _connection->prepare(
-        "INSERT INTO peaks                    \
-              VALUES ( :peak_id               \
-                     , :group_id              \
-                     , :sample_id             \
-                     , :pos                   \
-                     , :minpos                \
-                     , :maxpos                \
-                     , :rt                    \
-                     , :rtmin                 \
-                     , :rtmax                 \
-                     , :mzmin                 \
-                     , :mzmax                 \
-                     , :scan                  \
-                     , :minscan               \
-                     , :maxscan               \
-                     , :peak_area             \
-                     , :peak_area_corrected   \
-                     , :peak_area_top         \
-                     , :peak_area_fractional  \
-                     , :peak_rank             \
-                     , :peak_intensity        \
-                     , :peak_baseline_level   \
-                     , :peak_mz               \
-                     , :median_mz             \
-                     , :base_mz               \
-                     , :quality               \
-                     , :width                 \
-                     , :gauss_fit_sigma       \
-                     , :gauss_fit_r2          \
-                     , :no_noise_obs          \
-                     , :no_noise_fraction     \
-                     , :symmetry              \
-                     , :signal_baseline_ratio \
-                     , :group_overlap         \
-                     , :group_overlap_frac    \
-                     , :local_max_flag        \
-                     , :from_blank_sample     \
-                     , :label                 )");
+        "INSERT INTO peaks                      \
+              VALUES ( :peak_id                 \
+                     , :group_id                \
+                     , :sample_id               \
+                     , :pos                     \
+                     , :minpos                  \
+                     , :maxpos                  \
+                     , :rt                      \
+                     , :rtmin                   \
+                     , :rtmax                   \
+                     , :mzmin                   \
+                     , :mzmax                   \
+                     , :scan                    \
+                     , :minscan                 \
+                     , :maxscan                 \
+                     , :peak_area               \
+                     , :peak_area_corrected     \
+                     , :peak_area_top           \
+                     , :peak_area_top_corrected \
+                     , :peak_area_fractional    \
+                     , :peak_rank               \
+                     , :peak_intensity          \
+                     , :peak_baseline_level     \
+                     , :peak_mz                 \
+                     , :median_mz               \
+                     , :base_mz                 \
+                     , :quality                 \
+                     , :width                   \
+                     , :gauss_fit_sigma         \
+                     , :gauss_fit_r2            \
+                     , :no_noise_obs            \
+                     , :no_noise_fraction       \
+                     , :symmetry                \
+                     , :signal_baseline_ratio   \
+                     , :group_overlap           \
+                     , :group_overlap_frac      \
+                     , :local_max_flag          \
+                     , :from_blank_sample       \
+                     , :label                   )");
 
     for (Peak p : group->peaks) {
         peaksQuery->bind(":group_id", groupId);
@@ -225,6 +226,7 @@ void ProjectDatabase::saveGroupPeaks(PeakGroup* group, const int groupId)
         peaksQuery->bind(":peak_area", p.peakArea);
         peaksQuery->bind(":peak_area_corrected", p.peakAreaCorrected);
         peaksQuery->bind(":peak_area_top", p.peakAreaTop);
+        peaksQuery->bind(":peak_area_top_corrected", p.peakAreaTopCorrected);
         peaksQuery->bind(":peak_area_fractional", p.peakAreaFractional);
         peaksQuery->bind(":peak_rank", p.peakRank);
         peaksQuery->bind(":peak_intensity", p.peakIntensity);
@@ -645,6 +647,8 @@ void ProjectDatabase::loadGroupPeaks(PeakGroup* parentGroup,
         peak.peakArea = peaksQuery->floatValue("peak_area");
         peak.peakAreaCorrected = peaksQuery->floatValue("peak_area_corrected");
         peak.peakAreaTop = peaksQuery->floatValue("peak_area_top");
+        peak.peakAreaTopCorrected =
+            peaksQuery->floatValue("peak_area_top_corrected");
         peak.peakAreaFractional =
             peaksQuery->floatValue("peak_area_fractional");
         peak.peakRank = peaksQuery->floatValue("peak_rank");

--- a/src/projectDB/projectdatabase.h
+++ b/src/projectDB/projectdatabase.h
@@ -45,9 +45,13 @@ public:
     void saveSamples(const vector<mzSample*>& samples);
 
     /**
-     * @brief Save a given ser of peak groups.
+     * @brief Save a given set of peak groups.
      * @details For each group, this method calls `saveGroupAndPeaks. The peaks
-     * associated with every group are also saved.
+     * associated with every group are also saved. A major advantage of using
+     * this method over simply calling `saveGroupAndPeaks` within a loop is that
+     * all groups and their peaks are saved using a database transaction making
+     * the bulk write performance orders of magnitude better. This method
+     * is preferable when there is a need to write multiple peak groups.
      * @param groups A vector of pointers to PeakGroup objects to be saved.
      * @param tableName An optional parameter to save table name for groups.
      */

--- a/src/projectDB/projectdatabase.h
+++ b/src/projectDB/projectdatabase.h
@@ -1,0 +1,344 @@
+#ifndef PROJECTDATABASE_H
+#define PROJECTDATABASE_H
+
+#include <iostream>
+#include <map>
+#include <set>
+#include <vector>
+
+class Adduct;
+class Compound;
+class Connection;
+class mzSample;
+class PeakGroup;
+class Scan;
+
+using namespace std;
+
+/**
+ * @brief The ProjectDatabase class is the main interface meant to be used by
+ * applications to save/load project (session) data.
+ */
+class ProjectDatabase {
+
+public:
+    /**
+     * @brief Create a ProjectDatabase instance and connect to the database.
+     * @param dbFilename Absolute filename for the database file to be used.
+     */
+    ProjectDatabase(const string& dbFilename);
+
+    /**
+      * @brief Destroy the object and close database connection.
+      */
+    ~ProjectDatabase();
+
+    /**
+     * @brief Save information for a given set of samples.
+     * @details Consequently, each sample saved is also assigned a unique ID.
+     * Only samples with this ID should be used further to save peak groups,
+     * peaks, scans and alignment information, since they are inherently
+     * related to these samples and the relation will be stored as such.
+     * @param samples A vector of ponters to mzSample objects.
+     */
+    void saveSamples(const vector<mzSample*>& samples);
+
+    /**
+     * @brief Save a given ser of peak groups.
+     * @details For each group, this method calls `saveGroupAndPeaks. The peaks
+     * associated with every group are also saved.
+     * @param groups A vector of pointers to PeakGroup objects to be saved.
+     * @param tableName An optional parameter to save table name for groups.
+     */
+    void saveGroups(const vector<PeakGroup*>& groups,
+                    const string& tableName="");
+
+    /**
+     * @brief Save the given peak group, its sub-groups and their peaks
+     * @details After calling this method with a peak group, the user does not
+     * need to make extra calls to `saveGroupPeaks` for saving peaks of the
+     * peak group. Similarly, the user need not call this again for saving
+     * child groups for a group. The method recursively calls itself to save
+     * the sub-groups (and their peaks) of the parent group provided.
+     * @param group The PeakGroup which has to be saved, along with its
+     * children and their collective set of Peak objects.
+     * @param parentGroupId The group ID of the parent group, if any. Default
+     * value of this parameter is 0 (for top-level groups).
+     * @param tableName An optional parameter to save table name for the group.
+     * @return An integer ID for the group saved.
+     */
+    int saveGroupAndPeaks(PeakGroup* group,
+                          const int parentGroupId=0,
+                          const string& tableName="");
+
+    /**
+     * @brief Save peaks for the given group.
+     * @param group The peak group whose peaks need to be saved.
+     * @param groupId The group ID for the group (as saved in the database).
+     */
+    void saveGroupPeaks(PeakGroup* group, const int groupId);
+
+    /**
+     * @brief Save compounds linked to a given set of groups.
+     * @details This method filters out the total pool of Compound objects from
+     * the given peak groups ans sends only the unique ones to be saved by the
+     * an overloaded counterpart that takes in a set of compounds.
+     * @param groups A vector of pointers to PeakGroup objects.
+     */
+    void saveCompounds(const vector<PeakGroup>& groups);
+
+    /**
+     * @brief Save a set of Compound objets.
+     * @details This method uses a "REPLACE" SQL statement to ensure that
+     * repeated primary keys are replaced and only one entry for a unique
+     * Compound is saved.
+     * @param seenCompounds A set of pointers to Compound objects.
+     */
+    void saveCompounds(const set<Compound*>& seenCompounds);
+
+    /**
+     * @brief Save alignment data for all scans in all given samples.
+     * @param samples A vector of pointers to mzSample objects whose alignment
+     * data needs to be saved. These samples should already have a unique ID.
+     */
+    void saveAlignment(const vector<mzSample*>& samples);
+
+    /**
+     * @brief Save some information about the scans of a set of samples.
+     * @details Although there is a save method for scans information, there is
+     * no load counterpart. So its still unclear, but this is probably used by
+     * the author (Eugene) for their downstream work using the database file.
+     * @param sampleSet A vector of pointers to mzSample objects whose scans
+     * need to be saved. These samples should already have their uniqe ID set.
+     */
+    void saveScans(const vector<mzSample*>& sampleSet);
+
+    /**
+     * @brief Load sample filenames saved in the DB from a previous session.
+     * @details The filename of the sample is saved during the save process,
+     * and that filename is used to load the sample back in (unless its already
+     * loaded). If the file no longer exists, the sample file is searched for
+     * in the project directory (i.e., path of the database file connected
+     * through this interface). Additionally, two levels of parent paths
+     * relative to the executable are also searched for the sample file. Once
+     * the samples from these filenames are loaded in, the `updateSamples`
+     * method should be used to read in attributes of the samples from the
+     * previous session.
+     * @param loaded A vector of samples that have already been loaded. These
+     * samples' names will not be returned even if they are saved in the DB.
+     * @return A vector of strings, each a filename from which a sample can be
+     * loaded.
+     */
+    vector<string> loadSampleNames(const vector<mzSample*> loaded);
+
+    /**
+     * @brief Update sample attributes saved in the DB from a previous session.
+     * @details This method should be called with the set of samples that were
+     * successfully loaded from filenames returned by `loadSampleNames` method.
+     * Equivalence will be checked on the basis of sample name, i.e., sample
+     * name should be same as saved in DB for the sample to be assigned its
+     * attributes. Attributes loaded will include a unique ID that can be used
+     * to further load related data structures like peak groups, peaks, etc.
+     * that depend on existence of these samples.
+     * @param loaded A vector of samples that have been loaded. Attributes will
+     * only be updated for these samples.
+     * @return A vector of pointers to mzSample objects that were successfully
+     * loaded.
+     */
+    void updateSamples(const vector<mzSample*> freshlyLoaded);
+
+    /**
+     * @brief Load a PeakGroup object its peaks.
+     * @details This method will also attempt to find the parent group of the
+     * loaded group and try to associate with it. If not found, the group will
+     * be added as a top-level group itself.
+     * @param loaded A vector of loaded samples which will be associated with
+     * peaks.
+     * @return A vector of PeakGroup objects that were successfully loaded.
+     */
+    vector<PeakGroup*> loadGroups(const vector<mzSample*>& loaded);
+
+    /**
+     * @brief Load peaks for a given peak group.
+     * @param group The PeakGroup for which peaks are to be loaded.
+     * @param loaded A vector of loaded mzSample objects that will be iterated
+     * through to associate each peak with.
+     */
+    void loadGroupPeaks(PeakGroup* group,
+                        const vector<mzSample*>& loaded);
+
+    /**
+     * @brief Load saved compounds from the database file.
+     * @details Each compound is checked whether it was previously loaded
+     * through another operation. If the user supplies the optional parameter
+     * `databaseName` then only compounds belonging to this DB name will be
+     * loaded (if not already loaded). Upon successful load, no compounds from
+     * this database name will be loaded through an instance of this object.
+     * @param databaseName An optional parameter to filter loading of only
+     * compounds belonging to this database.
+     * @return A vector of pointers to new Compound objects loaded.
+     */
+    vector<Compound*> loadCompounds(const string databaseName="");
+
+    /**
+     * @brief Load alignment data and perform alignment on given sameples.
+     * @details This method needs to be supplied with a vector of loaded samples
+     * and these samples must have all the samples present in the previous
+     * session. This is because alignment saves sample ID and this will be used
+     * to set the original and updated retention time values, thus preforming
+     * alignment. Having incorrect set of samples might result in misaligned
+     * peaks.
+     * @param loaded A vector of pointers to loaded samples whose scans are
+     * to be aligned. Typically, these samples will have been loaded through
+     * `loadSamples` method to ensure they all have a unique ID.
+     */
+    void loadAndPerformAlignment(const vector<mzSample*>& loaded);
+
+    /**
+     * @brief Drop all tables, deleting all data stored by any of the save
+     * methods.
+     */
+    void deleteAll();
+
+    /**
+     * @brief Drop 'samples' table, removing all information stored for samples.
+     */
+    void deleteAllSamples();
+
+    /**
+     * @brief Drop 'compounds' tables, removing all information stored about
+     * compounds.
+     */
+    void deleteAllCompounds();
+
+    /**
+     * @brief Delete 'peakgroups' and 'peaks' tables together because they are
+     * not very useful without the other.
+     */
+    void deleteAllGroupsAndPeaks();
+
+    /**
+     * @brief Drop 'scans' tables, deleting all stored scans data.
+     */
+    void deleteAllScans();
+
+    /**
+     * @brief Drop all alignment data stored.
+     */
+    void deleteAllAlignmentData();
+
+    /**
+     * @brief Delete compounds for the given database name.
+     * @param dbName Name of the database whose compounds are to be deleted.
+     */
+    void deleteCompoundsForDB(const string& dbName);
+
+    /**
+     * @brief Delete peaks and peak groups associated with a peak group table.
+     * @param tableName Name of the table whose results are to be deleted.
+     */
+    void deleteTableGroups(const string& tableName);
+
+    /**
+     * @brief Delete a given peak group and any peaks associated with it.
+     * @param group
+     */
+    void deletePeakGroup(PeakGroup* group);
+
+    /**
+     * @brief Get the names of all the peak group tables present.
+     * @return A vector of strings as names of search tables.
+     */
+    vector<string> getTableNames();
+
+    /**
+     * @brief Get the parent path for the connected database file.
+     * @return Path of DB file as a string.
+     */
+    string projectPath();
+
+    /**
+     * @brief Get the file name for the connected database file.
+     * @return Name of DB file as a string.
+     */
+    string projectName();
+
+private:
+    /**
+     * @brief _connection A Connection object mediating connection with a SQLite
+     * database.
+     */
+    Connection* _connection;
+
+    /**
+     * @brief _loadedCompoundDatabases A list of names of the compound databases
+     * that have already been loaded.
+     */
+    vector<string> _loadedCompoundDatabases;
+
+    /**
+     * @brief _compoundIdMap A map of unique ID mapping to a Compound object.
+     * This map is used to determine whether a compound has already been loaded
+     * and need not be loaded again.
+     */
+    map<string, Compound*> _compoundIdMap;
+
+    /**
+     * @brief Assign each sample in the given vector with a unique ID.
+     * @details This unique ID is extremely important in ensuring that other
+     * object information such as peaks, peaks groups, scans and alignment
+     * data are correctly stored relating to these samples.
+     * @param samples A vector of mzSample objects to be assigned with an ID.
+     */
+    void _assignSampleIds(const vector<mzSample*>& samples);
+
+    /**
+     * @brief Tries to find an Adduct object for the given ID.
+     * @param id An adduct ID for positive H, negative H or zero H adduct.
+     * @return An adduct object.
+     */
+    Adduct* _findAdductByName(string id);
+
+    /**
+     * @brief Find compound with the given ID and from the given database
+     * @param id A string ID for the compound (unique for a compound database)
+     * @param db Name of the compound database.
+     * @return A Compound object if found, otherwise nullptr.
+     */
+    Compound* _findSpeciesById(string id, string databaseName);
+
+    /**
+     * @brief Find a compound using its name.
+     * @param name A string name of the compound.
+     * @param databaseName Name of the database to search using compound name.
+     * @return A vector of compounds by the name.
+     */
+    vector<Compound*> _findSpeciesByName(string name, string databaseName);
+
+    /**
+     * @brief Checks whether compound database of the given name has already
+     * been loaded or not.
+     * @param databaseName Name of the compound database.
+     * @return true if database has already been loaded, false otherwise.
+     */
+    bool _compoundDatabaseLoaded(string databaseName);
+
+    /**
+     * @brief Attempt to create a unique scan signature for a given Scan object.
+     * @param scan A Scan object for which signature needs to be created.
+     * @param limitSize A limiting number on the length of the scan signature.
+     * @return A scan signature of the Scan as a string.
+     */
+    string _getScanSignature(Scan* scan, int limitSize);
+
+    /**
+     * @brief Find a given sample within one of the possible paths.
+     * @param filepath Full file path for the sample to be searched for.
+     * @param pathlist A list of paths where the sample will be searched for.
+     * @return The path of the sample if found or an empty string otherwise.
+     */
+    string _locateSample(const string filepath,
+                         const vector<string>& pathlist);
+};
+
+#endif // PROJECTDATABASE_H

--- a/src/projectDB/projectdatabase.h
+++ b/src/projectDB/projectdatabase.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <map>
 #include <set>
+#include <utility>
 #include <vector>
 
 class Adduct;
@@ -116,20 +117,22 @@ public:
     /**
      * @brief Load sample filenames saved in the DB from a previous session.
      * @details The filename of the sample is saved during the save process,
-     * and that filename is used to load the sample back in (unless its already
-     * loaded). If the file no longer exists, the sample file is searched for
-     * in the project directory (i.e., path of the database file connected
-     * through this interface). Additionally, two levels of parent paths
-     * relative to the executable are also searched for the sample file. Once
-     * the samples from these filenames are loaded in, the `updateSamples`
-     * method should be used to read in attributes of the samples from the
-     * previous session.
+     * and that filename should be used to load the sample back in. If the file
+     * no longer exists, the sample file is searched for in the project
+     * directory (i.e., path of the database file connected through this
+     * interface). Additionally, two levels of parent paths relative to the
+     * executable are also searched for the sample file. If the files are still
+     * not found, they are returned in a second vector. Once the samples from
+     * these filenames are loaded in, the `updateSamples` method can be used to
+     * read in attributes of the samples from the previous session.
      * @param loaded A vector of samples that have already been loaded. These
      * samples' names will not be returned even if they are saved in the DB.
-     * @return A vector of strings, each a filename from which a sample can be
-     * loaded.
+     * @return A pair of string vectors, the first containing filenames of
+     * samples that were found and the second containing filenames of samples
+     * that were not automatically found.
      */
-    vector<string> loadSampleNames(const vector<mzSample*> loaded);
+    pair<vector<string>, vector<string>>
+    getSampleNames(const vector<mzSample*> loaded);
 
     /**
      * @brief Update sample attributes saved in the DB from a previous session.

--- a/src/projectDB/schema.h
+++ b/src/projectDB/schema.h
@@ -1,0 +1,132 @@
+#ifndef SCHEMA_H
+#define SCHEMA_H
+
+#define CREATE_SAMPLES_TABLE \
+    "CREATE TABLE IF NOT EXISTS samples ( sample_id    INTEGER PRIMARY KEY AUTOINCREMENT \
+                                        , name         TEXT                              \
+                                        , filename     TEXT                              \
+                                        , set_name     TEXT                              \
+                                        , sample_order INTEGER                           \
+                                        , is_selected  INTEGER                           \
+                                        , color_red    REAL                              \
+                                        , color_green  REAL                              \
+                                        , color_blue   REAL                              \
+                                        , color_alpha  REAL                              \
+                                        , norml_const  REAL                              \
+                                        , transform_a0 REAL                              \
+                                        , transform_a1 REAL                              \
+                                        , transform_a2 REAL                              \
+                                        , transform_a4 REAL                              \
+                                        , transform_a5 REAL                              );"
+
+#define CREATE_SCANS_TABLE \
+    "CREATE TABLE IF NOT EXISTS scans ( id               INTEGER PRIMARY KEY AUTOINCREMENT \
+                                      , sample_id        INTEGER NOT NULL                  \
+                                      , scan             INTEGER NOT NULL                  \
+                                      , file_seek_start  INTEGER NOT NULL                  \
+                                      , file_seek_end    INTEGER NOT NULL                  \
+                                      , mslevel          INTEGER NOT NULL                  \
+                                      , rt               REAL    NOT NULL                  \
+                                      , precursor_mz     REAL    NOT NULL                  \
+                                      , precursor_charge INTEGER NOT NULL                  \
+                                      , precursor_ic     REAL    NOT NULL                  \
+                                      , precursor_purity REAL                              \
+                                      , minmz            REAL    NOT NULL                  \
+                                      , maxmz            REAL    NOT NULL                  \
+                                      , data TEXT                                          );"
+
+#define CREATE_PEAKS_TABLE \
+    "CREATE TABLE IF NOT EXISTS peaks ( peak_id               INTEGER PRIMARY KEY AUTOINCREMENT \
+                                      , group_id              INTEGER                           \
+                                      , sample_id             INTEGER                           \
+                                      , pos                   INTEGER                           \
+                                      , minpos                INTEGER                           \
+                                      , maxpos                INTEGER                           \
+                                      , rt                    REAL                              \
+                                      , rtmin                 REAL                              \
+                                      , rtmax                 REAL                              \
+                                      , mzmin                 REAL                              \
+                                      , mzmax                 REAL                              \
+                                      , scan                  INTEGER                           \
+                                      , minscan               INTEGER                           \
+                                      , maxscan               INTEGER                           \
+                                      , peak_area             REAL                              \
+                                      , peak_area_corrected   REAL                              \
+                                      , peak_area_top         REAL                              \
+                                      , peak_area_fractional  REAL                              \
+                                      , peak_rank             REAL                              \
+                                      , peak_intensity        REAL                              \
+                                      , peak_baseline_level   REAL                              \
+                                      , peak_mz               REAL                              \
+                                      , median_mz             REAL                              \
+                                      , base_mz               REAL                              \
+                                      , quality               REAL                              \
+                                      , width                 INTEGER                           \
+                                      , gauss_fit_sigma       REAL                              \
+                                      , gauss_fit_r2          REAL                              \
+                                      , no_noise_obs          INTEGER                           \
+                                      , no_noise_fraction     REAL                              \
+                                      , symmetry              REAL                              \
+                                      , signal_baseline_ratio REAL                              \
+                                      , group_overlap         REAL                              \
+                                      , group_overlap_frac    REAL                              \
+                                      , local_max_flag        REAL                              \
+                                      , from_blank_sample     INTEGER                           \
+                                      , label                 INTEGER                           );"
+
+#define CREATE_PEAK_GROUPS_TABLE \
+    "CREATE TABLE IF NOT EXISTS peakgroups ( group_id           INTEGER PRIMARY KEY AUTOINCREMENT \
+                                           , parent_group_id    INTEGER                           \
+                                           , meta_group_id      INTEGER                           \
+                                           , tag_string         TEXT                              \
+                                           , expected_mz        REAL                              \
+                                           , expected_abundance REAL                              \
+                                           , expected_rt_diff   REAL                              \
+                                           , group_rank         REAL                              \
+                                           , label              TEXT                              \
+                                           , type               INTEGER                           \
+                                           , srm_id             TEXT                              \
+                                           , ms2_event_count    INTEGER                           \
+                                           , ms2_score          REAL                              \
+                                           , adduct_name        TEXT                              \
+                                           , compound_id        TEXT                              \
+                                           , compound_name      TEXT                              \
+                                           , compound_db        TEXT                              \
+                                           , table_name         TEXT                              );"
+
+#define CREATE_COMPOUNDS_TABLE \
+    "CREATE TABLE IF NOT EXISTS compounds ( compound_id           TEXT         \
+                                          , db_name               TEXT         \
+                                          , name                  TEXT         \
+                                          , formula               TEXT         \
+                                          , smile_string          TEXT         \
+                                          , srm_id                TEXT         \
+                                          , mass                  REAL         \
+                                          , charge                INTEGER      \
+                                          , expected_rt           REAL         \
+                                          , precursor_mz          REAL         \
+                                          , product_mz            REAL         \
+                                          , collision_energy      REAL         \
+                                          , log_p                 REAL         \
+                                          , virtual_fragmentation INTEGER      \
+                                          , ionization_mode       INTEGER      \
+                                          , category              TEXT         \
+                                          , fragment_mzs          TEXT         \
+                                          , fragment_intensity    TEXT         \
+                                          , PRIMARY KEY (compound_id, db_name) );"
+
+#define CREATE_ALIGNMENT_TABLE \
+    "CREATE TABLE IF NOT EXISTS alignment_rts ( sample_id   INTEGER NOT NULL \
+                                              , scannum     INTEGER NOT NULL \
+                                              , rt_original REAL    NOT NULL \
+                                              , rt_updated  REAL    NOT NULL );"
+
+#define CREATE_COMPOUNDS_DB_INDEX \
+    "CREATE INDEX IF NOT EXISTS compounds_db_idx    \
+                             ON compounds ( db_name );"
+
+#define CREATE_PEAKS_GROUP_INDEX \
+    "CREATE INDEX IF NOT EXISTS peaks_group_idx  \
+                             ON peaks ( group_id );"
+
+#endif  // SCHEMA_H

--- a/src/projectDB/schema.h
+++ b/src/projectDB/schema.h
@@ -36,43 +36,44 @@
                                       , data TEXT                                          );"
 
 #define CREATE_PEAKS_TABLE \
-    "CREATE TABLE IF NOT EXISTS peaks ( peak_id               INTEGER PRIMARY KEY AUTOINCREMENT \
-                                      , group_id              INTEGER                           \
-                                      , sample_id             INTEGER                           \
-                                      , pos                   INTEGER                           \
-                                      , minpos                INTEGER                           \
-                                      , maxpos                INTEGER                           \
-                                      , rt                    REAL                              \
-                                      , rtmin                 REAL                              \
-                                      , rtmax                 REAL                              \
-                                      , mzmin                 REAL                              \
-                                      , mzmax                 REAL                              \
-                                      , scan                  INTEGER                           \
-                                      , minscan               INTEGER                           \
-                                      , maxscan               INTEGER                           \
-                                      , peak_area             REAL                              \
-                                      , peak_area_corrected   REAL                              \
-                                      , peak_area_top         REAL                              \
-                                      , peak_area_fractional  REAL                              \
-                                      , peak_rank             REAL                              \
-                                      , peak_intensity        REAL                              \
-                                      , peak_baseline_level   REAL                              \
-                                      , peak_mz               REAL                              \
-                                      , median_mz             REAL                              \
-                                      , base_mz               REAL                              \
-                                      , quality               REAL                              \
-                                      , width                 INTEGER                           \
-                                      , gauss_fit_sigma       REAL                              \
-                                      , gauss_fit_r2          REAL                              \
-                                      , no_noise_obs          INTEGER                           \
-                                      , no_noise_fraction     REAL                              \
-                                      , symmetry              REAL                              \
-                                      , signal_baseline_ratio REAL                              \
-                                      , group_overlap         REAL                              \
-                                      , group_overlap_frac    REAL                              \
-                                      , local_max_flag        REAL                              \
-                                      , from_blank_sample     INTEGER                           \
-                                      , label                 INTEGER                           );"
+    "CREATE TABLE IF NOT EXISTS peaks ( peak_id                 INTEGER PRIMARY KEY AUTOINCREMENT \
+                                      , group_id                INTEGER                           \
+                                      , sample_id               INTEGER                           \
+                                      , pos                     INTEGER                           \
+                                      , minpos                  INTEGER                           \
+                                      , maxpos                  INTEGER                           \
+                                      , rt                      REAL                              \
+                                      , rtmin                   REAL                              \
+                                      , rtmax                   REAL                              \
+                                      , mzmin                   REAL                              \
+                                      , mzmax                   REAL                              \
+                                      , scan                    INTEGER                           \
+                                      , minscan                 INTEGER                           \
+                                      , maxscan                 INTEGER                           \
+                                      , peak_area               REAL                              \
+                                      , peak_area_corrected     REAL                              \
+                                      , peak_area_top           REAL                              \
+                                      , peak_area_top_corrected REAL                              \
+                                      , peak_area_fractional    REAL                              \
+                                      , peak_rank               REAL                              \
+                                      , peak_intensity          REAL                              \
+                                      , peak_baseline_level     REAL                              \
+                                      , peak_mz                 REAL                              \
+                                      , median_mz               REAL                              \
+                                      , base_mz                 REAL                              \
+                                      , quality                 REAL                              \
+                                      , width                   INTEGER                           \
+                                      , gauss_fit_sigma         REAL                              \
+                                      , gauss_fit_r2            REAL                              \
+                                      , no_noise_obs            INTEGER                           \
+                                      , no_noise_fraction       REAL                              \
+                                      , symmetry                REAL                              \
+                                      , signal_baseline_ratio   REAL                              \
+                                      , group_overlap           REAL                              \
+                                      , group_overlap_frac      REAL                              \
+                                      , local_max_flag          REAL                              \
+                                      , from_blank_sample       INTEGER                           \
+                                      , label                   INTEGER                           );"
 
 #define CREATE_PEAK_GROUPS_TABLE \
     "CREATE TABLE IF NOT EXISTS peakgroups ( group_id           INTEGER PRIMARY KEY AUTOINCREMENT \

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,4 +1,8 @@
 TEMPLATE = subdirs
 CONFIG += ordered qt thread
 
-SUBDIRS += core/libmaven pollyCLI gui/mzroll cli/peakdetector
+SUBDIRS += core/libmaven \
+           pollyCLI \
+           gui/mzroll \
+           cli/peakdetector \
+           projectDB

--- a/src/src.pro
+++ b/src/src.pro
@@ -3,6 +3,6 @@ CONFIG += ordered qt thread
 
 SUBDIRS += core/libmaven \
            pollyCLI \
+           projectDB \
            gui/mzroll \
-           cli/peakdetector \
-           projectDB
+           cli/peakdetector


### PR DESCRIPTION
This PR includes implementation of a new SQLite-based project feature. Users will be able to save their progress for a session in a new **"emDB"** format and load these files to continue where they left off from the saved session. This offers (hopefully a more stable) alternative to "mzroll" files that El-MAVEN (and MAVEN) have used to save project data. The implementation depends on the `projectDB` module proposed in PR #921. Ideally the user should be able to restore their progress from a previous session as completely as possible using these "emDB" files. It is worth mentioning that this feature was inspired (and a lot of code was borrowed) from the upstream branch of [MAVEN](https://github.com/eugenemel/maven) (latest v8.0.9).