### PR TITLE
[UI] Start progress bar from 0 for Obi-warp alignment

### DIFF
--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -316,7 +316,7 @@ void BackgroundPeakUpdate::alignWithObiWarp(){
                                         mainwindow->alignmentDialog->noStdNormal->isChecked(),
                                         mainwindow->alignmentDialog->binSizeObiWarp->value()
                                 );
-        Q_EMIT(updateProgressBar("Aligning Samples", 0, 0));
+        Q_EMIT(updateProgressBar("Aligning Samples", 0, 100));
 
         Aligner aligner;
         aligner.setAlignmentProgress.connect(boost::bind(&BackgroundPeakUpdate::qtSlot,


### PR DESCRIPTION
- Load samples
- Run Obi-warp alignment
- There should be no pulse progress bar at the start