### PR TITLE
Add a proper condition for empty db progress update

### DIFF
--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -588,7 +588,8 @@ void mzFileIO::fileImport(void) {
             if (!_missingSamples.empty()) {
                 _mainwindow->projectDockWidget->setLastOpenedProject(filename);
                 Q_EMIT(sqliteDBInadequateSamplesFound(samplePaths));
-            } else {
+            }
+            if (samplePaths.empty() && _missingSamples.empty()) {
                 // emit mock signals for empty database load
                 Q_EMIT(sqliteDBSamplesLoaded());
                 Q_EMIT(sqliteDBPeakTablesCreated());


### PR DESCRIPTION
A bad merge conflict resolution led to El-MAVEN recognizing all emDB files as empty (unless they were missing a few samples from the default path). This commit should fix it this error.