### PR TITLE
Fix incorrect compound associated with loaded peakgroup

### DIFF
--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -812,8 +812,14 @@ void mzFileIO::readAllPeakTablesSQLite(const vector<mzSample*> newSamples)
     for (auto& group : groups) {
         // assign a compound from global "DB" object to the group
         if (group->compound && !group->compound->db.empty()) {
-            group->compound = DB.findSpeciesById(group->compound->id,
-                                                 group->compound->db);
+            auto matches = DB.findSpeciesByName(group->compound->name,
+                                                group->compound->db);
+            if (matches.size()) {
+                group->compound = matches.at(0);
+            } else {
+                group->compound = DB.findSpeciesById(group->compound->id,
+                                                     group->compound->db);
+            }
             dbNames.insert(QString::fromStdString(group->compound->db));
         }
 


### PR DESCRIPTION
Instead of looking up by compound's ID and DB name, we will be looking with compound name and DB name to avoid ambiguity between same ID compounds (such as Alanine, L-Alanine, D-Alanine, etc) within a compound DB namespace. If we do not find a compound for name and DB, we can resort to ID+DB pair for obtaining compounds as a fallback.