### PR TITLE
Remove optimization flag from GUI build script

### DIFF
--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -12,7 +12,6 @@ QMAKE_CXXFLAGS +=  -std=c++11
 QMAKE_CXXFLAGS += -DOMP_PARALLEL
 linux: QMAKE_CXXFLAGS += -Ofast -ffast-math
 win32: QMAKE_CXXFLAGS += -Ofast -ffast-math
-macx: QMAKE_CXXFLAGS += -O3
 QMAKE_CXXFLAGS += -fopenmp
 !macx: LIBS += -fopenmp
 


### PR DESCRIPTION
Optimization flags are not needed for the frontend code of the application because most intensive calculations take place in libmaven. The presence of the "O3" flag in mzroll build script was leading to an endless number of crash reporters spawning when the application crashed on a MacOS system.