### PR TITLE
Show bookmark table when emDB loads groups into it

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2950,6 +2950,8 @@ void MainWindow::refreshIntensities() {
 	}
     bookmarkedPeaks->showAllGroups();
     _updateEMDBProgressBar(4, 4);
+    if (bookmarkedPeaks->allgroups.size() > 0)
+        bookmarkedPeaks->setVisible(true);
 }
 
 void MainWindow::showspectraMatchingForm() {


### PR DESCRIPTION
Loading an emDB file does not raise bookmarks table into visibility even if it had groups saved in it. This patch should fix it.