### PR TITLE
Fix certain emDB autosave issues

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -874,16 +874,24 @@ void MainWindow::_setProjectFilenameIfEmpty()
     }
 }
 
-void MainWindow::_setProjectFilenameFromProjectDockWidget()
+QString MainWindow::_getProjectFilenameFromProjectDockWidget()
 {
     auto lastSave = projectDockWidget->getLastSavedTime();
     auto lastLoad = projectDockWidget->getLastOpenedTime();
-    if (!projectDockWidget->getLastOpenedProject().isEmpty()
-            && lastLoad > lastSave)
-        _currentProjectName = projectDockWidget->getLastOpenedProject();
     if (!projectDockWidget->getLastSavedProject().isEmpty()
             && lastSave > lastLoad)
-        _currentProjectName = projectDockWidget->getLastSavedProject();
+        return projectDockWidget->getLastSavedProject();
+    if (!projectDockWidget->getLastOpenedProject().isEmpty()
+            && lastLoad > lastSave)
+        return projectDockWidget->getLastOpenedProject();
+    return "";
+}
+
+QString MainWindow::getLatestUserProject()
+{
+    if (_latestUserProjectName.isEmpty())
+        return _getProjectFilenameFromProjectDockWidget();
+    return _latestUserProjectName;
 }
 
 void MainWindow::resetAutosave()
@@ -939,7 +947,7 @@ void MainWindow::saveProject(bool explicitSave)
             return;
 
         if (_currentProjectName.isEmpty())
-            _setProjectFilenameFromProjectDockWidget();
+            _currentProjectName = _getProjectFilenameFromProjectDockWidget();
 
         // if no projects were saved or opened
         if (_latestUserProjectName.isEmpty()) {
@@ -999,7 +1007,7 @@ void MainWindow::saveProject(bool explicitSave)
         }
         this->autosave->saveProjectWorker();
     } else if (explicitSave) {
-        _setProjectFilenameFromProjectDockWidget();
+        _currentProjectName = _getProjectFilenameFromProjectDockWidget();
         if (_latestUserProjectName.isEmpty()) {
             auto reply = QMessageBox::question(this,
                                                "No project open",

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -908,6 +908,11 @@ void MainWindow::autosaveProject()
 
 void MainWindow::explicitSave()
 {
+    // the user is ordering an explicit save, reset the current project name
+    if (timestampFileExists) {
+        resetAutosave();
+    }
+
     saveProject(true);
 }
 
@@ -1005,7 +1010,6 @@ void MainWindow::saveProject(bool explicitSave)
 
             _loadedProjectName = _currentProjectName;
         } else {
-            resetAutosave();
             _currentProjectName = _loadedProjectName;
         }
         this->autosave->saveProjectWorker();

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -934,6 +934,14 @@ void MainWindow::threadSave(QString filename)
 
     _currentProjectName = filename;
     _latestUserProjectName = filename;
+
+    QFileInfo fileInfo(filename);
+    setWindowTitle(programName
+                   + "_"
+                   + STR(EL_MAVEN_VERSION)
+                   + " "
+                   + fileInfo.fileName());
+
     autosave->saveProjectWorker();
 }
 
@@ -1024,6 +1032,12 @@ void MainWindow::saveProject(bool explicitSave)
                 return;
 
             _latestUserProjectName = _currentProjectName;
+            QFileInfo fileInfo(_latestUserProjectName);
+            setWindowTitle(programName
+                           + "_"
+                           + STR(EL_MAVEN_VERSION)
+                           + " "
+                           + fileInfo.fileName());
         } else {
             _currentProjectName = _latestUserProjectName;
         }
@@ -1695,6 +1709,15 @@ void MainWindow::open()
     if (!sqliteProjectBeingLoaded.isEmpty()) {
         projectDockWidget->saveAndCloseCurrentSQLiteProject();
         _latestUserProjectName = sqliteProjectBeingLoaded;
+
+        // reset filename in the title to overwrite any saves while closing last
+        // SQLite project
+        QFileInfo fileInfo(_latestUserProjectName);
+        setWindowTitle(programName
+                       + "_"
+                       + STR(EL_MAVEN_VERSION)
+                       + " "
+                       + fileInfo.fileName());
     }
 
     bool cancelUploading = false;

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -513,7 +513,7 @@ private:
      * @brief Name of the project that was last loaded or saved and will be used
      * when saving from explicit user command or final save when exiting app.
      */
-    QString _loadedProjectName;
+    QString _latestUserProjectName;
 
     QString newFileName;
 

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -445,6 +445,12 @@ public Q_SLOTS:
      */
     void resetAutosave();
 
+    /**
+     * @brief Get the latest project that was loaded/saved by the user.
+     * @return A QString storing the name of the project.
+     */
+    QString getLatestUserProject();
+
 private Q_SLOTS:
 	void createMenus();
 	void openURL(int choice);
@@ -519,7 +525,7 @@ private:
 
     QString _newAutosaveFile();
     void _setProjectFilenameIfEmpty();
-    void _setProjectFilenameFromProjectDockWidget();
+    QString _getProjectFilenameFromProjectDockWidget();
     void _saveMzRollList(QString projectFileName);
     void _saveAllTablesAsMzRoll();
     void checkCorruptedSampleInjectionOrder();

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -653,9 +653,8 @@ void ProjectDockWidget::saveProjectAsSQLite()
 void ProjectDockWidget::saveSQLiteProject(QString filename)
 {
     auto success = _mainwindow->fileLoader->writeSQLiteProject(filename);
-    if (success)
+    if (success && !_mainwindow->timestampFileExists)
         setLastSavedProject(filename);
-    setLastSavedProject(filename);
 }
 
 void ProjectDockWidget::saveSQLiteProject()

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -659,8 +659,8 @@ void ProjectDockWidget::saveSQLiteProject(QString filename)
 
 void ProjectDockWidget::saveSQLiteProject()
 {
-    if (_mainwindow->fileLoader->sqliteProjectIsOpen()) {
-        _mainwindow->threadSave(getLastOpenedProject());
+    if (!_mainwindow->getLatestUserProject().isEmpty()) {
+        _mainwindow->threadSave(_mainwindow->getLatestUserProject());
     } else {
         saveProjectAsSQLite();
     }
@@ -688,11 +688,11 @@ void ProjectDockWidget::saveAndCloseCurrentSQLiteProject()
         return;
     }
 
-    auto userSessionWarning =
-        "Do you want to save your current session before opening the project?";
-    if (_mainwindow->fileLoader->sqliteProjectIsOpen())
-        userSessionWarning =
-            "Do you want to save and close the current project?";
+    auto userSessionWarning = "Do you want to save your current session before "
+                              "opening the project?";
+    if (!_mainwindow->getLatestUserProject().isEmpty())
+        userSessionWarning = "Do you want to save and close the current "
+                             "project?";
     QMessageBox::StandardButton reply = QMessageBox::question(
         this,
         "Opening Project",
@@ -700,9 +700,11 @@ void ProjectDockWidget::saveAndCloseCurrentSQLiteProject()
         QMessageBox::No | QMessageBox::Yes,
         QMessageBox::Yes
     );
-    _mainwindow->resetAutosave();
-    if (reply == QMessageBox::Yes)
+    if (reply == QMessageBox::Yes) {
         saveSQLiteProject();
+    } else {
+        _mainwindow->resetAutosave();
+    }
 
     // if an existing project is being saved, stall before clearing the session
     while(_mainwindow->autosave->isRunning());


### PR DESCRIPTION
This PR fixes the following issues pertaining to autosaving using emDB project format:
1. Fix explicit save operation using timestamp project name.
2. Fix threaded save not setting last saved project.
3. Fix no save before new session load.