### PR TITLE
Disable alignment for samples containing MS2 scans

### DIFF
--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -200,6 +200,22 @@ void AlignmentDialog::algoChanged()
     samplesBox->setVisible(obiWarp);
     refSampleLabel->setVisible(obiWarp);
 
+    auto samples = _mw->getSamples();
+    auto ms2SamplesDetected = false;
+    for (const auto sample : samples) {
+        if (sample->ms2ScanCount() > 0) {
+            showInfo("Obi-warp does not work with MS2 scans at the moment.\nWe "
+                     "will inform you once this functionality has been added.");
+            ms2SamplesDetected = true;
+            alignButton->setDisabled(true);
+            break;
+        }
+    }
+    if (!ms2SamplesDetected || !obiWarp) {
+        alignButton->setDisabled(false);
+        setProgressBar("Status", 0, 1);
+    }
+
 	if (peakDetectionAlgo->currentIndex() == 0) {
 		selectDatabase->setVisible(true);
 		selectDatabaseComboBox->setVisible(true);


### PR DESCRIPTION
OBI-Warp alignment takes too long for MS2 scans and appears to have frozen the application. Moreover, we have not confirmed if it actually works for such datasets. This commit disables alignment while any samples loaded contain MS/MS scans.