### PR TITLE
[Fix] Show error message for obi-warp instead of exiting

### DIFF
--- a/3rdparty/obiwarp/obiwarp.cpp
+++ b/3rdparty/obiwarp/obiwarp.cpp
@@ -106,11 +106,12 @@ vector<float> ObiWarp::align(vector<float> &rtPoints, vector<float> &mzPoints, v
 
     VecF nOutF;
     VecF mOutF;
-    tm_axis_vals(mOut, mOutF, _tm,_tm_vals);
-    tm_axis_vals(nOut, nOutF, tm,tm_vals); //
+    vector<float> alignedRts;
+    if (!tm_axis_vals(mOut, mOutF, _tm,_tm_vals) ||
+        !tm_axis_vals(nOut, nOutF, tm,tm_vals))
+        return alignedRts;
     warp_tm(nOutF, mOutF, tm);
     
-    vector<float> alignedRts;
     float* rts = tm.pointer();
     for(int i = 0; i < tm_vals; ++i)
         alignedRts.push_back(rts[i]);
@@ -122,7 +123,7 @@ vector<float> ObiWarp::align(vector<float> &rtPoints, vector<float> &mzPoints, v
 }
 
 
-void ObiWarp::tm_axis_vals(VecI &tmCoords, VecF &tmVals,VecF &_tm ,int _tm_vals){
+bool ObiWarp::tm_axis_vals(VecI &tmCoords, VecF &tmVals,VecF &_tm ,int _tm_vals){
     VecF tmp(tmCoords.length());
     for (int i = 0; i < tmCoords.length(); ++i) {
         if (tmCoords[i] < _tm_vals) {
@@ -130,10 +131,11 @@ void ObiWarp::tm_axis_vals(VecI &tmCoords, VecF &tmVals,VecF &_tm ,int _tm_vals)
         }
         else {
             printf("asking for time value at index: %d (length: %d)\n", tmCoords[i], _tm_vals);
-            exit(1);
+            return(false);
         }
     }
     tmVals.take(tmp);
+    return(true);
 }
 
 void ObiWarp::warp_tm(VecF &selfTimes, VecF &equivTimes, VecF &_tm){

--- a/3rdparty/obiwarp/obiwarp.h
+++ b/3rdparty/obiwarp/obiwarp.h
@@ -34,7 +34,7 @@ public:
     void setReferenceData(vector<float> &rtPoints, vector<float> &mzPoints, vector<vector<float> >& intMat);
     vector<float> align(vector<float> &rtPoints, vector<float> &mzPoints, vector<vector<float> >& intMat);
 private:
-    void tm_axis_vals(VecI &tmCoords, VecF &tmVals,VecF &_tm ,int _tm_vals);
+    bool tm_axis_vals(VecI &tmCoords, VecF &tmVals,VecF &_tm ,int _tm_vals);
     void warp_tm(VecF &selfTimes, VecF &equivTimes, VecF &_tm);
     VecF _tm;
     VecF _mz;

--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -479,6 +479,7 @@ bool Aligner::alignSampleRts(mzSample* sample,
     }
     else {
         rtPoints = obiWarp.align(rtPoints, mzPoints, mxn);
+        if (rtPoints.empty()) return(true);
         for(int j = 0; j < sample->scans.size(); ++j) {
             if (mp->stop) return (true);
             sample->scans[j]->rt = rtPoints[j];
@@ -543,7 +544,7 @@ bool Aligner::alignWithObiWarp(vector<mzSample*> samples,
     for (int i = 0; i < samples.size(); ++i) {
         if (samples[i] == refSample)
             continue;
-        if (mp->stop) {
+        if (mp->stop || stopped) {
             stopped = true;
             #pragma omp cancel for
         }

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -251,7 +251,7 @@ void BackgroundPeakUpdate::run(void) {
                 quit();
                 return;
         }
-        connect(this,SIGNAL(alignmentError(QString)),mainwindow,SLOT(showAlignmetErrorDialog(QString)));
+        connect(this, SIGNAL(alignmentError(QString)), mainwindow, SLOT(showAlignmentErrorDialog(QString)));
         if (mavenParameters->alignSamplesFlag) {
                 connect(this, SIGNAL(alignmentComplete(QList<PeakGroup> )), mainwindow, SLOT(showAlignmentWidget()));
         }
@@ -305,6 +305,7 @@ void BackgroundPeakUpdate::alignWithObiWarp()
     Aligner aligner;
     aligner.setAlignmentProgress.connect(boost::bind(&BackgroundPeakUpdate::qtSlot,
                                                      this, _1, _2, _3));
+
     _stopped = aligner.alignWithObiWarp(mavenParameters->samples, obiParams, mavenParameters);
     delete obiParams;
 
@@ -314,6 +315,12 @@ void BackgroundPeakUpdate::alignWithObiWarp()
         for (auto sample : mavenParameters->samples) {
             sample->restorePreviousRetentionTimes();
         }
+
+        //stopped without user intervention
+        if (!mavenParameters->stop)
+            Q_EMIT(alignmentError(
+                   QString("There was an error during alignment. Please try again.")));
+
         mavenParameters->stop = false;
         return;
     }

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1117,12 +1117,11 @@ void MainWindow::savePeakTableAsMzRoll(TableDockWidget* peaksTable,
     }
 }
 
-void MainWindow::showAlignmetErrorDialog(QString errorMessage)
+void MainWindow::showAlignmentErrorDialog(QString errorMessage)
 {
-    QErrorMessage alignmentErrorDialog(this);
-    alignmentErrorDialog.setWindowTitle("Alignment Error");
-    alignmentErrorDialog.showMessage(errorMessage);
-    alignmentErrorDialog.exec();
+    QMessageBox alignmentError;
+    alignmentError.setText(errorMessage);
+    alignmentError.open();
 }
 
 void MainWindow::openAWSDialog()

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -323,7 +323,7 @@ public Q_SLOTS:
     void togglePerGroupAlignmentWidget();
     void toggleAllGroupAlignmentWidget();
     void toggleSampleRtWidget();
-	void showAlignmetErrorDialog(QString errorMessage);
+	void showAlignmentErrorDialog(QString errorMessage);
 	void setMassCutoffType(QString massCutoffType);
 	void printvalue();
     void autosaveProject();


### PR DESCRIPTION
The app exits abruptly if a  sanity check in obi-warp (3rd party) fails. This leads to frequent crashes during alignment. This is non-deterministic and alignment tends to work if the process is re-started.
Until the reason for this process being non-deterministic is found, an error message has been put in place that will cancel the alignment if the check fails and ask the user to try again. This is just a temporary solution to prevent data loss.