### PR TITLE
ProjectDB versioning

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3892,27 +3892,9 @@ void MainWindow::markGroup(PeakGroup* group, char label) {
 	//getPlotWidget()->scene()->update();
 }
 
-int MainWindow::versionCheck() {
-
-//define a MACRO for converting DEFINES to strings.. jfc!
-#define xstr(s) str(s)
-#define str(s) #s
-
-	QString hostname = "http://genomics-pubs.princeton.edu";
-	QString path = "/mzroll/vercheck.php?";
-	QString os = "os=" + QString(xstr(PLATFORM));
-	//QString ver = "ver=" + QString::number(EL_MAVEN_VERSION);
-	QString ver = "ver=620";
-	QString query = os + "&" + ver;
-
-	logWidget->append("Latest version check: " + hostname + path + query);
-
-	QDownloader* downloader = new QDownloader(this);
-	downloader->getPage(hostname + path + query);
-	connect(downloader, SIGNAL(downloadResult(QString)), logWidget,
-			SLOT(append(QString)));
-
-	return 0;
+QString MainWindow::appVersion() {
+        auto version = STR(EL_MAVEN_VERSION);
+        return QString(version);
 }
 
 void MainWindow::toggleIsotopicBarPlot(bool show)

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -271,11 +271,12 @@ public:
 
 	PeakGroup::QType getUserQuantType();
 
-	//TODO: Sahil - Kiran, removed while merging mainwindow
-	// QSqlDatabase* getLocalDB() {
-	// 	return &localDB;
-	// }
-	int versionCheck();
+        /**
+         * @brief Converts `EL_MAVEN_VERSION" macro value to a usable QString
+         * and returns it.
+         * @return Application version as a QString.
+         */
+        QString appVersion();
 
 	void saveSettingsToLog();
 

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -276,7 +276,7 @@ public:
          * and returns it.
          * @return Application version as a QString.
          */
-        QString appVersion();
+        static QString appVersion();
 
 	void saveSettingsToLog();
 

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -798,7 +798,8 @@ bool mzFileIO::writeSQLiteProject(QString filename)
         qDebug() << "saving in existing project…";
     } else {
         qDebug() << "creating new project to save…";
-        _currentProject = new ProjectDatabase(filename.toStdString());
+        auto version = _mainwindow->appVersion().toStdString();
+        _currentProject = new ProjectDatabase(filename.toStdString(), version);
     }
 
     if (_currentProject) {
@@ -844,7 +845,8 @@ QList<QString> mzFileIO::readSamplesFromSQLiteProject(QString fileName)
     if (_currentProject)
         return empty;
 
-    _currentProject = new ProjectDatabase(fileName.toStdString());
+    auto version = _mainwindow->appVersion().toStdString();
+    _currentProject = new ProjectDatabase(fileName.toStdString(), version);
 
     // load compounds stored in the project file
     auto compounds = _currentProject->loadCompounds();

--- a/src/projectDB/projectDB.pro
+++ b/src/projectDB/projectDB.pro
@@ -26,9 +26,11 @@ INCLUDEPATH += $$top_srcdir/src/core/libmaven \
 
 SOURCES	= connection.cpp \
           cursor.cpp \
-          projectdatabase.cpp
+          projectdatabase.cpp \
+          projectversioning.cpp
 
 HEADERS +=  schema.h \
             connection.h \
             cursor.h \
-            projectdatabase.h
+            projectdatabase.h \
+            projectversioning.h

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -6,11 +6,45 @@
 #include "connection.h"
 #include "cursor.h"
 #include "mzSample.h"
+#include "projectversioning.h"
 #include "schema.h"
 
-ProjectDatabase::ProjectDatabase(const string& dbFilename)
+ProjectDatabase::ProjectDatabase(const string& dbFilename,
+                                 const string& version)
 {
     _connection = new Connection(dbFilename);
+
+    // figure out whether this database needs upgrade
+    using namespace ProjectVersioning;
+    auto aheadBy = 0;
+    auto versionInfo = extractVersionInfoFromTag(version, &aheadBy);
+    auto appVersion = Version(versionInfo.first);
+    auto requiredDbVersion = getDbVersionForApp(appVersion);
+    auto currentDbVersion = this->version();
+
+    // if build is ahead by non-zero number of commits, then its a dev build
+    if (aheadBy > 0) {
+        requiredDbVersion = getLatestDbVersion();
+    }
+
+    if (currentDbVersion != requiredDbVersion && !this->isEmpty()) {
+        // upgrade needed, close existing connection
+        delete _connection;
+
+        string upgradeScript = generateUpgradeScript(currentDbVersion,
+                                                     requiredDbVersion);
+        cout << "Debug: Upgrading database from v"
+             << currentDbVersion
+             << " to v"
+             << requiredDbVersion
+             << endl;
+        upgradeDatabase(dbFilename, upgradeScript, version);
+
+        // upgrade complete, re-establish connection
+        _connection = new Connection(dbFilename);
+    }
+
+    _setVersion(requiredDbVersion);
 }
 
 ProjectDatabase::~ProjectDatabase()
@@ -994,6 +1028,27 @@ string ProjectDatabase::projectName()
     return path.filename().string();
 }
 
+int ProjectDatabase::version()
+{
+    auto query = _connection->prepare("PRAGMA user_version");
+    auto version = 0;
+    while (query->next())
+        version = query->integerValue("user_version");
+    return version;
+}
+
+bool ProjectDatabase::isEmpty()
+{
+    auto query = _connection->prepare(
+        "SELECT COUNT(*) as table_count \
+           FROM sqlite_master           \
+          WHERE type = 'table'          ");
+    auto tableCount = 0;
+    while (query->next())
+        tableCount = query->integerValue("table_count");
+    return tableCount == 0;
+}
+
 void ProjectDatabase::_assignSampleIds(const vector<mzSample*>& samples) {
     int maxSampleId = -1;
     for (auto sample : samples)
@@ -1101,4 +1156,11 @@ string ProjectDatabase::_locateSample(const string filepath,
             return filepath.string();
     }
     return "";
+}
+
+void ProjectDatabase::_setVersion(int version)
+{
+    auto query = _connection->prepare("PRAGMA user_version = :user_version");
+    query->bind(":user_version", version);
+    query->execute();
 }

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -1160,7 +1160,9 @@ string ProjectDatabase::_locateSample(const string filepath,
 
 void ProjectDatabase::_setVersion(int version)
 {
-    auto query = _connection->prepare("PRAGMA user_version = :user_version");
-    query->bind(":user_version", version);
+    // using this syntax, because SQLite does not support
+    // binding for PRAGMA statements
+    auto query = _connection->prepare("PRAGMA user_version  = "
+                                      + to_string(version));
     query->execute();
 }

--- a/src/projectDB/projectdatabase.h
+++ b/src/projectDB/projectdatabase.h
@@ -26,8 +26,10 @@ public:
     /**
      * @brief Create a ProjectDatabase instance and connect to the database.
      * @param dbFilename Absolute filename for the database file to be used.
+     * @param version Version string for the application. This value will be
+     * used to deduce whether the database needs schema upgrade.
      */
-    ProjectDatabase(const string& dbFilename);
+    ProjectDatabase(const string& dbFilename, const string& version);
 
     /**
       * @brief Destroy the object and close database connection.
@@ -270,6 +272,30 @@ public:
      */
     string projectName();
 
+    /**
+     * @brief Obtain the user version of the database, useful for application(s)
+     * using this database.
+     * @details The `schema.user_version` attribute of SQLite databases is
+     * free for application developers to use however they intend to and will
+     * be treated as the schema version in context to our application. There is
+     * another `schema.schema_version` variable provided by SQLite DB, but
+     * should not be used since it has use cases for the SQLite library itself
+     * and tampering with it may lead to database corruption. Both these version
+     * attributes are of integer type.
+     * @return The user version of database as an integer.
+     */
+    int version();
+
+    /**
+     * @brief Check whether the underlying database has not yet been used (or
+     * appears to be so).
+     * @details Essentially any database that does not contain any tables, will
+     * be considered a fresh database - either it was not added with any data
+     * since it was created or any existing data has then purged.
+     * @return True if the database contains no tables, false otherwise.
+     */
+    bool isEmpty();
+
 private:
     /**
      * @brief _connection A Connection object mediating connection with a SQLite
@@ -346,6 +372,12 @@ private:
      */
     string _locateSample(const string filepath,
                          const vector<string>& pathlist);
+
+    /**
+     * @brief Write the database format version into the SQLite DB user version.
+     * @param version The integer version to set for database.
+     */
+    void _setVersion(int version);
 };
 
 #endif // PROJECTDATABASE_H

--- a/src/projectDB/projectversioning.cpp
+++ b/src/projectDB/projectversioning.cpp
@@ -1,0 +1,257 @@
+#include <boost/filesystem.hpp>
+#include <regex>
+
+#include "connection.h"
+#include "cursor.h"
+#include "mzUtils.h"
+#include "projectversioning.h"
+
+namespace bfs = boost::filesystem;
+
+namespace ProjectVersioning {
+
+/**
+ * Update this for every release where DB version changes. Intermediate
+ * releases using the same DB version as the last mentioned release need not be
+ * added.
+ */
+map<Version, int> appDbVersionMap = {
+    {Version("0.6.0"), 0},
+};
+
+/**
+ * Update this for every release where DB format changes. Please only add the
+ * absolute minimum change that would be needed for moving from one database
+ * format to the next. And DO NOT assume that any of the tables that should be
+ * transformed already exist.
+ */
+map<int, string> dbVersionUpgradeScripts = {};
+
+////////////////////////////////////////////////////////////////////////////////
+
+Version::Version(string version)
+{
+    string originalString = version;
+
+    // remove spaces from the string, if any
+    auto shuffled = std::remove_if(begin(version),
+                                   end(version),
+                                   [](unsigned char x) { return isspace(x); });
+    version.erase(shuffled, end(version));
+
+    // split on '.' character
+    vector<string> versionVec;
+    mzUtils::split(version, '.', versionVec);
+
+    // get version numnbers
+    _major = _minor = _patch = 0;
+    try {
+        if (versionVec.size() > 0)
+            _major = stoi(versionVec.at(0));
+        if (versionVec.size() > 1)
+            _minor = stoi(versionVec.at(1));
+        if (versionVec.size() > 2)
+            _patch = stoi(versionVec.at(2));
+    } catch(invalid_argument) {
+        cerr << "Error: unexpected version string format - \""
+             << originalString
+             << "\""
+             << endl;
+    }
+}
+
+string Version::toString() const
+{
+    return to_string(_major)
+           + '.'
+           + to_string(_minor)
+           + '.'
+           + to_string(_patch);
+}
+
+ostream& operator << (ostream& os, const Version& v)
+{
+    os << v.toString();
+    return os;
+}
+
+void Version::upMajor()
+{
+    ++_major;
+}
+
+void Version::upMinor()
+{
+    ++_minor;
+}
+
+void Version::upPatch()
+{
+    ++_patch;
+}
+
+bool Version::downMajor()
+{
+    if (_major != 0) {
+        --_major;
+        return true;
+    }
+    return false;
+}
+
+bool Version::downMinor()
+{
+    if (_minor != 0) {
+        --_minor;
+        return true;
+    }
+    return false;
+}
+
+bool Version::downPatch()
+{
+    if (_patch != 0) {
+        --_patch;
+        return true;
+    }
+    return false;
+}
+
+int Version::_compare(const Version& other) const
+{
+    int majorDiff = _major - other.major();
+    int minorDiff = _minor - other.minor();
+    int patchDiff = _patch - other.patch();
+    return majorDiff + minorDiff + patchDiff;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+pair<string, string> extractVersionInfoFromTag(const string tag, int* aheadBy)
+{
+    regex rgx("v((\\d+\\.\\d+\\.\\d+)(-(beta|alpha))?(\\.(\\d)*)?(-(\\d+))?)");
+    smatch matches;
+    pair<string, string> found;
+
+    if (regex_search(tag, matches, rgx)) {
+        // captured group for version should exist on index 2
+        found.first = matches[2].str();
+
+        // captured groups for alpha/beta build stage should be on index 4 and 5
+        found.second = matches[4].str() + matches[5].str();
+
+        // captured group for commit count should be on index 8
+        string commitCountStr = matches[8].str();
+        if (aheadBy != nullptr && commitCountStr.size() > 0) {
+            *aheadBy = stoi(commitCountStr);
+        } else if (aheadBy != nullptr) {
+            *aheadBy = 0;
+        }
+    } else {
+        cerr << "Error: given tag string \""
+             << tag
+             << "\" does not have expected format"
+             << endl;
+    }
+
+    return found;
+}
+
+int getDbVersionForApp(const Version& currentVersion)
+{
+    auto oldestVersion = begin(appDbVersionMap)->first;
+    if (currentVersion < oldestVersion)
+        return -1;
+
+    Version olderVersion;
+    Version laterVersion;
+    for (const auto entry : appDbVersionMap) {
+        auto version = entry.first;
+        if (version < currentVersion) {
+            olderVersion = version;
+        } else {
+            laterVersion = version;
+            break;
+        }
+    }
+    if (currentVersion == laterVersion)
+        return appDbVersionMap.at(laterVersion);
+
+    return appDbVersionMap.at(olderVersion);
+}
+
+int getLatestDbVersion()
+{
+    if (!appDbVersionMap.empty()) {
+        auto lastElement = --end(appDbVersionMap);
+        return lastElement->second;
+    }
+    return -1;
+}
+
+string generateUpgradeScript(const int fromVersion, const int toVersion)
+{
+    // the assumption here is that every database version must exist as a key
+    if (!dbVersionUpgradeScripts.count(fromVersion)
+        || !dbVersionUpgradeScripts.count(toVersion - 1)) {
+        cerr << "No conversion script can be generated for: "
+             << fromVersion << " → " << toVersion
+             << endl;
+        return "";
+    }
+
+    string mergedUpgradeScript;
+    for (const auto entry : dbVersionUpgradeScripts) {
+        int dbVersion = entry.first;
+        string upgradeScript = entry.second;
+
+        // relying on keys of map being sorted for generating the correct script
+        if (dbVersion >= fromVersion && dbVersion < toVersion)
+            mergedUpgradeScript += upgradeScript + "\n\n";
+    }
+
+    return mergedUpgradeScript;
+}
+
+void upgradeDatabase(const string& dbFilename,
+                     const string& upgradeScript,
+                     const string& appVersionString)
+{
+    bfs::path filepath(dbFilename);
+    auto filename = filepath.stem().string();
+    auto extension = filepath.extension().string();
+    auto newFilename = filename + "(" + appVersionString + ")" + extension;
+    auto newPath = filepath.parent_path() / bfs::path(newFilename);
+    auto success = backupFile(filepath.string(), newPath.string());
+    if (!success) {
+        cerr << "Error: failed to backup original database; "
+             << "continuing with the upgrade anyway …"
+             << endl;
+    }
+
+    Connection connection(dbFilename);
+    connection.prepare(upgradeScript)->execute();
+}
+
+bool backupFile(const string& originalFilepath, const string& newFilepath)
+{
+    cout << "Debug: backing up file "
+         << originalFilepath
+         << " as "
+         << newFilepath
+         << " …"
+         << endl;
+
+    bfs::path originalPath(originalFilepath);
+    bfs::path newPath(newFilepath);
+    try {
+        bfs::copy_file(originalPath, newPath);
+    } catch(boost::system::error_code) {
+        cerr << "Error: failed to copy file" << endl;
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace ProjectVersioning

--- a/src/projectDB/projectversioning.cpp
+++ b/src/projectDB/projectversioning.cpp
@@ -236,8 +236,10 @@ void upgradeDatabase(const string& dbFilename,
              << endl;
     }
 
-    Connection connection(dbFilename);
-    connection.prepare(upgradeScript)->execute();
+    if (!upgradeScript.empty()) {
+        Connection connection(dbFilename);
+        connection.prepare(upgradeScript)->execute();
+    }
 }
 
 bool backupFile(const string& originalFilepath, const string& newFilepath)

--- a/src/projectDB/projectversioning.cpp
+++ b/src/projectDB/projectversioning.cpp
@@ -122,7 +122,14 @@ int Version::_compare(const Version& other) const
     int majorDiff = _major - other.major();
     int minorDiff = _minor - other.minor();
     int patchDiff = _patch - other.patch();
-    return majorDiff + minorDiff + patchDiff;
+
+    if (majorDiff)
+        return majorDiff;
+
+    if (minorDiff)
+        return minorDiff;
+
+    return patchDiff;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/projectDB/projectversioning.h
+++ b/src/projectDB/projectversioning.h
@@ -1,0 +1,208 @@
+#ifndef PROJECTVERSIONING_H
+#define PROJECTVERSIONING_H
+
+#include <string>
+#include <map>
+
+using namespace std;
+
+namespace ProjectVersioning {
+
+/**
+ * @brief The Version struct is used to represent a version number having
+ * major, minor and patch levels (ref: htttps://semver.org). The most obvious
+ * reason for the existence of this struct is to allow comparison between two
+ * Version objects.
+ */
+struct Version {
+
+    /**
+     * @brief Create a version object from a version string of the form
+     * "MAJOR.MINOR.PATCH". If the string is not of this form, the returned
+     * Version object will most likely get an incorrect representation than what
+     * was intended.
+     * @param versionString String containing the version string to be converted
+     * to a Version object of equivalent value.
+     */
+    Version(string versionString);
+
+    /**
+     * @brief Default constructor.
+     */
+    Version() = default;
+
+    /**
+     * @brief Increase major version number by 1.
+     */
+    void upMajor();
+
+    /**
+     * @brief Increase minor version number by 1.
+     */
+    void upMinor();
+
+    /**
+     * @brief Increase patch version number by 1.
+     */
+    void upPatch();
+
+    /**
+     * @brief Decrease major version number by 1. If current major version
+     * number is 0, no decrement happens.
+     * @return Whether a decrement occurred.
+     */
+    bool downMajor();
+
+    /**
+     * @brief Increase minor version number by 1. If current minor version
+     * number is 0, no decrement happens.
+     * @return Whether a decrement occurred.
+     */
+    bool downMinor();
+
+    /**
+     * @brief Increase patch version number by 1. If current patch version
+     * number is 0, no decrement happens.
+     * @return Whether a decrement occurred.
+     */
+    bool downPatch();
+
+    /**
+     * @brief Convert this object to its string representation.
+     * @return String having the form "MAJOR.MINOR.PATCH".
+     */
+    string toString() const;
+
+    int major() const { return _major; }
+    int minor() const { return _minor; }
+    int patch() const { return _patch; }
+
+    bool operator < (const Version& rhs) const { return _compare(rhs) < 0; }
+    bool operator > (const Version& rhs) const { return _compare(rhs) > 0; }
+    bool operator <= (const Version& rhs) const { return _compare(rhs) <= 0; }
+    bool operator >= (const Version& rhs) const { return _compare(rhs) >= 0; }
+    bool operator == (const Version& rhs) const { return _compare(rhs) == 0; }
+    bool operator != (const Version& rhs) const { return _compare(rhs) != 0; }
+    friend ostream& operator << (ostream& os, const Version& v);
+
+private:
+    int _major;
+    int _minor;
+    int _patch;
+
+    /**
+     * @brief Compare Version object with another version object.
+     * @param other Version object to compare against.
+     * @return Positive integer if this object is of later version than `other`,
+     * negative if this version is older than `other` and 0 if they represent
+     * the same version.
+     */
+    int _compare(const Version& other) const;
+
+};
+
+/**
+ * @brief This map is for storing db versions corresponding to the application
+ * version they were meant to be used with. It should be made sure that this
+ * mapping is up-to-date for every new release version of the application where
+ * the database version changed. Failure to do so may cause irreversible
+ * compatibility issues.
+ */
+extern map<Version, int> appDbVersionMap;
+
+/**
+ * @brief A map of versions mapping to SQL scripts. The script for database
+ * version "1" can be used to upgrade a database having version "1" format to
+ * one having version "2" format.
+ */
+extern map<int, string> dbVersionUpgradeScripts;
+
+/**
+ * @brief Extract the version string ("MAJOR.MINOR.PATCH") from a string that is
+ * of the form "vMAJOR.MINOR.PATCH-xxx…". If the string also contains more
+ * information, the beta or alpha stage of the build will also be extracted, if
+ * present. This is temporarily useful for El-MAVEN's current version detection
+ * setup.
+ * @param tag Amalgamation of version and commit tag string obtained from
+ * the application.
+ * @param aheadBy Optional integer parameter which, if provided, will be set to
+ * the number of commits the build might be ahead of from the tagged version.
+ * This can be useful in telling whether the application is running as a dev
+ * build.
+ * @return A pair of strings. The first element is the version string (of form
+ * "MAJOR.MINOR.PATCH") obtained from successful extraction. The second string
+ * contains the alpha or beta buld stage of the running application, if found.
+ * If extraction fails due to regex mismatch, both these strings are empty.
+ */
+pair<string, string> extractVersionInfoFromTag(const string tag,
+                                               int* aheadBy=nullptr);
+
+/**
+ * @brief Fetches the database format version that will be compatible with a
+ * given version.
+ * @details The `appDbVersionMap` is a one-to-one mapping, i.e, only when the
+ * database format changes, the structure is updated with the application
+ * version (at which DB changes) and the incremented database version. This
+ * means that for all application versions in between two consequtive records of
+ * application version in the map, the same database format is used. To deduce
+ * this however, the application version string should be of a definite form.
+ * @param appVersion The version of application, as a string, for which database
+ * version is to be fetched. This application version should be a string of the
+ * form: "MAJOR.MINOR.PATCH" where MAJOR, MINOR and PATCH are integers
+ * representing the major, minor and patch release numbers as dictated by the
+ * semantic versioning document.
+ * @return The database version as integer, which is compatible with the given
+ * application version. Valid database versions are always positive integer
+ * numbers. If no DB version can be deduced, -1 is returned, indicating failure.
+ */
+int getDbVersionForApp(const Version& currentVersion);
+
+/**
+ * @brief Obtain the latest database version available in `appDbVersionMap`.
+ * @details This function should only be used to estimate the database version
+ * required for development builds. For all release builds, `getDbVersionForApp`
+ * function should be used instead.
+ * @return The latest database version as integer.
+ */
+int getLatestDbVersion();
+
+/**
+ * @brief Generates a database upgrade SQL script for given starting version
+ * and destination version.
+ * @param fromVersion The current version of database that has to be upgraded.
+ * @param toVersion The version of database to upgrade to.
+ * @return A SQL script as a string, that is created by joining all SQL scripts
+ * that are available to upgrade between every consequent DB version from
+ * starting version to destination version, excluding the script for destination
+ * version. Including the script for destination version would upgrade it by one
+ * extra version.
+ */
+string generateUpgradeScript(const int fromVersion, const int toVersion);
+
+/**
+ * @brief Upgrade a SQLite database by executing an upgrade script and backup
+ * the existing database.
+ * @param dbFilename Absolute path of the database file to be backed up and
+ * upgraded.
+ * @param upgradeScript A valid SQL string that can be executed to mutate a
+ * database to the new version without losing any more information than is
+ * necessary.
+ * @param appVersionString Version string for the application so that the
+ * existing database can be backed up with a name that is suffixed with this
+ * version string for appripriate identification.
+ */
+void upgradeDatabase(const string& dbFilename,
+                     const string& upgradeScript,
+                     const string& appVersionString);
+
+/**
+ * @brief Make a copy of a given file to another path.
+ * @param originalFilepath Path of the file to be copied.
+ * @param newFilepath Path at which the copied file should exist.
+ * @return True if the backup was successful, false otherwise.
+ */
+bool backupFile(const string& originalFilepath, const string& newFilepath);
+
+}
+
+#endif // PROJECTVERSIONING_H


### PR DESCRIPTION
This patch implements the following:
1. Add versioning utilities to "projectDB" module:
    - As the format of the database for storing information changes with subsequent releases, there might be cases where the table structure might need to be modified while keeping the data intact. A set of functions and data structures have been added in the module for allowing easy upgrades requiring minimal effort with each release involving an upgrade.
    - Upgrades can be made by writing SQL scripts that transform the data from one DB format to the next. For now, only backwards compatibility is guaranteed by these utilities, because only upgrades can be performed on database files from previous versions. Older releases of the library will have no way of knowing how to downgrade a newer version of the database to an older one that the older version of the application would be able to use.

2. Use versioning in `ProjectDatabase` class:
    - All ProjectDatabase instances will now be able to perform checks to evaluate whether they need a database upgrade and will automatically attempt to do so.
    - Since database upgrades can potentially change the database to be incompatible with older release in which it was first created, a backup is also saved of the original DB before upgrading.
    - For development builds, an extra check is made to ensure that the latest DB format available is used.
