### PR TITLE
Return true from crash reporter's callback

### DIFF
--- a/src/gui/mzroll/ElmavCrashHandler.cpp
+++ b/src/gui/mzroll/ElmavCrashHandler.cpp
@@ -53,7 +53,7 @@ static bool startCrashReporter(const wchar_t* dump_path,const wchar_t* id, void*
     cReporter->setProgram(qApp->applicationDirPath() + QDir::separator() + CRASH_REPORTER_WIN);
     cReporter->setArguments(QStringList() << QString::fromWCharArray(dump_path));
     cReporter->start();
-
+    return true;
 }
 #endif
 
@@ -78,6 +78,7 @@ static bool startCrashReporter(const char* dump_dir,const char* id, void* contex
 //    cReporter->setArguments(QStringList() << QString(eh->dump_path().c_str()));
     qDebug() << "arguments : " << cReporter->arguments();
     cReporter->startDetached(crashReporterPath,QStringList() << QString(eh->dump_path().c_str()));
+    return true;
 }
 #endif
 


### PR DESCRIPTION
The handler that Breakpad calls after generating the dump, to launch custom crash reporter must return true to make breakpad behave as if it has successfully handled the exception. This will ensure that breakpad terminates the aborted application and prevent system's crash reporter from coming up.