### PR TITLE
Revamp code around loading NIST library files

### DIFF
--- a/src/core/libmaven/Compound.cpp
+++ b/src/core/libmaven/Compound.cpp
@@ -29,5 +29,23 @@ float Compound::adjustedMass(int charge) {
     *@return    -    total mass by formula minus loss of electrons' mass 
     *@see  -  double MassCalculator::computeMass(string formula, int charge) in mzMassCalculator.cpp
     */
-    return MassCalculator::computeMass(formula,charge); 
+    return MassCalculator::computeMass(formula,charge);
+}
+
+Compound::Type Compound::type() {
+    bool hasFragMzs = fragmentMzValues.size() > 0;
+    bool hasFragInts = fragmentIntensities.size() == fragmentMzValues.size();
+    if (hasFragMzs && hasFragInts)
+        return Type::PRM;
+
+    bool hasPrecursorMz = precursorMz > 0;
+    bool hasProductMz = productMz > 0;
+    if (hasPrecursorMz && hasProductMz)
+        return Type::MRM;
+
+    // Is this the only requirement for being usable as an MS1 compound?
+    if (mass)
+        return Type::MS1;
+
+    return Type::UNKNOWN;
 }

--- a/src/core/libmaven/Compound.h
+++ b/src/core/libmaven/Compound.h
@@ -27,6 +27,13 @@ class Compound{
         bool      _groupUnlinked;
 
     public:
+        enum class Type {
+            MS1,
+            MRM,
+            PRM,
+            UNKNOWN
+        };
+
         /**
         *@brief  -   constructor for this compound
         */
@@ -120,6 +127,13 @@ class Compound{
          * @brief categories of this compund or peptide etc.
          */
         vector<string> category;
+
+        /**
+         * @brief Get the type of this compound, whether it can be used for
+         * targeted analysis of MS (level 1), SRM, MRM or PRM datasets.
+         * @return Type of the compound as a `Compound::Type` enum.
+         */
+        Type type();
 
         float adjustedMass(int charge);  /**   total mass by formula minus loss of electrons' mass  */
         void addReaction(Reaction* r) { reactions.push_back(r); }   /**  add reaction of this compound   */

--- a/src/core/libmaven/Compound.h
+++ b/src/core/libmaven/Compound.h
@@ -59,8 +59,14 @@ class Compound{
         string hmdb_id;         /**@param  -  hmdb_id-    Human Metabolome Database id */
         string alias;       /**@param   -  alias name of compound   */
 
-        // TODO: from MAVEN (upstream), find out what this is
+        /**
+         * @brief A simple string in form of a line notation for describing the
+         * structure of chemical species using short ASCII strings.
+         */
         string smileString;
+
+        // TODO: from MAVEN (upstream), find out what this is
+        string adductString;
 
         /**
         *@param -  srmId will hold filterLine string from mzxml file which represent type of
@@ -92,9 +98,28 @@ class Compound{
         string db;			/**@param -   name of database for example KEGG, ECOCYC.. etc..    */
 
         int transition_id;  /**  TODO */
-        vector<float>fragment_mzs;  /**@param  -   mzs of fragments generated from this compund   */
-        vector<float>fragment_intensity;    /**@param  -  intensities of fragments generated from this compund     */
-        vector<string> category;    /**@param  -   categories of this compund- peptide etc.   */
+
+        /**
+         * @brief Vector of m/z values of fragments generated from this compund.
+         */
+        vector<float>fragmentMzValues;
+
+        /**
+         * @brief Vector of intensities of fragments generated from this
+         * compund.
+         */
+        vector<float>fragmentIntensities;
+
+        /**
+         * @brief Collection of indices of fragment values mapping to its
+         * ionisation type information.
+         */
+        map<int, string>fragmentIonTypes;
+
+        /**
+         * @brief categories of this compund or peptide etc.
+         */
+        vector<string> category;
 
         float adjustedMass(int charge);  /**   total mass by formula minus loss of electrons' mass  */
         void addReaction(Reaction* r) { reactions.push_back(r); }   /**  add reaction of this compound   */

--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -99,6 +99,7 @@ bool Database::addCompound(Compound* newCompound)
         compoundAdded = true;
     } else {
         bool matched = false;
+        bool newFragmentPattern = false;
         for (int i = 0; i < compoundsDB.size(); i++) {
             Compound* currentCompound = compoundsDB[i];
             bool sameID = currentCompound->id == newCompound->id;
@@ -141,20 +142,21 @@ bool Database::addCompound(Compound* newCompound)
                 if (equalMzs && equalIntensities && equalIonTypes) {
                     matched = true;
                 } else {
-                    // same compound but different fragmentation spectra, change
-                    // its name according to the number of compounds with the
-                    // same ID
-                    int loadOrder = prmIdCount.at(newCompound->id);
-                    newCompound->name = newCompound->name
-                                        + " ("
-                                        + to_string(loadOrder)
-                                        + ")";
-                    prmIdCount[newCompound->id] = ++loadOrder;
-                    break;
+                    newFragmentPattern = true;
                 }
             }
         }
         if (!matched) {
+            // existing compound but different fragmentation spectra, change
+            // its name according to the number of compounds with the same ID
+            if (newFragmentPattern) {
+                int loadOrder = prmIdCount.at(newCompound->id);
+                newCompound->name = newCompound->name
+                                    + " ("
+                                    + to_string(loadOrder)
+                                    + ")";
+                prmIdCount[newCompound->id] = ++loadOrder;
+            }
             compoundsDB.push_back(newCompound);
             compoundAdded = true;
         }

--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -91,15 +91,6 @@ bool Database::addCompound(Compound* newCompound)
 
     bool compoundAdded = false;
 
-    // lambda that checks if a compound contains PRM information
-    auto isPRM = [](const Compound* cpd) -> bool {
-        bool hasMzValues = cpd->fragmentMzValues.size() > 0;
-        bool hasIntensityValues =
-            cpd->fragmentIntensities.size()
-            == cpd->fragmentMzValues.size();
-        return hasMzValues && hasIntensityValues;
-    };
-
     // new compound id, insert into compound list
     if (!compoundIdMap.count(newCompound->id)) {
         compoundIdMap[newCompound->id] = newCompound;
@@ -112,7 +103,8 @@ bool Database::addCompound(Compound* newCompound)
             Compound* currentCompound = compoundsDB[i];
             bool sameID = currentCompound->id == newCompound->id;
             bool sameDB = currentCompound->db == newCompound->db;
-            bool bothPRM = isPRM(currentCompound) && isPRM(newCompound);
+            bool bothPRM = (currentCompound->type() == Compound::Type::PRM
+                            && newCompound->type() == Compound::Type::PRM);
 
             // compound with same ID and from the same database but not PRM
             if (sameDB && sameID && !bothPRM) {
@@ -432,6 +424,13 @@ map<string,int> Database::getDatabaseNames() {
 	return dbnames;
 }
 
+bool Database::isNISTLibrary(string dbName) {
+    auto compounds = getCompoundsSubset(dbName);
+    if (compounds.size() > 0) {
+        return compounds.at(0)->type() == Compound::Type::PRM;
+    }
+    return false;
+}
 
 void Database::loadAdducts(string filename) {
     ifstream myfile(filename.c_str());

--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -84,36 +84,86 @@ void Database::loadCategories() {
 	return;
 }
 
-bool Database::addCompound(Compound* c) {
-    if(c == NULL) return false;
+bool Database::addCompound(Compound* newCompound)
+{
+    if(newCompound == nullptr)
+        return false;
+
     bool compoundAdded = false;
 
-    //new compound id .. insert into compound list
-    if (!compoundIdMap.count(c->id)) {
-        compoundIdMap[c->id] = c;
-        compoundsDB.push_back(c);
+    // lambda that checks if a compound contains PRM information
+    auto isPRM = [](const Compound* cpd) -> bool {
+        bool hasMzValues = cpd->fragmentMzValues.size() > 0;
+        bool hasIntensityValues =
+            cpd->fragmentIntensities.size()
+            == cpd->fragmentMzValues.size();
+        return hasMzValues && hasIntensityValues;
+    };
+
+    // new compound id, insert into compound list
+    if (!compoundIdMap.count(newCompound->id)) {
+        compoundIdMap[newCompound->id] = newCompound;
+        prmIdCount[newCompound->id] = 1;
+        compoundsDB.push_back(newCompound);
         compoundAdded = true;
-    } else { //compound exists with the same name, match database
-        bool matched=false;
-        for(int i=0; i < compoundsDB.size();i++) {
+    } else {
+        bool matched = false;
+        for (int i = 0; i < compoundsDB.size(); i++) {
             Compound* currentCompound = compoundsDB[i];
-            if ( currentCompound->db == c->db && currentCompound->id==c->id) { //compound from the same database
-                currentCompound->id=c->id;
-                currentCompound->name=c->name;
-                currentCompound->formula = c->formula;
-                currentCompound->srmId = c->srmId;
-                currentCompound->expectedRt = c->expectedRt;
-                currentCompound->charge = c->charge;
-                currentCompound->mass = c->mass;
-                currentCompound->precursorMz = c->precursorMz;
-                currentCompound->productMz = c->productMz;
-                currentCompound->collisionEnergy = c->collisionEnergy;
-                currentCompound->category = c->category;
-                matched=true;
+            bool sameID = currentCompound->id == newCompound->id;
+            bool sameDB = currentCompound->db == newCompound->db;
+            bool bothPRM = isPRM(currentCompound) && isPRM(newCompound);
+
+            // compound with same ID and from the same database but not PRM
+            if (sameDB && sameID && !bothPRM) {
+                currentCompound->name = newCompound->name;
+                currentCompound->formula = newCompound->formula;
+                currentCompound->srmId = newCompound->srmId;
+                currentCompound->expectedRt = newCompound->expectedRt;
+                currentCompound->charge = newCompound->charge;
+                currentCompound->mass = newCompound->mass;
+                currentCompound->precursorMz = newCompound->precursorMz;
+                currentCompound->productMz = newCompound->productMz;
+                currentCompound->collisionEnergy = newCompound->collisionEnergy;
+                currentCompound->category = newCompound->category;
+
+                currentCompound->fragmentMzValues =
+                    newCompound->fragmentMzValues;
+                currentCompound->fragmentIntensities =
+                    newCompound->fragmentIntensities;
+                currentCompound->fragmentIonTypes =
+                    newCompound->fragmentIonTypes;
+
+                matched = true;
+            } else if (sameDB && sameID && bothPRM) {
+                bool equalMzs =
+                    newCompound->fragmentMzValues
+                    == currentCompound->fragmentMzValues;
+                bool equalIntensities =
+                    newCompound->fragmentIntensities
+                    == currentCompound->fragmentIntensities;
+                bool equalIonTypes =
+                    newCompound->fragmentIonTypes
+                    == currentCompound->fragmentIonTypes;
+
+                if (equalMzs && equalIntensities && equalIonTypes) {
+                    matched = true;
+                } else {
+                    // same compound but different fragmentation spectra, change
+                    // its name according to the number of compounds with the
+                    // same ID
+                    int loadOrder = prmIdCount.at(newCompound->id);
+                    newCompound->name = newCompound->name
+                                        + " ("
+                                        + to_string(loadOrder)
+                                        + ")";
+                    prmIdCount[newCompound->id] = ++loadOrder;
+                    break;
+                }
             }
         }
-        if(!matched) {
-            compoundsDB.push_back(c);
+        if (!matched) {
+            compoundsDB.push_back(newCompound);
             compoundAdded = true;
         }
     }

--- a/src/gui/mzroll/database.h
+++ b/src/gui/mzroll/database.h
@@ -49,7 +49,19 @@ class Database {
 
 	vector<string> getPathwayReactions(string pathway_id);
 
-	map<string, int> getDatabaseNames();
+        /**
+         * @brief Checks whether the library with the given name is an NIST
+         * library or not.
+         * @details The first compound in the database (if it has any compounds)
+         * is checked for PRM information and if found, the database is
+         * regarded as an NIST library.
+         * @param dbName String name of the database to be checked.
+         * @return True if the database with given name is an NIST library,
+         * false otherwise.
+         */
+        bool isNISTLibrary(string dbName);
+
+        map<string, int> getDatabaseNames();
 	map<string, int> getChromotographyMethods();
 
 	Molecule2D* getMolecularCoordinates(QString id);

--- a/src/gui/mzroll/database.h
+++ b/src/gui/mzroll/database.h
@@ -74,11 +74,12 @@ class Database {
 	deque<Molecule2D*> coordinatesDB;
 
 	map<string, Compound*> compoundIdMap;
-	map<string, Reaction*> reactionIdMap;
+        map<string, Reaction*> reactionIdMap;
 	map<string, Pathway*> pathwayIdMap;
 	map<string, Molecule2D*> coordinatesMap;
     vector<string> notFoundColumns;
     vector<string> invalidRows;
+    map<string, int> prmIdCount;
     //Added while merging with Maven776 - Kiran
     const std::string ANYDATABASE;
        private:

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -374,12 +374,18 @@ void LigandWidget::showTable() {
         parent->setData(0, Qt::UserRole, QVariant::fromValue(compound));
         parent->setFlags(Qt::ItemIsSelectable|Qt::ItemIsDragEnabled|Qt::ItemIsEnabled);
 
-        if (compound->charge) addItem(parent,"Charge", compound->charge);
-        if (compound->formula.length()) addItem(parent,"Formula", compound->formula.c_str());
-        if (compound->precursorMz) addItem(parent,"Precursor Mz", compound->precursorMz);
-        if (compound->productMz) addItem(parent,"Product Mz", compound->productMz);
-        if (compound->collisionEnergy) addItem(parent,"Collision Energy", compound->collisionEnergy);
-        if (compound->hasGroup() ) parent->setIcon(0,QIcon(":/images/link.png"));
+        if (compound->charge)
+            addItem(parent, "Charge", compound->charge);
+        if (compound->formula.length())
+            addItem(parent, "Formula", compound->formula.c_str());
+        if (compound->precursorMz && compound->fragmentMzValues.size() == 0)
+            addItem(parent, "Precursor Mz", compound->precursorMz);
+        if (compound->productMz)
+            addItem(parent, "Product Mz", compound->productMz);
+        if (compound->collisionEnergy)
+            addItem(parent, "Collision Energy", compound->collisionEnergy);
+        if (compound->hasGroup())
+            parent->setIcon(0, QIcon(":/images/link.png"));
 
         if(compound->category.size() > 0) {
             QStringList catList;

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -389,12 +389,12 @@ void LigandWidget::showTable() {
             parent->setText(3,catList.join(";"));
         }
 
-        if (compound->fragment_mzs.size()) {
+        if (compound->fragmentMzValues.size()) {
             QStringList mzList;
-            for(unsigned int i=0; i<compound->fragment_mzs.size();i++) {
-                mzList << QString::number(compound->fragment_mzs[i],'f',2);
+            for(unsigned int i=0; i<compound->fragmentMzValues.size();i++) {
+                mzList << QString::number(compound->fragmentMzValues[i],'f',2);
             }
-            QTreeWidgetItem* child = addItem(parent,"Fragments",compound->fragment_mzs[0]);
+            QTreeWidgetItem* child = addItem(parent,"Fragments",compound->fragmentMzValues[0]);
             child->setText(1,mzList.join(";"));
         }
 
@@ -722,20 +722,20 @@ Compound* LigandWidget::getSelectedCompound() {
 void LigandWidget::matchFragmentation() {
     // New feature added - Merged with Maven776 - Kiran
 	Compound* c = getSelectedCompound();
-	if (!c or c->fragment_mzs.size() == 0) return;
+        if (!c or c->fragmentMzValues.size() == 0) return;
 
     QStringList searchText;
-	int mzCount = c->fragment_mzs.size();
-	int intsCount = c->fragment_intensity.size(); 
+        int mzCount = c->fragmentMzValues.size();
+        int intsCount = c->fragmentIntensities.size();
 
     int charge = _mw->mavenParameters->getCharge(c); //user specified ionization mode
 	float precursorMz = c->precursorMz;
     if (!c->formula.empty()) precursorMz = c->adjustedMass(charge);
 
     for(int i=0; i < mzCount; i++ ) {
-			float mz = c->fragment_mzs[i];
-			float ints = 0; 
-			if (i < intsCount) ints = c->fragment_intensity[i];
+                        float mz = c->fragmentMzValues[i];
+			float ints = 0;
+                        if (i < intsCount) ints = c->fragmentIntensities[i];
 
             searchText  << tr("%1\t%2")
                 .arg(QString::number(mz,'f', 5))

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2001,18 +2001,28 @@ bool MainWindow::loadMetaInformation(QString filename) {
 
 void MainWindow::loadCompoundsFile()
 {
+    QString dir = ".";
+    if (settings->contains("lastCompoundsDir")) {
+        QString ldir = settings->value("lastCompoundsDir").value<QString>();
+        QDir test(ldir);
+        if (test.exists())
+            dir = ldir;
+    }
+
     QStringList filelist = QFileDialog::getOpenFileNames(
         this,
         "Select Compounds File To Load",
-        ".",
+        dir,
         "All Known Formats(*.csv *.tab *.tab.txt *.msp *.sptxt *.pepXML "
         "*.massbank);;Tab Delimited(*.tab);;Tab Delimited Text(*.tab.txt);;CSV "
         "File(*.csv);;NIST "
         "Library(*.msp);;SpectraST(*.sptxt);;pepXML(*.pepXML);;MassBank(*."
         "massbank");
 
+    // why even allow loading multiple files if only the first one is read
     if (filelist.size() == 0 || filelist[0].isEmpty())
         return;
+
     if (!loadCompoundsFile(filelist[0])) {
         string dbfilename = filelist[0].toStdString();
         string dbname = mzUtils::cleanFilename(dbfilename);
@@ -2075,6 +2085,14 @@ void MainWindow::loadCompoundsFile()
             int ret = msgBox.exec();
         }
     }
+
+    // Saving the file location into QSettings class so that it can be
+    // used the next time user wants to load a compounds DB
+    QString absoluteFilePath(filelist[0]);
+    QFileInfo fileInfo(absoluteFilePath);
+    QDir tmp = fileInfo.absoluteDir();
+    if (tmp.exists())
+        settings->setValue("lastCompoundsDir", tmp.absolutePath());
 }
 
 // open function for set csv

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -514,6 +514,10 @@ using namespace mzUtils;
 	connect(fileLoader,SIGNAL(projectLoaded()), this,SLOT(setIonizationModeLabel()));
 	connect(fileLoader,SIGNAL(projectLoaded()), this,SLOT(deleteCrashFileTables()));
     connect(fileLoader,SIGNAL(projectLoaded()), this, SLOT(setInjectionOrderFromTimeStamp()));
+    connect(fileLoader,
+            SIGNAL(compoundsLoaded(QString, int)),
+            this,
+            SLOT(_postCompoundsDBLoadActions(QString,int)));
 
     // EMDB singals and slots
     connect(fileLoader,
@@ -595,30 +599,30 @@ using namespace mzUtils;
 		loadPathwaysFolder(pathwaysFolder);
 	}
 
-	setCentralWidget(eicWidgetController());	
+        setCentralWidget(eicWidgetController());
 
-	if (ligandWidget) {
-		if (settings->contains("lastDatabaseFile")) {
-			QString lfile =
-					settings->value("lastDatabaseFile").value<QString>();
-			QFile testf(lfile);
-			qDebug() << "Loading last database" << lfile;
-			if (testf.exists())
-				loadCompoundsFile(lfile);
-		}
-		QString databaseSet;
-		if (settings->contains("lastCompoundDatabase")) {
-			ligandWidget->setDatabase(
-					settings->value("lastCompoundDatabase").toString());
-			databaseSet = settings->value("lastCompoundDatabase").toString();
-		} else {
-			ligandWidget->setDatabase("KNOWNS");
-			databaseSet = "KNOWNS";
-		}
+        if (ligandWidget) {
+            if (settings->contains("lastDatabaseFile")) {
+                QString lfile =
+                    settings->value("lastDatabaseFile").value<QString>();
+                QFile testf(lfile);
+                qDebug() << "Loading last database" << lfile;
+                if (testf.exists())
+                    loadCompoundsFile(lfile, false);
+            }
+            QString databaseSet;
+            if (settings->contains("lastCompoundDatabase")) {
+                ligandWidget->setDatabase(
+                    settings->value("lastCompoundDatabase").toString());
+                databaseSet =
+                    settings->value("lastCompoundDatabase").toString();
+            } else {
+                ligandWidget->setDatabase("KNOWNS");
+                databaseSet = "KNOWNS";
+            }
+        }
 
-	}
-
-	setAcceptDrops(true);
+        setAcceptDrops(true);
 
 	showNormal();	//return from full screen on startup
 
@@ -1814,57 +1818,123 @@ void MainWindow::loadModel() {
 		clsf->loadModel(filelist[0].toStdString());
 }
 
-bool MainWindow::loadCompoundsFile(QString filename) {
-
-	string dbfilename = filename.toStdString();
-	string dbname = mzUtils::cleanFilename(dbfilename);
-	int compoundCount = 0;
-	bool reloading = false;
-
-    //added while merging with Maven776 - Kiran
-    if ( filename.endsWith("pepXML",Qt::CaseInsensitive)) {
-       // compoundCount=fileLoader->loadPepXML(filename);
-    } else if ( filename.endsWith("msp",Qt::CaseInsensitive) || filename.endsWith("sptxt",Qt::CaseInsensitive)) {
-        compoundCount=fileLoader->loadNISTLibrary(filename);
-    } else if ( filename.endsWith("massbank",Qt::CaseInsensitive)) { 
-        compoundCount=fileLoader->loadMassBankLibrary(filename);
-    } else {
-        compoundCount = DB.loadCompoundCSVFile(dbfilename);
+void MainWindow::loadCompoundsFile(QString filename, bool threaded)
+{
+    // added while merging with Maven776 - Kiran
+    if (threaded) {
+        fileLoader->addFileToQueue(filename);
+        fileLoader->start();
+        return;
     }
-	deque<Compound*> compoundsDB = DB.getCompoundsDB();
 
-	for (int i=0; i < compoundsDB.size(); i++) {
-        Compound* currentCompound = compoundsDB[i];
-		if (currentCompound->db == dbname) {
-			reloading = true;
-			break;
-		}
-	}
-
-	//check status in case the same file had been uploaded earlier
-	//without modifications
-	if ((compoundCount > 0 || reloading) && ligandWidget) {
-		ligandWidget->setDatabaseNames();
-		if (ligandWidget->isVisible())
-			ligandWidget->setDatabase(QString(dbname.c_str()));
-
-		int msLevel = 1;
-		vector<Compound*> loadedCompounds = DB.getCompoundsSubset(dbname);
-		if (loadedCompounds[0]->precursorMz > 0 && loadedCompounds[0]->productMz > 0) {
-			msLevel = 2;
-		}
-		
-		analytics->hitEvent("Load Compound DB", "Successful Load", msLevel);
-		
-		settings->setValue("lastDatabaseFile", filename);
-		setStatusText(tr("loadCompounds: done after loading %1 compounds").arg(QString::number(compoundCount)));
-		return true;
-	} else {
-		setStatusText(tr("loadCompounds: not able to load %1 database").arg(filename));
-		return false;
-	}
+    int compoundCount = fileLoader->loadCompoundsFromFile(filename);
+    _postCompoundsDBLoadActions(filename, compoundCount);
 }
 
+void MainWindow::_postCompoundsDBLoadActions(QString filename,
+                                             int compoundCount)
+{
+    string dbName = mzUtils::cleanFilename(filename.toStdString());
+
+    bool reloading = false;
+    deque<Compound*> compoundsDB = DB.getCompoundsDB();
+    for (int i = 0; i < compoundsDB.size(); i++) {
+        Compound* currentCompound = compoundsDB[i];
+        if (currentCompound->db == dbName) {
+            reloading = true;
+            break;
+        }
+    }
+
+    // check status in case the same file had been uploaded earlier
+    // without modifications
+    if ((compoundCount > 0 || reloading) && ligandWidget) {
+        ligandWidget->setDatabaseNames();
+        if (ligandWidget->isVisible())
+            ligandWidget->setDatabase(QString(dbName.c_str()));
+
+        int msLevel = 1;
+        vector<Compound*> loadedCompounds = DB.getCompoundsSubset(dbName);
+        if (loadedCompounds[0]->precursorMz > 0
+            && (loadedCompounds[0]->productMz > 0
+                || loadedCompounds[0]->fragmentMzValues.size() > 0)) {
+            msLevel = 2;
+        }
+        analytics->hitEvent("Load Compound DB", "Successful Load", msLevel);
+
+        settings->setValue("lastDatabaseFile", filename);
+
+        setStatusText(tr("Loaded %1 compounds successfully")
+                        .arg(QString::number(compoundCount)));
+        _notifyIfBadCompoundsDB(filename, false);
+    } else {
+        setStatusText(tr("Failed to load compound database")
+                        .arg(filename));
+        _notifyIfBadCompoundsDB(filename, true);
+    }
+}
+
+void MainWindow::_notifyIfBadCompoundsDB(QString filename,
+                                         bool failedToLoadCompletely)
+{
+    if (failedToLoadCompletely) {
+        analytics->hitEvent("Load Compound DB", "Column Error", 1);
+
+        string dbfilename = filename.toStdString();
+        string dbname = mzUtils::cleanFilename(dbfilename);
+
+        QMessageBox msgBox;
+        msgBox.setText(tr("Failed to load compound database %1")
+                         .arg(QString::fromStdString(dbname)));
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setWindowFlags(msgBox.windowFlags()
+                              & ~Qt::WindowCloseButtonHint);
+
+        string msgString = "Following are the unknown column name(s) found:";
+        if (DB.notFoundColumns.size() > 0) {
+            for (const auto& column : DB.notFoundColumns) {
+                 msgString += "\n - " + column;
+            }
+            msgBox.setDetailedText(QString::fromStdString(msgString));
+        }
+        msgBox.open();
+    } else {
+        if (DB.notFoundColumns.size() > 0) {
+            analytics->hitEvent("Load Compound DB", "Column Error", 0);
+
+            QMessageBox msgBox;
+            msgBox.setText(tr("Found some unknown column name(s)"));
+            msgBox.setIcon(QMessageBox::Information);
+            msgBox.setWindowFlags(msgBox.windowFlags()
+                                  & ~Qt::WindowCloseButtonHint);
+
+            string msgString = "Following are the unknown column name(s) "
+                               "found:";
+            for (const auto& column : DB.notFoundColumns) {
+                 msgString += "\n - " + column;
+            }
+            msgBox.setDetailedText(QString::fromStdString(msgString));
+            msgBox.open();
+        }
+        if (DB.invalidRows.size() > 0) {
+            analytics->hitEvent("Load Compound DB", "Row Error");
+
+            QMessageBox msgBox;
+            msgBox.setText(tr("Invalid compounds found"));
+            msgBox.setIcon(QMessageBox::Information);
+            msgBox.setWindowFlags(Qt::CustomizeWindowHint);
+
+            string msgString = "The following compounds had insufficient "
+                               "information for peak detection, and were not "
+                               "loaded:";
+            for (auto compoundID : DB.invalidRows) {
+                msgString += "\n - " + compoundID;
+            }
+            msgBox.setDetailedText(QString::fromStdString(msgString));
+            msgBox.open();
+        }
+    }
+}
 
 void MainWindow::checkCorruptedSampleInjectionOrder()
 {
@@ -2022,68 +2092,7 @@ void MainWindow::loadCompoundsFile()
     if (filename.isEmpty())
         return;
 
-    if (!loadCompoundsFile(filename)) {
-        string dbfilename = filename.toStdString();
-        string dbname = mzUtils::cleanFilename(dbfilename);
-        string notFoundColumns = "Following are the unknown column name(s) "
-                                 "found: ";
-
-        QMessageBox msgBox;
-        msgBox.setText(tr("Trouble in loading compound database %1")
-                         .arg(QString::fromStdString(dbname)));
-        msgBox.setIcon(QMessageBox::Warning);
-        if (DB.notFoundColumns.size() > 0) {
-            for (std::vector<string>::iterator it = DB.notFoundColumns.begin();
-                 it != DB.notFoundColumns.end();
-                 ++it) {
-                notFoundColumns += "\n" + *it;
-            }
-            msgBox.setDetailedText(QString::fromStdString(notFoundColumns));
-            msgBox.setWindowFlags(msgBox.windowFlags()
-                                  & ~Qt::WindowCloseButtonHint);
-        }
-        analytics->hitEvent("Load Compound DB",
-                            "Column Error",
-                            1);
-
-        int ret = msgBox.exec();
-    } else {
-        if (DB.notFoundColumns.size() > 0) {
-            analytics->hitEvent("Load Compound DB",
-                                "Column Error",
-                                0);
-            string notFoundColumns = "Following are the unknown column name(s) "
-                                     "found: ";
-            QMessageBox msgBox;
-            msgBox.setText(tr("Found some unknown column name(s)"));
-            for (std::vector<string>::iterator it = DB.notFoundColumns.begin();
-                 it != DB.notFoundColumns.end();
-                 ++it) {
-                notFoundColumns += "\n" + *it;
-            }
-            msgBox.setDetailedText(QString::fromStdString(notFoundColumns));
-            msgBox.setWindowFlags(msgBox.windowFlags()
-                                  & ~Qt::WindowCloseButtonHint);
-            msgBox.setIcon(QMessageBox::Information);
-            int ret = msgBox.exec();
-        }
-        if (DB.invalidRows.size() > 0) {
-            analytics->hitEvent("Load Compound DB",
-                                "Row Error");
-            string invalidRowsString = "The following compounds had "
-                                       "insufficient information for peak "
-                                       "detection, and were not loaded:";
-            QMessageBox msgBox;
-            msgBox.setText(tr("Invalid compounds found"));
-            for (auto compoundID : DB.invalidRows) {
-                invalidRowsString += "\n - " + compoundID;
-            }
-            msgBox.setDetailedText(QString::fromStdString(invalidRowsString));
-            msgBox.setWindowFlags(Qt::CustomizeWindowHint);
-            msgBox.setIcon(QMessageBox::Information);
-            int ret = msgBox.exec();
-        }
-    }
+    loadCompoundsFile(filename);
 
     // Saving the file location into QSettings class so that it can be
     // used the next time user wants to load a compounds DB

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1862,7 +1862,15 @@ void MainWindow::_postCompoundsDBLoadActions(QString filename,
         }
         analytics->hitEvent("Load Compound DB", "Successful Load", msLevel);
 
-        settings->setValue("lastDatabaseFile", filename);
+        // do not save NIST library files for automatic load when starting next
+        // session, unless they are less than 2Mb in size
+        QFileInfo fileInfo(filename);
+        bool isMSPFile = filename.endsWith("msp", Qt::CaseInsensitive);
+        bool isSPTXTFile = filename.endsWith("sptxt", Qt::CaseInsensitive);
+        bool notNISTFile = !(isMSPFile || isSPTXTFile);
+        bool smallerThan5Mb = fileInfo.size() < 2000000;
+        if (notNISTFile || smallerThan5Mb)
+            settings->setValue("lastDatabaseFile", filename);
 
         setStatusText(tr("Loaded %1 compounds successfully")
                         .arg(QString::number(compoundCount)));

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2009,7 +2009,7 @@ void MainWindow::loadCompoundsFile()
             dir = ldir;
     }
 
-    QStringList filelist = QFileDialog::getOpenFileNames(
+    QString filename = QFileDialog::getOpenFileName(
         this,
         "Select Compounds File To Load",
         dir,
@@ -2019,12 +2019,11 @@ void MainWindow::loadCompoundsFile()
         "Library(*.msp);;SpectraST(*.sptxt);;pepXML(*.pepXML);;MassBank(*."
         "massbank");
 
-    // why even allow loading multiple files if only the first one is read
-    if (filelist.size() == 0 || filelist[0].isEmpty())
+    if (filename.isEmpty())
         return;
 
-    if (!loadCompoundsFile(filelist[0])) {
-        string dbfilename = filelist[0].toStdString();
+    if (!loadCompoundsFile(filename)) {
+        string dbfilename = filename.toStdString();
         string dbname = mzUtils::cleanFilename(dbfilename);
         string notFoundColumns = "Following are the unknown column name(s) "
                                  "found: ";
@@ -2088,7 +2087,7 @@ void MainWindow::loadCompoundsFile()
 
     // Saving the file location into QSettings class so that it can be
     // used the next time user wants to load a compounds DB
-    QString absoluteFilePath(filelist[0]);
+    QString absoluteFilePath(filename);
     QFileInfo fileInfo(absoluteFilePath);
     QDir tmp = fileInfo.absoluteDir();
     if (tmp.exists())

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -335,8 +335,8 @@ public Q_SLOTS:
 	void setMzValue(float mz1, float mz2 = 0.0);
 	void loadModel();
 	void refreshIntensities();
-	void loadCompoundsFile();
-	bool loadCompoundsFile(QString filename);
+    void loadCompoundsFile();
+    void loadCompoundsFile(QString filename, bool threaded=true);
     void loadMetaInformation();
     bool loadMetaInformation(QString filename);
     int loadMetaCsvFile(string filename);
@@ -488,6 +488,7 @@ private Q_SLOTS:
     void _setStatusString(QString);
     void _showEMDBProgressBar(QString projectFilename);
     void _updateEMDBProgressBar(int progress, int finish);
+    void _postCompoundsDBLoadActions(QString filename, int compoundCount);
 
 private:
 	int m_value;
@@ -530,7 +531,7 @@ private:
     void _saveAllTablesAsMzRoll();
     void checkCorruptedSampleInjectionOrder();
     void warningForInjectionOrders(QMap<int, QList<mzSample*>>, QList<mzSample*>);
-
+    void _notifyIfBadCompoundsDB(QString filename, bool failedToLoadCompletely);
 };
 
 struct FileLoader {

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -244,8 +244,8 @@ int mzFileIO::loadNISTLibrary(QString filename) {
     QTextStream stream(&data);
     while (!stream.atEnd()) {
         QString line = stream.readLine();
-        if (line.startsWith("NAME:", Qt::CaseInsensitive)) {
-            // before reading the next record, save the
+        if (line.startsWith("NAME:", Qt::CaseInsensitive) || stream.atEnd()) {
+            // before reading the next record or ending stream, save the
             // compound created from last record
             if (currentCompound and !currentCompound->name.empty()) {
                 if (!currentCompound->formula.empty()) {
@@ -257,14 +257,18 @@ int mzFileIO::loadNISTLibrary(QString filename) {
                 ++compoundCount;
             }
 
-            // new compound
-            QString name = line.mid(5, line.length()).simplified();
-            currentCompound = new Compound(name.toStdString(),
-                                           name.toStdString(),
-                                           "",
-                                           0);
-            currentCompound->db = dbname;
-            capturePeaks = false;
+            // we need to check this again before creating a new compound,
+            // otherwise it would create one at stream end as well
+            if (line.startsWith("NAME:", Qt::CaseInsensitive)) {
+                // new compound
+                QString name = line.mid(5, line.length()).simplified();
+                currentCompound = new Compound(name.toStdString(),
+                                               name.toStdString(),
+                                               "",
+                                               0);
+                currentCompound->db = dbname;
+                capturePeaks = false;
+            }
         }
 
         if(currentCompound == nullptr)

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -167,8 +167,8 @@ PK$PEAK: m/z int. rel.int.
                Compound* cpd = new Compound( id.toStdString(), name.toStdString(), formula.toStdString(), charge);
                cpd->precursorMz=precursor;
                cpd->db=dbname;
-               cpd->fragment_mzs = mzs;
-               cpd->fragment_intensity = intest;
+               cpd->fragmentMzValues = mzs;
+               cpd->fragmentIntensities = intest;
 			   Q_FOREACH (QString cat, compound_class) { cpd->category.push_back(cat.toStdString()); }
                DB.addCompound(cpd);
                compoundCount++;
@@ -223,112 +223,149 @@ PK$PEAK: m/z int. rel.int.
     } while (!line.isNull());
     return compoundCount;
 }
-//TODO: Shouldnot be here
-int mzFileIO::loadNISTLibrary(QString fileName) {
-    qDebug() << "Loading Nist Libary: " << fileName;
-    QFile data(fileName);
 
+int mzFileIO::loadNISTLibrary(QString filename) {
+    qDebug() << "Loading NIST Libary: " << filename;
+    QFile data(filename);
     if (!data.open(QFile::ReadOnly) ) {
-        qDebug() << "Can't open " << fileName; 
+        qDebug() << "Can't open " << filename;
         return 0;
     }
 
-    string dbfilename = fileName.toStdString();
-    string dbname = mzUtils::cleanFilename(dbfilename);
+    QRegExp whiteSpace("\\s+");
+    QRegExp formulaMatch("Formula\\=(C\\d+H\\d+\\S*)");
+    QRegExp retentionTimeMatch("AvgRt\\=(\\S+)");
 
-   QTextStream stream(&data);
+    string dbname = mzUtils::cleanFilename(filename.toStdString());
+    Compound* currentCompound = nullptr;
+    bool capturePeaks = false;
+    int compoundCount = 0;
 
-   /* sample
-   Name: DGDG 8:0; [M-H]-; DGDG(2:0/6:0)
-   MW: 555.22888
-   PRECURSORMZ: 555.22888
-   Comment: Parent=555.22888 Mz_exact=555.22888 ; DGDG 8:0; [M-H]-; DGDG(2:0/6:0); C23H40O15
-   Num Peaks: 2
-   115.07586 999 "sn2 FA"
-   59.01330 999 "sn1 FA"
-   */
-
-   QRegExp whiteSpace("\\s+");
-   QRegExp formulaMatch("Formula\\=(C\\d+H\\d+\\S*)");
-   QRegExp retentionTimeMatch("AvgRt\\=(\\S+)");
-
-   int charge=0;
-   QString line;
-   QString name, comment,formula;
-   double retentionTime;
-   double mw=0;
-   double precursor=0;
-   int peaks=0;
-   vector<float>mzs;
-   vector<float>intest;
-
-   int compoundCount=0;
-
-    do {
-        line = stream.readLine();
-
-        if(line.startsWith("Name:",Qt::CaseInsensitive) && !name.isEmpty()) {
-            if (!name.isEmpty()) { //insert new compound
-
-                Compound* cpd = new Compound(
-                           name.toStdString(),
-                           name.toStdString(),
-                           formula.toStdString(),
-                           charge);
-			   if (precursor and mw) { cpd->mass=precursor; cpd->precursorMz=precursor; }
-			   else if (mw) { cpd->mass=mw; cpd->precursorMz=precursor; }
-               //cpd->mass=mw;
-               //cpd->precursorMz=mw;
-               cpd->db=dbname;
-               cpd->fragment_mzs = mzs;
-               cpd->fragment_intensity = intest;
-			   cpd->expectedRt=retentionTime;
-               DB.addCompound(cpd);
-               compoundCount++;
+    QTextStream stream(&data);
+    while (!stream.atEnd()) {
+        QString line = stream.readLine();
+        if (line.startsWith("NAME:", Qt::CaseInsensitive)) {
+            // before reading the next record, save the
+            // compound created from last record
+            if (currentCompound and !currentCompound->name.empty()) {
+                if (!currentCompound->formula.empty()) {
+                    auto formula = currentCompound->formula;
+                    auto exactMass = MassCalculator::computeMass(formula, 0);
+                    currentCompound->mass = exactMass;
+                }
+                DB.addCompound(currentCompound);
+                ++compoundCount;
             }
 
-            //reset for the next record
-           name = comment = formula = QString();
-           mw=precursor=0;
-		   retentionTime=0;
-           peaks=0;
-           mzs.clear();
-           intest.clear();
+            // new compound
+            QString name = line.mid(5, line.length()).simplified();
+            currentCompound = new Compound(name.toStdString(),
+                                           name.toStdString(),
+                                           "",
+                                           0);
+            currentCompound->db = dbname;
+            capturePeaks = false;
         }
 
-         if(line.startsWith("Name:",Qt::CaseInsensitive)) {
-             name = line.mid(5,line.length()).simplified();
-         } else if (line.startsWith("MW:",Qt::CaseInsensitive)) {
-             mw = line.mid(4,line.length()).simplified().toDouble();
-         } else if (line.startsWith("PRECURSORMZ:",Qt::CaseInsensitive)) {
-             precursor = line.mid(13,line.length()).simplified().toDouble();
-         } else if (line.startsWith("Comment:",Qt::CaseInsensitive)) {
-             comment = line.mid(8,line.length()).simplified();
-             if (comment.contains(formulaMatch)){
-                 formula=formulaMatch.capturedTexts().at(1);
-                 qDebug() << "Formula=" << formula;
-             }
-			if (comment.contains(retentionTimeMatch)){
-                 retentionTime=retentionTimeMatch.capturedTexts().at(1).simplified().toDouble();
-                 //qDebug() << "retentionTime=" << retentionTimeString;
-             }
-         } else if (line.startsWith("Num Peaks:",Qt::CaseInsensitive) || line.startsWith("NumPeaks:",Qt::CaseInsensitive)) {
-            //  peaks = line.mid(11,line.length()).simplified().toInt();
-             peaks = 1;
-         } else if ( peaks ) {
-             QStringList mzintpair = line.split(whiteSpace);
-             if( mzintpair.size() >=2 ) {
-                 bool ok=false; bool ook=false;
-                 float mz = mzintpair.at(0).toDouble(&ok);
-                 float ints = mzintpair.at(1).toDouble(&ook);
-                 if (ok && ook && mz >= 0 && ints >= 0) {
-                     mzs.push_back(mz);
-                     intest.push_back(ints);
-                 }
-             }
-         }
+        if(currentCompound == nullptr)
+            continue;
 
-    } while (!line.isNull());
+        if (line.startsWith("MW:", Qt::CaseInsensitive)) {
+            currentCompound->mass = line.mid(3, line.length())
+                                        .simplified()
+                                        .toDouble();
+        } else if (line.startsWith("CE:", Qt::CaseInsensitive)) {
+            currentCompound->collisionEnergy = line.mid(3, line.length())
+                                                   .simplified()
+                                                   .toDouble();
+        } else if (line.startsWith("ID:", Qt::CaseInsensitive)) {
+            QString id = line.mid(3, line.length()).simplified();
+            if (!id.isEmpty())
+                currentCompound->id = id.toStdString();
+        } else if (line.startsWith("LOGP:", Qt::CaseInsensitive)) {
+            currentCompound->logP = line.mid(5, line.length())
+                                        .simplified()
+                                        .toDouble();
+        } else if (line.startsWith("RT:", Qt::CaseInsensitive)) {
+            currentCompound->expectedRt = line.mid(3, line.length())
+                                              .simplified()
+                                              .toDouble();
+        } else if (line.startsWith("SMILE:", Qt::CaseInsensitive)) {
+            QString smileString = line.mid(7, line.length()).simplified();
+            if (!smileString.isEmpty())
+                currentCompound->smileString = smileString.toStdString();
+        } else if (line.startsWith("SMILES:", Qt::CaseInsensitive)) {
+            QString smileString = line.mid(8, line.length()).simplified();
+            if (!smileString.isEmpty())
+                currentCompound->smileString = smileString.toStdString();
+        } else if (line.startsWith("PRECURSORMZ:", Qt::CaseInsensitive)) {
+            currentCompound->precursorMz = line.mid(13, line.length())
+                                               .simplified()
+                                               .toDouble();
+        } else if (line.startsWith("EXACTMASS:", Qt::CaseInsensitive)) {
+            currentCompound->mass = line.mid(10, line.length())
+                                        .simplified()
+                                        .toDouble();
+        } else if (line.startsWith("ADDUCT:", Qt::CaseInsensitive)) {
+            currentCompound->adductString = line.mid(8, line.length())
+                                                .simplified()
+                                                .toStdString();
+        } else if (line.startsWith("FORMULA:", Qt::CaseInsensitive)) {
+            QString formula = line.mid(9, line.length()).simplified();
+            formula.replace("\"", "", Qt::CaseInsensitive);
+            if (!formula.isEmpty())
+                currentCompound->formula = formula.toStdString();
+        } else if (line.startsWith("MOLECULE FORMULA:", Qt::CaseInsensitive)) {
+            QString formula = line.mid(17, line.length()).simplified();
+            formula.replace("\"", "", Qt::CaseInsensitive);
+            if (!formula.isEmpty())
+                currentCompound->formula = formula.toStdString();
+        } else if (line.startsWith("CATEGORY:", Qt::CaseInsensitive)) {
+            currentCompound->category.push_back(line.mid(10, line.length())
+                                                    .simplified()
+                                                    .toStdString());
+        } else if (line.startsWith("TAG:", Qt::CaseInsensitive)) {
+            if (line.contains("VIRTUAL", Qt::CaseInsensitive))
+                currentCompound->virtualFragmentation = true;
+        } else if (line.startsWith("ION MODE:", Qt::CaseInsensitive)) {
+            if (line.contains("NEG", Qt::CaseInsensitive))
+                currentCompound->ionizationMode = -1;
+            if (line.contains("POS", Qt::CaseInsensitive))
+                currentCompound->ionizationMode = +1;
+        } else if (line.startsWith("COMMENT:", Qt::CaseInsensitive)) {
+            QString comment = line.mid(8, line.length()).simplified();
+            if (comment.contains(formulaMatch)) {
+                currentCompound->formula = formulaMatch.capturedTexts()
+                                                       .at(1)
+                                                       .toStdString();
+            }
+            if (comment.contains(retentionTimeMatch)) {
+                currentCompound->expectedRt = retentionTimeMatch.capturedTexts()
+                                                                .at(1)
+                                                                .simplified()
+                                                                .toDouble();
+            }
+        } else if (line.startsWith("NUM PEAKS:", Qt::CaseInsensitive)
+                   || line.startsWith("NUMPEAKS:", Qt::CaseInsensitive)) {
+            capturePeaks = true;
+        } else if (capturePeaks) {
+            QStringList mzIntensityPair = line.split(whiteSpace);
+            if (mzIntensityPair.size() >= 2) {
+                double mz = mzIntensityPair.at(0).toDouble();
+                double in = mzIntensityPair.at(1).toDouble();
+                if (mz >= 0.0 && in >= 0.0) {
+                    currentCompound->fragmentMzValues.push_back(mz);
+                    currentCompound->fragmentIntensities.push_back(in);
+                }
+            }
+
+            int fragIdx = currentCompound->fragmentMzValues.size() - 1;
+            if (mzIntensityPair.size() >= 3) {
+                currentCompound->fragmentIonTypes[fragIdx] =
+                    mzIntensityPair.at(2).toStdString();
+            }
+        }
+    }
 
     return compoundCount;
 }
@@ -390,8 +427,6 @@ int mzFileIO::loadPepXML(QString fileName) {
 		    cpd->mass=precursorMz;
 		    cpd->precursorMz=precursorMz;
 		    cpd->db=dbname;
-		    //cpd->fragment_mzs = mzs;
-		    //cpd->fragment_intensity = intest;
 		    DB.addCompound(cpd);
 
                 } else if (xml.name() == "mod_aminoacid_mass" ) {

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -224,7 +224,8 @@ PK$PEAK: m/z int. rel.int.
     return compoundCount;
 }
 
-int mzFileIO::loadNISTLibrary(QString filename) {
+int mzFileIO::loadNISTLibrary(QString filename)
+{
     qDebug() << "Loading NIST Libary: " << filename;
     QFile data(filename);
     if (!data.open(QFile::ReadOnly) ) {
@@ -572,8 +573,9 @@ void mzFileIO::fileImport(void) {
     QStringList peaks;
     QStringList projects;
     QStringList spectralhits;
+    QStringList compoundsDatabases;
 
-    Q_FOREACH(QString filename, filelist ) {
+    Q_FOREACH (QString filename, filelist) {
         try {
             QFileInfo fileInfo(filename);
             if (!fileInfo.exists())
@@ -587,12 +589,12 @@ void mzFileIO::fileImport(void) {
                 peaks << filename;
             } else if (isSpectralHitType(filename)) {
                 spectralhits << filename;
-            }
-            else
+            } else if (isCompoundDatabaseType(filename)) {
+                compoundsDatabases << filename;
+            } else {
                 throw MavenException(ErrorMsg::UnsupportedFormat);
-        }
-
-        catch (MavenException& excp) {
+            }
+        } catch (MavenException& excp) {
             qDebug() << "Error: " << excp.what();
         }
     }
@@ -720,29 +722,40 @@ void mzFileIO::fileImport(void) {
                                               "MS2",
                                               numMS2SamplesLoaded);
     if (numPRMSamplesLoaded)
-        _mainwindow->getAnalytics()->hitEvent("Samples Loaded",
-                                              "PRM",
-                                              numPRMSamplesLoaded);
+        _mainwindow->getAnalytics()->hitEvent(
+            "Samples Loaded", "PRM", numPRMSamplesLoaded);
 
-    Q_FOREACH(QString filename, spectralhits ) {
-        if (filename.contains("pepXML",Qt::CaseInsensitive)) {
+    Q_FOREACH (QString filename, spectralhits) {
+        if (filename.contains("pepXML", Qt::CaseInsensitive)) {
             _mainwindow->spectralHitsDockWidget->loadPepXML(filename);
+        } else if (filename.contains("pep.xml", Qt::CaseInsensitive)) {
+            _mainwindow->spectralHitsDockWidget->loadPepXML(filename);
+        } else if (filename.contains("idpDB", Qt::CaseInsensitive)) {
+            _mainwindow->spectralHitsDockWidget->loadIdPickerDB(filename);
         }
-        else if (filename.contains("pep.xml",Qt::CaseInsensitive)) {
-             _mainwindow->spectralHitsDockWidget->loadPepXML(filename);
-        }
-        else if (filename.contains("idpDB",Qt::CaseInsensitive)) {
-             _mainwindow->spectralHitsDockWidget->loadIdPickerDB(filename);
-        }
-   }
+    }
 
-    //done..
-    Q_EMIT (updateProgressBar( "Done importing", samples.size(), samples.size()));
-    if (samples.size() > 0)       Q_EMIT(sampleLoaded());
-    if (spectralhits.size() >0)   Q_EMIT(spectraLoaded());
-    if (projects.size() >0)       Q_EMIT(projectLoaded());
-    if (peaks.size() > 0)    	  Q_EMIT(peaklistLoaded());
-    filelist.clear(); //empty queue
+    Q_EMIT(updateStatusString("Loading compounds…"));
+    map<QString, int> databaseCompoundCounts;
+    Q_FOREACH (QString filename, compoundsDatabases) {
+        int compoundCount = loadCompoundsFromFile(filename);
+        databaseCompoundCounts[filename] = compoundCount;
+    }
+
+    Q_EMIT(updateProgressBar("Done importing", samples.size(), samples.size()));
+    if (samples.size() > 0)
+        Q_EMIT(sampleLoaded());
+    if (spectralhits.size() > 0)
+        Q_EMIT(spectraLoaded());
+    if (projects.size() > 0)
+        Q_EMIT(projectLoaded());
+    if (peaks.size() > 0)
+        Q_EMIT(peaklistLoaded());
+    for (auto dbEntry : databaseCompoundCounts)
+        Q_EMIT(compoundsLoaded(dbEntry.first, dbEntry.second));
+
+    // clear queue
+    filelist.clear();
 }
 
 void mzFileIO::qtSlot(const string& progressText, unsigned int completed_samples, int total_samples)
@@ -751,12 +764,38 @@ void mzFileIO::qtSlot(const string& progressText, unsigned int completed_samples
 
 }
 
+int mzFileIO::loadCompoundsFromFile(QString filename)
+{
+   int compoundCount = 0;
+   if (filename.endsWith("msp", Qt::CaseInsensitive)
+       || filename.endsWith("sptxt", Qt::CaseInsensitive)) {
+       compoundCount = loadNISTLibrary(filename);
+   } else if (filename.endsWith("massbank", Qt::CaseInsensitive)) {
+       compoundCount = loadMassBankLibrary(filename);
+   } else if (filename.contains("csv", Qt::CaseInsensitive)
+              || filename.contains("tab", Qt::CaseInsensitive)) {
+       compoundCount = DB.loadCompoundCSVFile(filename.toStdString());
+   }
+   return compoundCount;
+}
 
 bool mzFileIO::isKnownFileType(QString filename) {
     if (isSampleFileType(filename))  return true;
     if (isProjectFileType(filename)) return true;
     if (isSpectralHitType(filename)) return true;
     if (isPeakListType(filename)) return true;
+    if (isCompoundDatabaseType(filename)) return true;
+    return false;
+}
+
+bool mzFileIO::isCompoundDatabaseType(QString filename)
+{
+    QStringList extList;
+    extList << ".csv" << ".tab" << "msp" << "sptxt" << "massbank";
+    Q_FOREACH (QString suffix, extList) {
+        if (filename.endsWith(suffix, Qt::CaseInsensitive))
+            return true;
+    }
     return false;
 }
 

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -71,11 +71,14 @@ Q_OBJECT
         int loadPepXML(QString filename);
         int ThermoRawFileImport(QString fileName);
 
+        int loadCompoundsFromFile(QString filename);
+
         bool isKnownFileType(QString filename);
         bool isSampleFileType(QString filename);
         bool isProjectFileType(QString filename);
         bool isSpectralHitType(QString filename);
         bool isPeakListType(QString filename);
+        bool isCompoundDatabaseType(QString filename);
 
         /**
          * @brief Check whether the filename ends with a ".mzroll" extension.
@@ -208,6 +211,7 @@ Q_OBJECT
      void spectraLoaded();
      void projectLoaded();
      void peaklistLoaded();
+     void compoundsLoaded(QString, int);
      void createPeakTableSignal(QString);
      void addNewSample(mzSample*);
      void sqliteDBLoadStarted(QString);

--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -224,7 +224,7 @@ void SpectraWidget::overlayPeptideFragmentation(QString peptideSeq,MassCutoff *p
 */
 //TODO: Sahil, Added while merging spectrawidget
 void SpectraWidget::overlayCompoundFragmentation(Compound* c) {
-    if(_currentScan and c->fragment_mzs.size()) {
+    if(_currentScan and c->fragmentMzValues.size()) {
 		SpectralHit hit;
 	  	hit.score = 0;
         hit.precursorMz = c->precursorMz;
@@ -232,8 +232,8 @@ void SpectraWidget::overlayCompoundFragmentation(Compound* c) {
         hit.sampleName="";
         hit.productMassCutoff=mainwindow->getUserMassCutoff();
         hit.scan=NULL;
-        for(int i=0; i < c->fragment_mzs.size();i++)        hit.mzList << c->fragment_mzs[i];
-        for(int i=0; i < c->fragment_intensity.size();i++)  hit.intensityList<< c->fragment_intensity[i];
+        for(int i=0; i < c->fragmentMzValues.size();i++)        hit.mzList << c->fragmentMzValues[i];
+        for(int i=0; i < c->fragmentIntensities.size();i++)  hit.intensityList<< c->fragmentIntensities[i];
         _spectralHit = hit;//copy hit
        	cerr << "SpectraWidge::overlayCompoundfragmentation(Compound)" << c->name << " " << c->precursorMz << endl;
 

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -311,14 +311,14 @@ void ProjectDatabase::saveCompounds(const set<Compound*>& seenCompounds)
         catStr = catStr.substr(0, catStr.size() - 1);
 
         stringstream fragMz;
-        for (float f : c->fragment_mzs) {
+        for (float f : c->fragmentMzValues) {
             fragMz << fixed << setprecision(5) << f << ";";
         }
         string fragMzStr = fragMz.str();
         fragMzStr = fragMzStr.substr(0, fragMzStr.size() - 1);
 
         stringstream fragIntensity;
-        for (float f : c->fragment_intensity) {
+        for (float f : c->fragmentIntensities) {
             fragIntensity << fixed << setprecision(5) << f << ";";
         }
         string fragIntensityStr = fragIntensity.str();
@@ -766,17 +766,17 @@ vector<Compound*> ProjectDatabase::loadCompounds(const string databaseName)
                 compound->category.push_back(category);
         }
 
-        string fragment_mzs = compoundsQuery->stringValue("fragment_mzs");
-        for (string frag_mz : split(fragment_mzs, ';')) {
-            if (!frag_mz.empty())
-                compound->fragment_mzs.push_back(stof(frag_mz));
+        string fragmentMzValues = compoundsQuery->stringValue("fragment_mzs");
+        for (string fragMz : split(fragmentMzValues, ';')) {
+            if (!fragMz.empty())
+                compound->fragmentMzValues.push_back(stof(fragMz));
         }
 
-        string fragment_intensities =
+        string fragmentIntensities =
                 compoundsQuery->stringValue("fragment_intensity");
-        for (string frag_intensity : split(fragment_intensities, ';')) {
-            if (!frag_intensity.empty())
-                compound->fragment_intensity.push_back(stof(frag_intensity));
+        for (string fragIntensity : split(fragmentIntensities, ';')) {
+            if (!fragIntensity.empty())
+                compound->fragmentIntensities.push_back(stof(fragIntensity));
         }
 
         _compoundIdMap[compound->id + compound->db] = compound;


### PR DESCRIPTION
This PR includes the following changes:

1. Add checks for more fields available in MSP files.
2. Prevent last compound in MSP from getting lost.
3. Save last opened directory for compounds DB.
4. Disallow selecting multiple compound files while loading.
5. Load compound databases in a separate thread.
6. Show progress bar when loading NIST library files.
7. Add criteria for saving NIST library files as "lastDatabaseFile".
8. Do not show "Precursor Mz" information for compounds having fragmentation information.
9. Preserve all fragmentation records from MSP files.
10. Add methods to obtain compound type and check whether a database is an NIST library.

Issue: #965 
Issue: #842 