### PR TITLE
Disable storing alignment data for samples with MS2 scans

### DIFF
--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -1,4 +1,5 @@
 #include <sstream>
+#include <unordered_map>
 #include <boost/filesystem.hpp>
 #include "projectdatabase.h"
 #include "Compound.h"
@@ -796,9 +797,9 @@ void ProjectDatabase::loadAndPerformAlignment(const vector<mzSample*>& loaded)
               , samples                                    \
           WHERE samples.sample_id = alignment_rts.sample_id");
 
-    map<int, map<int, Scan*>> sampleScanMap;
+    unordered_map<int, unordered_map<int, Scan*>> sampleScanMap;
     for (auto sample : loaded) {
-        map<int, Scan*> scanMap;
+        unordered_map<int, Scan*> scanMap;
         for (auto scan : sample->scans) {
             scanMap[scan->scannum] = scan;
         }

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -372,6 +372,10 @@ void ProjectDatabase::saveAlignment(const vector<mzSample*>& samples)
     _connection->begin();
 
     for (auto s : samples) {
+        // ignore samples having MS2 scans
+        if (s->ms2ScanCount() > 0)
+            continue;
+
         for (auto scan : s->scans) {
             float rt_original = scan->originalRt;
             float rt_updated = scan->rt;
@@ -799,6 +803,10 @@ void ProjectDatabase::loadAndPerformAlignment(const vector<mzSample*>& loaded)
 
     unordered_map<int, unordered_map<int, Scan*>> sampleScanMap;
     for (auto sample : loaded) {
+        // ignore samples having MS2 scans
+        if (sample->ms2ScanCount() > 0)
+            continue;
+
         unordered_map<int, Scan*> scanMap;
         for (auto scan : sample->scans) {
             scanMap[scan->scannum] = scan;


### PR DESCRIPTION
This following attempts have been made to reduce load times with emDB while restoring alignment data:
 * Use an `unordered_map` for scan map whose average insertion/access has constant time complexity (compared to log(n) complexity of the regular C++ `map` data structure).
 * Completely ignore storing and restoring of samples having MS2 scans. PRM and MRM datasets have not been confirmed to work well (or at all) with the alignment algorithms present in El-MAVEN. There can be some efficiency in storage of scan data (or at least alignment data) as well. Until these improvements are in place, the save/load feature for alignment data of these samples will be disabled.