### PR TITLE
Fix crash from save before emDB load in same session

### DIFF
--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -712,7 +712,7 @@ void ProjectDockWidget::saveAndCloseCurrentSQLiteProject()
     }
 
     // if an existing project is being saved, stall before clearing the session
-    while(_mainwindow->fileLoader->isRunning());
+    while(_mainwindow->autosave->isRunning());
 
     // clear session regardless of whether the project was saved
     clearSession();


### PR DESCRIPTION
The conditional blocker meant to prevent session clean up before
a project has been saved was checking for loader thread instead
of autosave thread. This led to crashes due to database module
trying to save deallocated samples/scans.