### PR TITLE
Calculate peakSplineArea for manually integrated groups #496

### DIFF
--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -567,7 +567,6 @@ void EIC::getPeakDetails(Peak &peak)
     peak.peakArea = 0;
     peak.peakSplineArea = 0;
     float baselineArea = 0;
-    int jj = 0;
 
     if (sample != NULL && sample->isBlank)
     {
@@ -581,9 +580,9 @@ void EIC::getPeakDetails(Peak &peak)
     if (peak.minpos >= N)
         peak.minpos = peak.pos; //unsigned number weirdness.
 
-    for (unsigned int ii = peak.splineminpos; ii <=peak.splinemaxpos; ii++)
-    {
-        peak.peakSplineArea += spline[ii];
+    for (unsigned int i = peak.splineminpos; i <= peak.splinemaxpos; i++) {
+        if (peak.splineminpos == 0 && peak.splinemaxpos == 0) break;
+        peak.peakSplineArea += spline[i];
     }
 
     float lastValue = intensity[peak.minpos];
@@ -624,7 +623,6 @@ void EIC::getPeakDetails(Peak &peak)
         }
 
         lastValue = intensity[j];
-        jj++;
     }
 
     getPeakWidth(peak);

--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -166,6 +166,12 @@ void PeakGroup::clear() {
     groupRank=INT_MAX;
 }
 
+void PeakGroup::addPeak(const Peak &peak)
+{
+	peaks.push_back(peak);
+	peaks.back().groupNum = groupId;
+}
+
 //TODO: a duplicate function getPeak exists. Delete this function
 Peak* PeakGroup::getSamplePeak(mzSample* sample) {
     for (unsigned int i=0; i< peaks.size(); i++ ) {

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1879,8 +1879,4 @@ mzLink::mzLink(float a, float b, string n) : mz1(a), mz2(b), note(n)
 	data1 = data2 = NULL;
 	correlation = 0;
 }
-void PeakGroup::addPeak(const Peak &peak)
-{
-	peaks.push_back(peak);
-	peaks.back().groupNum = groupId;
-}
+

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -156,10 +156,12 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
 			if (eic->rt[j] >= rtmin && eic->rt[j] <= rtmax) {
 				if (peak.minpos == 0) {
 					peak.minpos = j;
+					peak.splineminpos = j;
 					peak.rtmin = eic->rt[j];
 				}
 				if (peak.maxpos < j) {
 					peak.maxpos = j;
+					peak.splinemaxpos = j;
 					peak.rtmax = eic->rt[j];
 				}
 				peak.peakArea += eic->intensity[j];


### PR DESCRIPTION
peakSplineArea is recorded in Peak Detailed format CSV and is the area under the spline curve (smoothened peak). The spline bounds are calculated during automated peak detection (including double-click bookmarking) but were not being set for manually integrated groups using shift-drag. This led to the peakSplineArea = spline[0] for all such groups, usually 0.

Both these bugs have been resolved in this PR.

Related issue: #496 