### PR TITLE
Fix filtering of groups based on peak quality

### DIFF
--- a/src/core/libmaven/groupFiltering.cpp
+++ b/src/core/libmaven/groupFiltering.cpp
@@ -46,7 +46,12 @@ bool GroupFiltering::filterByMS1(PeakGroup &peakgroup)
 
     peakgroup.groupStatistics();
 
-    if (_mavenParameters->clsf->hasModel() && peakgroup.goodPeakCount < _mavenParameters->minGoodGroupCount)
+    if (_mavenParameters->clsf->hasModel()) {
+        _mavenParameters->clsf->classify(&peakgroup);
+        peakgroup.updateQuality();
+    }
+
+    if (peakgroup.goodPeakCount < _mavenParameters->minGoodGroupCount)
         return true;
 
     if (peakgroup.maxNoNoiseObs < _mavenParameters->minNoNoiseObs)

--- a/src/core/libmaven/groupFiltering.cpp
+++ b/src/core/libmaven/groupFiltering.cpp
@@ -49,10 +49,9 @@ bool GroupFiltering::filterByMS1(PeakGroup &peakgroup)
     if (_mavenParameters->clsf->hasModel()) {
         _mavenParameters->clsf->classify(&peakgroup);
         peakgroup.updateQuality();
+        if (peakgroup.goodPeakCount < _mavenParameters->minGoodGroupCount)
+            return true;
     }
-
-    if (peakgroup.goodPeakCount < _mavenParameters->minGoodGroupCount)
-        return true;
 
     if (peakgroup.maxNoNoiseObs < _mavenParameters->minNoNoiseObs)
         return true;

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -165,16 +165,10 @@ void TableDockWidget::updateItem(QTreeWidgetItem *item) {
     return;
   heatmapBackground(item);
 
-  // score peak quality
-  Classifier *clsf = _mainwindow->getClassifier();
-  if (clsf != NULL) {
-    clsf->classify(group);
-    group->updateQuality();
+  if (viewType == groupView)
+    item->setText(11, QString::number(group->maxQuality, 'f', 2));
 
-    if (viewType == groupView)
-      item->setText(11, QString::number(group->maxQuality, 'f', 2));
-    item->setText(1, QString(group->getName().c_str()));
-  }
+  item->setText(1, QString(group->getName().c_str()));
 
   // Updating the peakid
   item->setText(0, QString::number(group->groupId));

--- a/tests/MavenTests/testCLI.cpp
+++ b/tests/MavenTests/testCLI.cpp
@@ -138,10 +138,9 @@ void TestCLI::testReduceGroups() {
 		vector<mzSlice*> slices = peakdetectorCLI->peakDetector->processCompounds(
 				peakdetectorCLI->mavenParameters->compounds, "compounds");
         peakdetectorCLI->peakDetector->processSlices(slices, "compounds");
-
-        QVERIFY(peakdetectorCLI->mavenParameters->allgroups.size() == 23);
+        QVERIFY(peakdetectorCLI->mavenParameters->allgroups.size() == 22);
         peakdetectorCLI->reduceGroups();
-        QVERIFY(peakdetectorCLI->mavenParameters->allgroups.size() == 21);
+        QVERIFY(peakdetectorCLI->mavenParameters->allgroups.size() == 20);
 		delete_all(slices);
 	}
 


### PR DESCRIPTION
El-MAVEN's group filtering methods filtered based on peak quality quantile before it was actually updated by the classifier. The classifier was being used to assign a peak quality when groups had
already been filtered and were being added into the peak table. 

This commit makes the necessary changes such that peak qualities (assigned using the classifier) and group qualities (assigned based on each peak quality within the group) are being considered when the actual group filtering process happens. Hence, no groups with all bad peaks (based on user set quantile) will end up in the peak table from automated peak detections.

Issue: #970