### PR TITLE
Plot sample Rt deviation when widget is opened

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2878,6 +2878,7 @@ void MainWindow::toggleSampleRtWidget()
     }
 
     sampleRtWidget->show();
+	sampleRtWidget->plotGraph();
 }
 
 void MainWindow::setMassCutoffType(QString massCutoffType){


### PR DESCRIPTION
Widget only plots the graph if it is open while running alignment.
Shows a blank plot if widget is opened after alignment has been run.

This behavior has been fixed.