### PR TITLE
Fix unresponsive UI after using EPI with no internet

### DIFF
--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -231,7 +231,10 @@ void PollyElmavenInterfaceDialog::handleAuthentication(QString status)
         _loadingDialog->statusLabel->setStyleSheet("QLabel {color : red;}");
         _loadingDialog->statusLabel->setText("No Internet Access");
         QCoreApplication::processEvents();
-        close();
+        QTimer *timer = new QTimer(this);
+        connect(timer, SIGNAL(timeout()), _loadingDialog, SLOT(close()));
+        connect(timer, SIGNAL(timeout()), this, SLOT(close()));
+        timer->start(5000);
     } else {
         _loadingDialog->statusLabel->setStyleSheet("QLabel {color : red;}");
         _loadingDialog->statusLabel->setText("Authentication failed. Please login again.");


### PR DESCRIPTION
This is a fix for a Mac OS  only issue where the GUI would become insensitive to any actions after Polly interface dialogs are auto-dismissed on a system having no internet connection. With this patch, the loading dialog will stay for 5 seconds after it has failed to connect to the internet and informs user about the issue. The UI becomes responsive after this.