### PR TITLE
Use open instead of exec to prevent rare alignment bug

### DIFF
--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -85,7 +85,7 @@ void AlignmentDialog::show()
 	_mw->getAnalytics()->hitScreenView("AlignmentDialog");
     inputInitialValuesAlignmentDialog();
 	intialSetup();
-	QDialog::exec();
+        QDialog::open();
 }
 
 void AlignmentDialog::inputInitialValuesAlignmentDialog()


### PR DESCRIPTION
Using `open` for a dialog opens is asynchronously and prevents certain bugs that might otherwise occur when `exec` is used in its place.

See: http://doc.qt.io/qt-5/qdialog.html#exec