### PR TITLE
Cancel obi-warp alignment

### DIFF
--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -257,7 +257,7 @@ void PeakDetector::alignSamples(const int& method) {
             make use mavenParameters to access all the values */
             ObiParams params("cor", false, 2.0, 1.0, 0.20, 3.40, 0.0, 20.0, false, 0.60);
             Aligner mzAligner;
-            mzAligner.alignWithObiWarp(mavenParameters->samples, &params);
+            mzAligner.alignWithObiWarp(mavenParameters->samples, &params, mavenParameters);
         }
 
         break;

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -113,7 +113,7 @@ MavenParameters::MavenParameters(string settingsPath):lastUsedSettingsPath(setti
 	S34Labeled_IsoWidget = false;
 	D2Labeled_IsoWidget = false;
 
-        alignMaxItterations = 10;  //TODO: Sahil - Kiran, Added while merging mainwindow
+        alignMaxIterations = 10;  //TODO: Sahil - Kiran, Added while merging mainwindow
         alignPolynomialDegree = 5; //TODO: Sahil - Kiran, Added while merging mainwindow
         
         quantileQuality = 0.0;

--- a/src/core/libmaven/mavenparameters.h
+++ b/src/core/libmaven/mavenparameters.h
@@ -239,7 +239,7 @@ class MavenParameters
         vector<mzSlice*> _slices;
         bool stop;
 
-        int alignMaxItterations; //TODO: Sahil - Kiran, Added while merging mainwindow
+        int alignMaxIterations; //TODO: Sahil - Kiran, Added while merging mainwindow
         int alignPolynomialDegree; //TODO: Sahil - Kiran, Added while merging mainwindow
 
         float minFragmentMatchScore;

--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -510,6 +510,11 @@ int Aligner::alignWithObiWarp(vector<mzSample*> samples,
         refSample = samples[rand()%samples.size()];
     }
 
+    //save current retention times
+    for (auto sample : samples) {
+        sample->saveCurrentRetentionTimes();
+    }
+
     ObiWarp* obiWarp = new ObiWarp(obiParams);
 
     float binSize = obiParams->binSize;

--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -557,10 +557,12 @@ int Aligner::alignWithObiWarp(vector<mzSample*> samples,
             #pragma omp cancel for
         }
         #pragma omp cancellation point for
-        stopped = alignSampleRts(samples[i], mzPoints, *obiWarp, false, mp);
-
-        samplesAligned++;
-        setAlignmentProgress("Aligning samples", samplesAligned, samples.size()-1);
+        if (alignSampleRts(samples[i], mzPoints, *obiWarp, false, mp)) {
+            stopped = 1;
+        } else {
+            samplesAligned++;
+            setAlignmentProgress("Aligning samples", samplesAligned, samples.size()-1);
+        }
     }
 
     cerr << "Samples modified: " << samplesAligned << endl;

--- a/src/core/libmaven/mzAligner.h
+++ b/src/core/libmaven/mzAligner.h
@@ -29,8 +29,14 @@ class Aligner {
     void restoreFit();
     void setMaxItterations(int x) { maxItterations = x; }
     void setPolymialDegree(int x) { polynomialDegree = x; }
-    int alignWithObiWarp(vector<mzSample*> samples , ObiParams* obiParams, MavenParameters* mavenParameters);
-    void alignSampleRts(mzSample* sample, vector<float> &mzPoints,ObiWarp& obiWarp, bool setAsReference);
+    int alignWithObiWarp(vector<mzSample*> samples,
+                         ObiParams* obiParams,
+                         const MavenParameters* mp);
+    void alignSampleRts(mzSample* sample,
+                        vector<float> &mzPoints,
+                        ObiWarp& obiWarp,
+                        bool setAsReference,
+                        const MavenParameters* mp);
     map<pair<string,string>, double> getDeltaRt() {return deltaRt; }
 	map<pair<string, string>, double> deltaRt;
     vector<vector<float> > fit;

--- a/src/core/libmaven/mzAligner.h
+++ b/src/core/libmaven/mzAligner.h
@@ -10,6 +10,7 @@
 #include "mzSample.h"
 #include "Compound.h"
 #include "obiwarp.h"
+#include "mavenparameters.h"
 #include <QJsonObject>
 
 #include <boost/signals2.hpp>
@@ -28,7 +29,7 @@ class Aligner {
     void restoreFit();
     void setMaxItterations(int x) { maxItterations = x; }
     void setPolymialDegree(int x) { polynomialDegree = x; }
-    void alignWithObiWarp(vector<mzSample*> samples , ObiParams* obiParams);
+    int alignWithObiWarp(vector<mzSample*> samples , ObiParams* obiParams, MavenParameters* mavenParameters);
     void alignSampleRts(mzSample* sample, vector<float> &mzPoints,ObiWarp& obiWarp, bool setAsReference);
     map<pair<string,string>, double> getDeltaRt() {return deltaRt; }
 	map<pair<string, string>, double> deltaRt;

--- a/src/core/libmaven/mzAligner.h
+++ b/src/core/libmaven/mzAligner.h
@@ -27,12 +27,12 @@ class Aligner {
     void saveFit();
     void PolyFit(int poly_align_degree);
     void restoreFit();
-    void setMaxItterations(int x) { maxItterations = x; }
+    void setMaxIterations(int x) { maxIterations = x; }
     void setPolymialDegree(int x) { polynomialDegree = x; }
-    int alignWithObiWarp(vector<mzSample*> samples,
+    bool alignWithObiWarp(vector<mzSample*> samples,
                          ObiParams* obiParams,
                          const MavenParameters* mp);
-    int alignSampleRts(mzSample* sample,
+    bool alignSampleRts(mzSample* sample,
                         vector<float> &mzPoints,
                         ObiWarp& obiWarp,
                         bool setAsReference,
@@ -63,7 +63,7 @@ public:
 
    private:
     vector<PeakGroup*> allgroups;
-    int maxItterations;
+    int maxIterations;
     int polynomialDegree;
 
 };

--- a/src/core/libmaven/mzAligner.h
+++ b/src/core/libmaven/mzAligner.h
@@ -32,7 +32,7 @@ class Aligner {
     int alignWithObiWarp(vector<mzSample*> samples,
                          ObiParams* obiParams,
                          const MavenParameters* mp);
-    void alignSampleRts(mzSample* sample,
+    int alignSampleRts(mzSample* sample,
                         vector<float> &mzPoints,
                         ObiWarp& obiWarp,
                         bool setAsReference,

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1802,12 +1802,15 @@ void mzSample::saveCurrentRetentionTimes()
 
 void mzSample::restorePreviousRetentionTimes()
 {
-	if (lastSavedRTs.size() == 0)
-		return;
-
-	for (unsigned int ii = 0; ii < scans.size(); ii++)
-	{
-		scans[ii]->rt = lastSavedRTs[ii];
+	if (lastSavedRTs.size() == 0) {
+		//restore original RTs if no alignment has been performed
+		for (auto scan : scans) {
+			scan->rt = scan->originalRt;
+		}
+	} else {
+		for (unsigned int ii = 0; ii < scans.size(); ii++) {
+			scans[ii]->rt = lastSavedRTs[ii];
+		}
 	}
 }
 

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1792,26 +1792,22 @@ Scan *mzSample::getAverageScan(float rtmin, float rtmax, int mslevel, int polari
 
 void mzSample::saveCurrentRetentionTimes()
 {
-	if (originalRetentionTimes.size() > 0)
-		return;
-
-	originalRetentionTimes.resize(scans.size());
+	lastSavedRTs.resize(scans.size());
+	
 	for (unsigned int ii = 0; ii < scans.size(); ii++)
 	{
-		originalRetentionTimes[ii] = scans[ii]->rt;
+		lastSavedRTs[ii] = scans[ii]->rt;
 	}
 }
 
 void mzSample::restorePreviousRetentionTimes()
 {
-	//TODO naman unused function
-
-	if (originalRetentionTimes.size() == 0)
+	if (lastSavedRTs.size() == 0)
 		return;
 
 	for (unsigned int ii = 0; ii < scans.size(); ii++)
 	{
-		scans[ii]->rt = originalRetentionTimes[ii];
+		scans[ii]->rt = lastSavedRTs[ii];
 	}
 }
 

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1790,7 +1790,7 @@ Scan *mzSample::getAverageScan(float rtmin, float rtmax, int mslevel, int polari
 	return avgScan;
 }
 
-void mzSample::saveOriginalRetentionTimes()
+void mzSample::saveCurrentRetentionTimes()
 {
 	if (originalRetentionTimes.size() > 0)
 		return;
@@ -1802,7 +1802,7 @@ void mzSample::saveOriginalRetentionTimes()
 	}
 }
 
-void mzSample::restoreOriginalRetentionTimes()
+void mzSample::restorePreviousRetentionTimes()
 {
 	//TODO naman unused function
 

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -429,15 +429,15 @@ class mzSample
 
     /**
              * [save Original Retention Times]
-             * @method saveOriginalRetentionTimes
+             * @method saveCurrentRetentionTimes
              */
-    void saveOriginalRetentionTimes();
+    void saveCurrentRetentionTimes();
 
     /**
                           * [restore Original Retention Times]
-                          * @method restoreOriginalRetentionTimes
+                          * @method restorePreviousRetentionTimes
                           */
-    void restoreOriginalRetentionTimes();
+    void restorePreviousRetentionTimes();
 
     void applyPolynomialTransform(); //TODO: Sahil, Added while merging projectdockwidget
 

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -428,15 +428,14 @@ class mzSample
     EIC *getBIC(float rtmin, float rtmax, int mslevel);
 
     /**
-             * [save Original Retention Times]
-             * @method saveCurrentRetentionTimes
-             */
+     * @brief save alignment state before next alignment is performed
+     **/
     void saveCurrentRetentionTimes();
 
     /**
-                          * [restore Original Retention Times]
-                          * @method restorePreviousRetentionTimes
-                          */
+     * @brief restore last state of alignment
+     * @details last saved state is restored on cancelling alignment
+     **/
     void restorePreviousRetentionTimes();
 
     void applyPolynomialTransform(); //TODO: Sahil, Added while merging projectdockwidget
@@ -706,8 +705,8 @@ class mzSample
 
     //saving and restoring retention times
 
-    /** saved retention times prior to alignment */
-    vector<float> originalRetentionTimes;
+    //saved retention times prior to every alignment
+    vector<float> lastSavedRTs;
 
     vector<double> polynomialAlignmentTransformation; //parameters for polynomial transform
 

--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -219,12 +219,12 @@ void AlignmentDialog::algoChanged()
 
 	if (alignAlgo->currentIndex() == 0) {
 		label_7->setVisible(true);
-		maxItterations->setVisible(true);
+		maxIterations->setVisible(true);
 		label_8->setVisible(true);
 		polynomialDegree->setVisible(true);
 	} else {
 		label_7->setVisible(false);
-		maxItterations->setVisible(false);
+		maxIterations->setVisible(false);
 		label_8->setVisible(false);
 		polynomialDegree->setVisible(false);
 	}

--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -58,6 +58,7 @@ void AlignmentDialog::cancel() {
     if (workerThread) {
         if (workerThread->isRunning()) {
             workerThread->completeStop();
+			cerr << "completeStop done" << endl;
             return;
         }
     }

--- a/src/gui/mzroll/alignmentdialog.h
+++ b/src/gui/mzroll/alignmentdialog.h
@@ -44,6 +44,7 @@ class AlignmentDialog : public QDialog, public Ui_AlignmentDialog {
 		void toggleObiParams(bool show);
 		void showAdvanceParameters(bool checked);
 		void samplesAligned(bool status);
+		void updateRestoreStatus();
 };
 
 #endif

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -305,13 +305,15 @@ void BackgroundPeakUpdate::alignWithObiWarp()
     Aligner aligner;
     aligner.setAlignmentProgress.connect(boost::bind(&BackgroundPeakUpdate::qtSlot,
                                                      this, _1, _2, _3));
-    int stopped = aligner.alignWithObiWarp(mavenParameters->samples, obiParams, mavenParameters);
+    _stopped = aligner.alignWithObiWarp(mavenParameters->samples, obiParams, mavenParameters);
     delete obiParams;
 
-    if (stopped) {
+    if (_stopped) {
         //restore previous RTs
-        for (auto sample : mavenParameters->samples)
+        for (auto sample : mavenParameters->samples) {
+            cerr << "restoring sample RTs" << endl;
             sample->restorePreviousRetentionTimes();
+        }
         return;
     }
         
@@ -597,7 +599,7 @@ void BackgroundPeakUpdate::completeStop() {
         
         peakDetector.resetProgressBar();
         mavenParameters->stop = true;
-        //stop();
+        stop();
 }
 
 void BackgroundPeakUpdate::computePeaks() {

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -309,9 +309,9 @@ void BackgroundPeakUpdate::alignWithObiWarp()
     delete obiParams;
 
     if (_stopped) {
+        Q_EMIT(restoreAlignment());
         //restore previous RTs
         for (auto sample : mavenParameters->samples) {
-            cerr << "restoring sample RTs" << endl;
             sample->restorePreviousRetentionTimes();
         }
         return;

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -34,7 +34,7 @@ QString BackgroundPeakUpdate::printSettings() {
     summary << "-------------------SETTINGS-------------------"<< "\n"<< "\n";
 //     summary << "runFunction =" << runFunction<< "\n";
     summary << "alignSamplesFlag="  <<  mavenParameters->alignSamplesFlag<< "\n";
-    summary << "alignMaxItterations="  <<  mavenParameters->alignMaxItterations << "\n";
+    summary << "alignMaxIterations="  <<  mavenParameters->alignMaxIterations << "\n";
     summary << "alignPolynomialDegree="  <<  mavenParameters->alignPolynomialDegree << "\n";
 
     summary << "--------------------------------MASS SLICING"<< "\n";
@@ -314,6 +314,7 @@ void BackgroundPeakUpdate::alignWithObiWarp()
         for (auto sample : mavenParameters->samples) {
             sample->restorePreviousRetentionTimes();
         }
+        mavenParameters->stop = false;
         return;
     }
         
@@ -463,7 +464,7 @@ void BackgroundPeakUpdate::align() {
                 int alignAlgo = mainwindow->alignmentDialog->alignAlgo->currentIndex();
 
                 if (alignAlgo == 0) {
-                        aligner.setMaxItterations(mainwindow->alignmentDialog->maxItterations->value());
+                        aligner.setMaxIterations(mainwindow->alignmentDialog->maxIterations->value());
                         aligner.setPolymialDegree(mainwindow->alignmentDialog->polynomialDegree->value());
                         aligner.doAlignment(groups);
                         mainwindow->sampleRtWidget->setDegreeMap(aligner.sampleDegree);

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -260,25 +260,8 @@ void BackgroundPeakUpdate::run(void) {
 	connect(this, SIGNAL(alignmentComplete(QList<PeakGroup> )), mainwindow->groupRtWidget, SLOT(setCurrentGroups(QList<PeakGroup>)));
         connect(this, SIGNAL(alignmentComplete(QList<PeakGroup> )), mainwindow->sampleRtWidget, SLOT(plotGraph()));
         mavenParameters->stop = false;
-        //_stopped = false;
+        started();
 
-        //populating the maven setting insatnces with with the samples
-        // if (mavenParameters->samples.size() == 0) {
-        //         mavenParameters->samples = mainwindow->getSamples();
-        // }
-        //Getting the classification model
-        //mavenParameters->clsf = mainwindow->getClassifier();
-
-        //Setting the ionization mode if the user specifies the ionization mode
-        //then its given the priority else the ionization mode is taken from the
-        //sample
-        //TODO: See how the ionization mode is effected if the user selects
-        //Neutral or autodetect
-        // if (mainwindow->getIonizationMode()) {
-        //         mavenParameters->ionizationMode = mainwindow->getIonizationMode();
-        // } else {
-        //         mavenParameters->setIonizationMode();
-        // }
         if (runFunction == "findPeaksQQQ") {
                 findPeaksQQQ();
         } else if (runFunction == "alignUsingDatabase") {
@@ -321,9 +304,13 @@ void BackgroundPeakUpdate::alignWithObiWarp(){
         Aligner aligner;
         aligner.setAlignmentProgress.connect(boost::bind(&BackgroundPeakUpdate::qtSlot,
                                                          this, _1, _2, _3));
-        aligner.alignWithObiWarp(mavenParameters->samples, obiParams);
+        int stopped = aligner.alignWithObiWarp(mavenParameters->samples, obiParams, mavenParameters);
         delete obiParams;
 
+        if (stopped) {
+            return;
+        }
+        
         mainwindow->sampleRtWidget->plotGraph();
         Q_EMIT(samplesAligned(true));
 

--- a/src/gui/mzroll/background_peaks_update.h
+++ b/src/gui/mzroll/background_peaks_update.h
@@ -131,6 +131,11 @@ Q_SIGNALS:
 	void samplesAligned(bool);
 
 	/**
+	 * @brief signal for alignment cancellation and restore
+	 */
+	void restoreAlignment();
+
+	/**
 	 * [new PeakGroup]
 	 * @param group [pointer to PeakGroup]
 	 */

--- a/src/gui/mzroll/forms/alignmentdialog.ui
+++ b/src/gui/mzroll/forms/alignmentdialog.ui
@@ -337,12 +337,12 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
-         <string>Maximum Number of Itterations</string>
+         <string>Maximum Number of Iterations</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSpinBox" name="maxItterations">
+       <widget class="QSpinBox" name="maxIterations">
         <property name="minimum">
          <number>1</number>
         </property>
@@ -606,7 +606,7 @@
   <tabstop>minIntensity</tabstop>
   <tabstop>maxIntensity</tabstop>
   <tabstop>alignAlgo</tabstop>
-  <tabstop>maxItterations</tabstop>
+  <tabstop>maxIterations</tabstop>
   <tabstop>polynomialDegree</tabstop>
   <tabstop>UndoAlignment</tabstop>
   <tabstop>alignButton</tabstop>

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3116,6 +3116,7 @@ void MainWindow::Align() {
 		workerThread->start();
 		connect(workerThread, SIGNAL(finished()), eicWidget, SLOT(replotForced()));
 		connect(workerThread, SIGNAL(finished()), alignmentDialog, SLOT(close()));
+		connect(workerThread, SIGNAL(restoreAlignment()), alignmentDialog, SLOT(updateRestoreStatus()));
 		return;
 	}
 	

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3189,10 +3189,10 @@ void MainWindow::showAlignmentWidget() {
 void MainWindow::UndoAlignment() {
 	alignmentDialog->samplesAligned(false);
     if(alignmentDialog->alignAlgo->currentIndex() == 1){
-		for (int i = 0; i < samples.size(); i++) {
-			for(int j = 0; j < samples[i]->scans.size(); ++j)
-				if(samples[i]->scans[j]->originalRt >= 0)
-					samples[i]->scans[j]->rt = samples[i]->scans[j]->originalRt;
+		for (auto sample : samples) {
+			for(auto scan : sample->scans)
+				if(scan->originalRt >= 0)
+					scan->rt = scan->originalRt;
 		}
 
 		eicWidget->replotForced();
@@ -3200,17 +3200,17 @@ void MainWindow::UndoAlignment() {
 		return;
 	}
 
-	for (int i = 0; i < samples.size(); i++) {
-		if (samples[i])
-			samples[i]->restoreOriginalRetentionTimes();
+	for (auto sample : samples) {
+		if (sample)
+			sample->restorePreviousRetentionTimes();
 	}
 	getEicWidget()->replotForced();
 
 	mavenParameters->alignButton = 0;
 
 	QList<PeakGroup> listGroups;
-	for (unsigned int i = 0; i<mavenParameters->undoAlignmentGroups.size(); i++) {
-			listGroups.append(mavenParameters->undoAlignmentGroups.at(i));
+	for (auto group : mavenParameters->undoAlignmentGroups) {
+		listGroups.append(group);
 	}
 
 	Q_EMIT(undoAlignment(listGroups));

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3112,6 +3112,7 @@ void MainWindow::Align() {
     if(alignmentDialog->alignAlgo->currentIndex() == 1){
 		workerThread = newWorkerThread("alignWithObiWarp");
 		workerThread->setMavenParameters(mavenParameters);
+		alignmentDialog->setWorkerThread(workerThread);
 		workerThread->start();
 		connect(workerThread, SIGNAL(finished()), eicWidget, SLOT(replotForced()));
 		connect(workerThread, SIGNAL(finished()), alignmentDialog, SLOT(close()));
@@ -3121,9 +3122,10 @@ void MainWindow::Align() {
 	if (alignmentDialog->peakDetectionAlgo->currentText() == "Compound Database Search") {
 		workerThread = newWorkerThread("alignUsingDatabase");
         mavenParameters->setCompounds(DB.getCompoundsSubset(alignmentDialog->selectDatabaseComboBox->currentText().toStdString()));
-
+		alignmentDialog->setWorkerThread(workerThread);
 	} else {
 		workerThread = newWorkerThread("processMassSlices");
+		alignmentDialog->setWorkerThread(workerThread);
 	}
 
 	connect(workerThread, SIGNAL(finished()), eicWidget, SLOT(replotForced()));
@@ -3163,7 +3165,6 @@ void MainWindow::Align() {
 	mavenParameters->stop = false;
 	workerThread->setMavenParameters(mavenParameters);
 	workerThread->setPeakDetector(new PeakDetector(mavenParameters));
-	alignmentDialog->setWorkerThread(workerThread);
 
     //connect new connections
     connect(workerThread, SIGNAL(newPeakGroup(PeakGroup*)), bookmarkedPeaks, SLOT(addPeakGroup(PeakGroup*))); //TODO: Sahil-Kiran, Added while merging mainwindow

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3187,24 +3187,16 @@ void MainWindow::showAlignmentWidget() {
 
 }
 
-void MainWindow::UndoAlignment() {
+void MainWindow::UndoAlignment()
+{
 	alignmentDialog->samplesAligned(false);
-    if(alignmentDialog->alignAlgo->currentIndex() == 1){
-		for (auto sample : samples) {
-			for(auto scan : sample->scans)
-				if(scan->originalRt >= 0)
-					scan->rt = scan->originalRt;
-		}
-
-		eicWidget->replotForced();
-		alignmentDialog->close();
-		return;
-	}
-
+	
 	for (auto sample : samples) {
-		if (sample)
-			sample->restorePreviousRetentionTimes();
+		for(auto scan : sample->scans)
+			if(scan->originalRt >= 0)
+				scan->rt = scan->originalRt;
 	}
+
 	getEicWidget()->replotForced();
 
 	mavenParameters->alignButton = 0;
@@ -3213,9 +3205,9 @@ void MainWindow::UndoAlignment() {
 	for (auto group : mavenParameters->undoAlignmentGroups) {
 		listGroups.append(group);
 	}
-
+	
+	alignmentDialog->close();
 	Q_EMIT(undoAlignment(listGroups));
-
 }
 
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -696,7 +696,7 @@ void MainWindow::saveSettingsToLog() {
     summary << "\n\n-------------------Maven Parameters-------------------"<< "\n"<< "\n";
 //     summary << "runFunction =" << runFunction<< "\n";
     summary << "alignSamplesFlag="  <<  mavenParameters->alignSamplesFlag<< "\n";
-    summary << "alignMaxItterations="  <<  mavenParameters->alignMaxItterations << "\n";
+    summary << "alignMaxIterations="  <<  mavenParameters->alignMaxIterations << "\n";
     summary << "alignPolynomialDegree="  <<  mavenParameters->alignPolynomialDegree << "\n";
 
     summary << "--------------------------------MASS SLICING"<< "\n";
@@ -3154,7 +3154,7 @@ void MainWindow::Align() {
 
 
     mavenParameters->minSignalBlankRatio = 0; //TODO: Sahil-Kiran, Added while merging mainwindow
-    mavenParameters->alignMaxItterations = alignmentDialog->maxItterations->value(); //TODO: Sahil-Kiran, Added while merging mainwindow
+    mavenParameters->alignMaxIterations = alignmentDialog->maxIterations->value(); //TODO: Sahil-Kiran, Added while merging mainwindow
     mavenParameters->alignPolynomialDegree = alignmentDialog->polynomialDegree->value(); //TODO: Sahil-Kiran, Added while merging mainwindow
 
     mavenParameters->checkConvergance=false; //TODO: Sahil-Kiran, Added while merging mainwindow

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -969,7 +969,7 @@ void ProjectDockWidget::loadMzRollProject(QString fileName) {
 				}
 				qDebug() << "polynomialAlignmentTransformation: "; printF(transform);
 				currentSample->polynomialAlignmentTransformation = transform;
-				currentSample->saveOriginalRetentionTimes();
+				currentSample->saveCurrentRetentionTimes();
 				currentSample->applyPolynomialTransform();
 			}
         }

--- a/src/gui/mzroll/samplertwidget.cpp
+++ b/src/gui/mzroll/samplertwidget.cpp
@@ -59,60 +59,60 @@ void SampleRtWidget::setYAxis() {
 
 }
 
-void SampleRtWidget::prepareGraphDataPolyFit(QVector<double>&xAxis, QVector<double>&yAxis, mzSample* sample)
+void SampleRtWidget::prepareGraphDataPolyFit(QVector<double>&xAxis,
+                                             QVector<double>&yAxis,
+                                             mzSample* sample)
 {
-        vector<double> coefficients;
-        double degree;
+    vector<double> coefficients;
+    double degree;
 
-        if (degreeMap.empty()) return;
-        if (coefficientMap.empty()) return;
+    if (degreeMap.empty()) return;
+    if (coefficientMap.empty()) return;
 
-        degree = degreeMap[sample];
-        coefficients = coefficientMap[sample];
-        double *coe = &coefficients[0];
+    degree = degreeMap[sample];
+    coefficients = coefficientMap[sample];
+    double *coe = &coefficients[0];
 
-        /* just a sanity check to prevent SIGSEV
-         */
-        if(!sample->scans.empty() && coe != NULL){
+    // just a sanity check to prevent SIGSEV
+    if (!sample->scans.empty() && coe != NULL) {
+        for (auto const scan : sample->scans) {
+            xAxis.push_back(scan->rt);
 
-            for(unsigned int i=0; i < sample->scans.size(); i++ ) {
-                double rt = sample->scans[i]->rt;
-                xAxis.push_back(rt);
+            double y = 0;
+            y = leasev(coe, degree, scan->rt);
 
-                double y = 0;
-                y = leasev(coe, degree, rt);
-
-                yAxis.push_back(y - rt);
-            }
+            yAxis.push_back(y - scan->rt);
         }
+    }
 }
 
-void SampleRtWidget::prepareGraphDataLoessFit(QVector<double>&xAxis, QVector<double>&yAxis, mzSample* sample)
+void SampleRtWidget::prepareGraphDataLoessFit(QVector<double>&xAxis,
+                                              QVector<double>&yAxis,
+                                              mzSample* sample)
 {
     double rt, rtDiff;
-    if(!sample->originalRetentionTimes.empty() && !sample->scans.empty()){
-
-        for(unsigned int i=0; i < sample->scans.size(); i++ ) {
-
-            rt = sample->originalRetentionTimes[i];
+    if (!sample->scans.empty()) {
+        for (auto const scan : sample->scans) {
+            rt = scan->originalRt;
             xAxis.push_back(rt);
 
-            rtDiff = sample->originalRetentionTimes[i] - sample->scans[i]->rt;
+            rtDiff = scan->originalRt - scan->rt;
             yAxis.push_back(rtDiff);
         }
     }
 }
 
-void SampleRtWidget::prepareGraphDataObiWarp(QVector<double>&xAxis, QVector<double>&yAxis, mzSample* sample)
+void SampleRtWidget::prepareGraphDataObiWarp(QVector<double>&xAxis,
+                                             QVector<double>&yAxis,
+                                             mzSample* sample)
 {
     double rt, rtDiff;
 
-    for(unsigned int i=0; i < sample->scans.size(); i++ ) {
-
-        rt = sample->scans[i]->originalRt;
+    for (auto const scan : sample->scans) {
+        rt = scan->originalRt;
         xAxis.push_back(rt);
 
-        rtDiff = sample->scans[i]->originalRt - sample->scans[i]->rt;
+        rtDiff = scan->originalRt - scan->rt;
         yAxis.push_back(rtDiff);
     }
 }

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -1450,8 +1450,8 @@ void TableDockWidget::align() {
     for (int i = 0; i < allgroups.size(); i++)
       groups.push_back(&allgroups[i]);
     Aligner aligner;
-    aligner.setMaxItterations(
-        _mainwindow->alignmentDialog->maxItterations->value());
+    aligner.setMaxIterations(
+        _mainwindow->alignmentDialog->maxIterations->value());
     aligner.setPolymialDegree(
         _mainwindow->alignmentDialog->polynomialDegree->value());
     aligner.doAlignment(groups);

--- a/tests/MavenTests/testMzAligner.cpp
+++ b/tests/MavenTests/testMzAligner.cpp
@@ -46,7 +46,7 @@ void TestMzAligner::testObiWarp()
 
     ObiParams params("cor", false, 2.0, 1.0, 0.20, 3.40, 0.0, 20.0, false, 0.60);
     Aligner aligner;
-    aligner.alignWithObiWarp(mavenparameters->samples, &params);
+    aligner.alignWithObiWarp(mavenparameters->samples, &params, mavenparameters);
 
     maventests::database.loadCompoundCSVFile("bin/methods/KNOWNS.csv");
     vector<Compound*> compounds = maventests::database.getCompoundsSubset("KNOWNS");


### PR DESCRIPTION
Expected behavior:
- Stops alignment process. Alignment status shows cancellation is in progress
- Restore all RTs to the state before this round of alignment started
- If no alignment was performed before the canceled process, undo alignment stays disabled
- visualization plot uses original RT to calculate RT deviations, not current RTs
