### PR TITLE
Autosave session progress in emDB without prompts

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -93,7 +93,7 @@ void MainWindow::printvalue() {
         const QString timestamp = nowTime.toString(QLatin1String("yyyyMMdd-hhmmsszzz"));
         QString AutosavePath = samplePath + timestamp + ".mzroll";
         this->_currentProjectName = AutosavePath;
-        this->autosaveEnabled = true;
+        this->timestampFileExists = true;
         this->saveProject();
         unsigned int countCrashState = 0;
         settings->beginWriteArray("crashTables");
@@ -827,7 +827,7 @@ QString MainWindow::_newAutosaveFile()
 AutoSave::AutoSave(MainWindow* mw)
 {
     _mainwindow = mw;
-    _mainwindow->autosaveEnabled = false;
+    _mainwindow->timestampFileExists = false;
     saveTablesOnly = false;
 }
 
@@ -888,28 +888,20 @@ void MainWindow::_setProjectFilenameFromProjectDockWidget()
 
 void MainWindow::resetAutosave()
 {
-    if (this->autosaveEnabled)
+    if (this->timestampFileExists)
         QFile::remove(_currentProjectName);
-    this->autosaveEnabled = false;
+    this->timestampFileExists = false;
     this->peaksMarked = 0;
     _currentProjectName = "";
 }
 
 void MainWindow::autosaveProject()
 {
-    if (this->peaksMarked == 1) {
-        if (!this->autosaveEnabled)
+    if (this->peaksMarked == 1 || this->timestampFileExists) {
+        if (!this->timestampFileExists) {
             this->_currentProjectName = this->_newAutosaveFile();
-
-        if (this->_currentProjectName.isEmpty()) {
-            this->autosaveEnabled = false;
-            return;
-        } else {
-            this->autosaveEnabled = true;
+            this->timestampFileExists = true;
         }
-
-        autosave->saveProjectWorker();
-    } else if (this->autosaveEnabled) {
         autosave->saveProjectWorker();
     }
 }
@@ -974,7 +966,7 @@ void MainWindow::saveProject(bool explicitSave)
             msgBox.exec();
 
             // remove current project file only if it was created by autosave
-            if (this->autosaveEnabled)
+            if (this->timestampFileExists)
                 QFile::remove(_currentProjectName);
 
             if (msgBox.clickedButton() == newButton) {
@@ -1013,7 +1005,7 @@ void MainWindow::saveProject(bool explicitSave)
             _currentProjectName = _loadedProjectName;
         }
         this->autosave->saveProjectWorker();
-    } else if (this->autosaveEnabled) {
+    } else if (this->timestampFileExists) {
         this->autosave->saveProjectWorker(true);
     } else if (this->peaksMarked > 5 || this->allPeaksMarked) {
         this->autosave->saveProjectWorker();

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -950,16 +950,14 @@ void MainWindow::saveProject(bool explicitSave)
 
             // remove timestamp autosave file in any case
             QFile::remove(_currentProjectName);
-            if (reply == QMessageBox::Yes) {
-                _currentProjectName = "";
-                _setProjectFilenameIfEmpty();
-
-                // if the filename is still empty, (confused user?) do not save
-                if (_currentProjectName.isEmpty())
-                    return;
-            } else {
+            if (reply != QMessageBox::Yes)
                 return;
-            }
+
+            _currentProjectName = "";
+            _setProjectFilenameIfEmpty();
+
+            if (_currentProjectName.isEmpty())
+                return;
         } else {
             QMessageBox msgBox;
             QString message = "Please choose the project file to save your "
@@ -982,15 +980,14 @@ void MainWindow::saveProject(bool explicitSave)
             if (msgBox.clickedButton() == newButton) {
                 _currentProjectName = "";
                 _setProjectFilenameIfEmpty();
-
-                // if the filename is still empty, (confused user?) do not save
-                if (_currentProjectName.isEmpty())
-                    return;
             } else if (msgBox.clickedButton() == saveButton) {
                 _currentProjectName = _loadedProjectName;
             } else {
                 return;
             }
+
+            if (_currentProjectName.isEmpty())
+                return;
         }
         this->autosave->saveProjectWorker();
     } else if (explicitSave) {

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -92,8 +92,8 @@ void MainWindow::printvalue() {
         const QDateTime nowTime = QDateTime::currentDateTime();
         const QString timestamp = nowTime.toString(QLatin1String("yyyyMMdd-hhmmsszzz"));
         QString AutosavePath = samplePath + timestamp + ".mzroll";
-        this->fileName = AutosavePath;
-        this->doAutosave = true;
+        this->_currentProjectName = AutosavePath;
+        this->autosaveEnabled = true;
         this->saveProject();
         unsigned int countCrashState = 0;
         settings->beginWriteArray("crashTables");
@@ -814,32 +814,20 @@ void MainWindow::createPeakTable(QString filenameNew) {
     peaksTable->showAllGroups();
 }
 
-bool MainWindow::askAutosave()
+QString MainWindow::_newAutosaveFile()
 {
-    bool doAutosave = false;
-    _setProjectFilenameFromProjectDockWidget();
-    if (this->fileName.isEmpty()) {
-        auto reply = QMessageBox::question(this,
-                                           "Autosave",
-                                           "Do you want to enable autosave? "
-                                           "You will have to create a new "
-                                           "project to save in.",
-                                           QMessageBox::Yes | QMessageBox::No,
-                                           QMessageBox::Yes);
-        if (reply == QMessageBox::Yes) {
-            doAutosave = true;
-        } else {
-            doAutosave = false;
-        }
-    }
-    return doAutosave;
+    auto now = QDateTime::currentDateTime();
+    auto tempFilename = now.toString(Qt::ISODate) + ".emDB";
+    auto firstSampleFile = getSamples()[0]->fileName;
+    auto sampleFileInfo = QFileInfo(QString::fromStdString(firstSampleFile));
+    auto samplePath = sampleFileInfo.absolutePath();
+    return samplePath + QDir::separator() + tempFilename;
 }
 
 AutoSave::AutoSave(MainWindow* mw)
 {
     _mainwindow = mw;
-    _mainwindow->doAutosave = false;
-    _mainwindow->askAutosaveMain = 0;
+    _mainwindow->autosaveEnabled = false;
     saveTablesOnly = false;
 }
 
@@ -861,7 +849,7 @@ void AutoSave::run()
 
 void MainWindow::_setProjectFilenameIfEmpty()
 {
-    if (this->fileName.isEmpty()) {
+    if (this->_currentProjectName.isEmpty()) {
         QString dir = ".";
         if (settings->contains("lastDir")) {
             QString ldir = settings->value("lastDir").value<QString>();
@@ -878,9 +866,9 @@ void MainWindow::_setProjectFilenameIfEmpty()
                                          "El-MAVEN Database Format(*.emDB)");
         if (!filename.isEmpty()) {
             if (!filename.endsWith(".emDB", Qt::CaseInsensitive)) {
-                this->fileName = filename + ".emDB";
+                this->_currentProjectName = filename + ".emDB";
             } else {
-                this->fileName = filename;
+                this->_currentProjectName = filename;
             }
         }
     }
@@ -892,26 +880,36 @@ void MainWindow::_setProjectFilenameFromProjectDockWidget()
     auto lastLoad = projectDockWidget->getLastOpenedTime();
     if (!projectDockWidget->getLastOpenedProject().isEmpty()
             && lastLoad > lastSave)
-        fileName = projectDockWidget->getLastOpenedProject();
+        _currentProjectName = projectDockWidget->getLastOpenedProject();
     if (!projectDockWidget->getLastSavedProject().isEmpty()
             && lastSave > lastLoad)
-        fileName = projectDockWidget->getLastSavedProject();
+        _currentProjectName = projectDockWidget->getLastSavedProject();
+}
+
+void MainWindow::resetAutosave()
+{
+    if (this->autosaveEnabled)
+        QFile::remove(_currentProjectName);
+    this->autosaveEnabled = false;
+    this->peaksMarked = 0;
+    _currentProjectName = "";
 }
 
 void MainWindow::autosaveProject()
 {
-    if (this->peaksMarked == 1 && this->askAutosaveMain == 0) {
-        this->askAutosaveMain++;
-        this->doAutosave = this->askAutosave();
-        if (this->doAutosave) {
-            _setProjectFilenameIfEmpty();
-            if (this->fileName.isEmpty()) {
-                this->doAutosave = false;
-                return;
-            }
-            autosave->saveProjectWorker();
+    if (this->peaksMarked == 1) {
+        if (!this->autosaveEnabled)
+            this->_currentProjectName = this->_newAutosaveFile();
+
+        if (this->_currentProjectName.isEmpty()) {
+            this->autosaveEnabled = false;
+            return;
+        } else {
+            this->autosaveEnabled = true;
         }
-    } else if (this->doAutosave) {
+
+        autosave->saveProjectWorker();
+    } else if (this->autosaveEnabled) {
         autosave->saveProjectWorker();
     }
 }
@@ -923,7 +921,7 @@ void MainWindow::explicitSave()
 
 void MainWindow::threadSave(QString filename)
 {
-    fileName = filename;
+    _currentProjectName = filename;
     autosave->saveProjectWorker();
 }
 
@@ -936,13 +934,13 @@ void MainWindow::saveProject(bool explicitSave)
         if (getSamples().size() == 0)
             return;
 
-        if (fileName.isEmpty())
+        if (_currentProjectName.isEmpty())
             _setProjectFilenameFromProjectDockWidget();
 
-        // if fileName is still empty, no projects were closed or opened
-        if (fileName.isEmpty()) {
-            QString message =
-                "Would you like to save your data for this session as a project?";
+        // if no projects were saved or opened
+        if (_loadedProjectName.isEmpty()) {
+            QString message = "Would you like to save your data for this "
+                              "session as a project?";
             QMessageBox::StandardButton reply;
             reply = QMessageBox::question(this,
                                           "Save as project",
@@ -950,12 +948,46 @@ void MainWindow::saveProject(bool explicitSave)
                                           QMessageBox::Yes | QMessageBox::No,
                                           QMessageBox::Yes);
 
+            // remove timestamp autosave file in any case
+            QFile::remove(_currentProjectName);
             if (reply == QMessageBox::Yes) {
+                _currentProjectName = "";
                 _setProjectFilenameIfEmpty();
 
                 // if the filename is still empty, (confused user?) do not save
-                if (fileName.isEmpty())
+                if (_currentProjectName.isEmpty())
                     return;
+            } else {
+                return;
+            }
+        } else {
+            QMessageBox msgBox;
+            QString message = "Please choose the project file to save your "
+                              "progress for this session.";
+            msgBox.setText(message);
+            QPushButton* cancelButton = msgBox.addButton(tr("Cancel"),
+                                                         QMessageBox::ActionRole);
+            QPushButton* newButton = msgBox.addButton(tr("Save in new"),
+                                                      QMessageBox::ActionRole);
+            QPushButton* saveButton = msgBox.addButton(tr("Save in current"),
+                                                       QMessageBox::ActionRole);
+            msgBox.setDefaultButton(saveButton);
+            msgBox.setEscapeButton(cancelButton);
+            msgBox.exec();
+
+            // remove current project file only if it was created by autosave
+            if (this->autosaveEnabled)
+                QFile::remove(_currentProjectName);
+
+            if (msgBox.clickedButton() == newButton) {
+                _currentProjectName = "";
+                _setProjectFilenameIfEmpty();
+
+                // if the filename is still empty, (confused user?) do not save
+                if (_currentProjectName.isEmpty())
+                    return;
+            } else if (msgBox.clickedButton() == saveButton) {
+                _currentProjectName = _loadedProjectName;
             } else {
                 return;
             }
@@ -963,7 +995,7 @@ void MainWindow::saveProject(bool explicitSave)
         this->autosave->saveProjectWorker();
     } else if (explicitSave) {
         _setProjectFilenameFromProjectDockWidget();
-        if (fileName.isEmpty()) {
+        if (_loadedProjectName.isEmpty()) {
             auto reply = QMessageBox::question(this,
                                                "No project open",
                                                "You do not have a project for "
@@ -975,11 +1007,16 @@ void MainWindow::saveProject(bool explicitSave)
                 _setProjectFilenameIfEmpty();
 
             // still empty?!
-            if (fileName.isEmpty())
+            if (_currentProjectName.isEmpty())
                 return;
+
+            _loadedProjectName = _currentProjectName;
+        } else {
+            resetAutosave();
+            _currentProjectName = _loadedProjectName;
         }
         this->autosave->saveProjectWorker();
-    } else if (this->doAutosave) {
+    } else if (this->autosaveEnabled) {
         this->autosave->saveProjectWorker(true);
     } else if (this->peaksMarked > 5 || this->allPeaksMarked) {
         this->autosave->saveProjectWorker();
@@ -988,25 +1025,25 @@ void MainWindow::saveProject(bool explicitSave)
 
 void MainWindow::saveProjectForFilename(bool tablesOnly)
 {
-    if (fileLoader->isMzRollProject(fileName)) {
+    if (fileLoader->isMzRollProject(_currentProjectName)) {
         _saveAllTablesAsMzRoll();
-    } else if (fileLoader->isSQLiteProject(fileName)) {
+    } else if (fileLoader->isSQLiteProject(_currentProjectName)) {
         if (tablesOnly) {
             auto allTables = getPeakTableList();
             allTables.append(bookmarkedPeaks);
             for (auto table : allTables)
-                projectDockWidget->savePeakTableInSQLite(table, fileName);
+                projectDockWidget->savePeakTableInSQLite(table, _currentProjectName);
         } else {
-            projectDockWidget->saveSQLiteProject(fileName);
+            projectDockWidget->saveSQLiteProject(_currentProjectName);
         }
     }
 }
 
 void MainWindow::_saveAllTablesAsMzRoll()
 {
-    if (fileName.isEmpty()) {
-        fileName = this->projectDockWidget->getLastSavedProject();
-        if (!fileLoader->isMzRollProject(fileName)) {
+    if (_currentProjectName.isEmpty()) {
+        _currentProjectName = this->projectDockWidget->getLastSavedProject();
+        if (!fileLoader->isMzRollProject(_currentProjectName)) {
             projectDockWidget->saveProjectAsMzRoll();
             return;
         }
@@ -1015,7 +1052,7 @@ void MainWindow::_saveAllTablesAsMzRoll()
             && this->projectDockWidget->getLastSavedProject() == newFileName) {
         projectDockWidget->saveMzRollProject(newFileName);
     } else {
-        projectDockWidget->saveMzRollProject(fileName);
+        projectDockWidget->saveMzRollProject(_currentProjectName);
     }
 }
 
@@ -1677,16 +1714,18 @@ void MainWindow::open()
                    + " "
                    + fileInfo.fileName());
 
-    bool sqliteProjectBeingLoaded = false;
+    QString sqliteProjectBeingLoaded = "";
     Q_FOREACH (QString filename, filelist) {
         if (fileLoader->isSQLiteProject(filename))
-            sqliteProjectBeingLoaded = true;
+            sqliteProjectBeingLoaded = filename;
 
         fileLoader->addFileToQueue(filename);
     }
 
-    if (sqliteProjectBeingLoaded)
+    if (!sqliteProjectBeingLoaded.isEmpty()) {
         projectDockWidget->saveAndCloseCurrentSQLiteProject();
+        _loadedProjectName = sqliteProjectBeingLoaded;
+    }
 
     bool cancelUploading = false;
     cancelUploading = updateSamplePathinMzroll(filelist);

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -283,10 +283,28 @@ public:
 	void setValue(int value);
 	//TODO: Sahil - Kiran, removed while merging mainwindow
 	// bool isSampleFileType(QString filename);
-	// bool isProjectFileType(QString filename);
+        // bool isProjectFileType(QString filename);
+
+    /**
+     * @brief Save a session as an emDB project.
+     * @param explicitSave This boolean value tells the method whether save
+     * command was issued explicitly by the user. False by default.
+     */
     void saveProject(bool explicitSave=false);
+
+    /**
+     * @brief Call appropriate save methods for the filename set in
+     * `_currentProjectName` variable.
+     * @param tablesOnly Save only peak tables in the project file.
+     */
     void saveProjectForFilename(bool tablesOnly=false);
-    bool autosaveEnabled;
+
+    /**
+     * @brief Stores whether a timestamp file is being used to save in the
+     * background.
+     */
+    bool timestampFileExists;
+
 	void loadPollySettings(QString fileName);
 Q_SIGNALS:
 	void valueChanged(int newValue);
@@ -408,8 +426,23 @@ public Q_SLOTS:
     void saveSettings();
     void loadSettings();
     void showNotification(TableDockWidget* table);
+
+    /**
+     * @brief Save method that can be called when user explicitly asks for a
+     * project save.
+     */
     void explicitSave();
+
+    /**
+     * @brief Save a session in a filename using a background thread.
+     * @param filename String name of a  project file to save to.
+     */
     void threadSave(QString filename);
+
+    /**
+     * @brief Reset the status of autosave for current El-MAVEN session. Should
+     * be called whenever a new project is loaded into the session.
+     */
     void resetAutosave();
 
 private Q_SLOTS:
@@ -469,9 +502,19 @@ private:
 
     QProgressDialog* _loadProgressDialog;
 
-	QToolButton* addDockWidgetButton(QToolBar*, QDockWidget*, QIcon, QString);
+        QToolButton* addDockWidgetButton(QToolBar*, QDockWidget*, QIcon, QString);
+
+    /**
+     * @brief Name of the project to which all threaded saving will be done.
+     */
     QString _currentProjectName;
+
+    /**
+     * @brief Name of the project that was last loaded or saved and will be used
+     * when saving from explicit user command or final save when exiting app.
+     */
     QString _loadedProjectName;
+
     QString newFileName;
 
     QString _newAutosaveFile();

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -284,11 +284,9 @@ public:
 	//TODO: Sahil - Kiran, removed while merging mainwindow
 	// bool isSampleFileType(QString filename);
 	// bool isProjectFileType(QString filename);
-	bool askAutosave();
     void saveProject(bool explicitSave=false);
     void saveProjectForFilename(bool tablesOnly=false);
-    bool doAutosave;
-	int askAutosaveMain;
+    bool autosaveEnabled;
 	void loadPollySettings(QString fileName);
 Q_SIGNALS:
 	void valueChanged(int newValue);
@@ -412,6 +410,7 @@ public Q_SLOTS:
     void showNotification(TableDockWidget* table);
     void explicitSave();
     void threadSave(QString filename);
+    void resetAutosave();
 
 private Q_SLOTS:
 	void createMenus();
@@ -471,8 +470,11 @@ private:
     QProgressDialog* _loadProgressDialog;
 
 	QToolButton* addDockWidgetButton(QToolBar*, QDockWidget*, QIcon, QString);
-	QString fileName;
+    QString _currentProjectName;
+    QString _loadedProjectName;
     QString newFileName;
+
+    QString _newAutosaveFile();
     void _setProjectFilenameIfEmpty();
     void _setProjectFilenameFromProjectDockWidget();
     void _saveMzRollList(QString projectFileName);

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -788,9 +788,10 @@ bool mzFileIO::writeSQLiteProject(QString filename)
         }
         _currentProject->saveCompounds(compoundSet);
         qDebug() << "finished writing to project" << filename;
-        Q_EMIT(updateStatusString(
-            QString("Project successfully saved to %1").arg(filename)
-        ));
+        if (!_mainwindow->autosaveEnabled)
+            Q_EMIT(updateStatusString(
+                QString("Project successfully saved to %1").arg(filename)
+            ));
         return true;
     }
     qDebug() << "cannot write to closed project" << filename;

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -788,7 +788,7 @@ bool mzFileIO::writeSQLiteProject(QString filename)
         }
         _currentProject->saveCompounds(compoundSet);
         qDebug() << "finished writing to project" << filename;
-        if (!_mainwindow->autosaveEnabled)
+        if (!_mainwindow->timestampFileExists)
             Q_EMIT(updateStatusString(
                 QString("Project successfully saved to %1").arg(filename)
             ));

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -698,8 +698,10 @@ void ProjectDockWidget::saveAndCloseCurrentSQLiteProject()
         this,
         "Opening Project",
         userSessionWarning,
-        QMessageBox::Yes | QMessageBox::Cancel
+        QMessageBox::No | QMessageBox::Yes,
+        QMessageBox::Yes
     );
+    _mainwindow->resetAutosave();
     if (reply == QMessageBox::Yes)
         saveSQLiteProject();
 


### PR DESCRIPTION
Whenever El-MAVEN crashes, the user risks losing their progress for that session. This calls for a need to have a somewhat fail-safe autosaving mechanism that tries to minimize this loss in the event of an abrupt application exit. A timestamped autosave file will now be generated the first time a user bookmarks or marks a peak group as good or bad. This file will be used to constantly save any further curation done by the user in that session. Finally a prompt will appear at the end of a session asking the user if they want to save it as a named emDB file.