### PR TITLE
Make OBI-WARP work for PRM data

### DIFF
--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -520,11 +520,13 @@ bool Aligner::alignWithObiWarp(vector<mzSample*> samples,
     float binSize = obiParams->binSize;
     float minMzRange = 1e9;
     float maxMzRange = 0;
-    for (int j = 0; j < refSample->scans.size(); ++j) {
-        if(refSample->scans[j]->mslevel  == 1 ){
-            for (int k = 0; k < refSample->scans[j]->mz.size(); ++k) {
-                minMzRange = min(minMzRange, refSample->scans[j]->mz[k]);
-                maxMzRange = max(maxMzRange, refSample->scans[j]->mz[k]);
+
+    for(const auto scan: refSample->scans) {
+        // PRM/DDA data have both mslevel 1 and mslevel 2 scans. We only want to align mslevel 1 scans
+        if(scan->mslevel == 1) {
+            for(const auto mz: scan->mz) {
+                minMzRange = min(minMzRange, mz);
+                maxMzRange = max(maxMzRange, mz);
             }
         }
     }

--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -452,26 +452,31 @@ bool Aligner::alignSampleRts(mzSample* sample,
                              bool setAsReference,
                              const MavenParameters* mp)
 {
-    vector<float> rtPoints(sample->scans.size());
-    vector<vector<float> > mxn(sample->scans.size());
-    for (int j = 0; j < sample->scans.size(); ++j) {
-        if (mp->stop) return (true);
-        rtPoints[j] = sample->scans[j]->originalRt;
-        mxn[j] = vector<float> (mzPoints.size());
-    }
+    vector<float> rtPoints;
+    vector<vector<float> > mxn;
 
-    for (int j = 0 ; j < sample->scans.size(); ++j) {
-        for (int k = 0; k < sample->scans[j]->mz.size(); ++k) {
-            if (mp->stop) return (true);
-            if (sample->scans[j]->mz[k] < mzPoints.front()
-                || sample->scans[j]->mz[k] > mzPoints.back())
-                continue;
-            int index = upper_bound(mzPoints.begin(), mzPoints.end(), sample->scans[j]->mz[k])
-                            - mzPoints.begin() -1;
-
-            mxn[j][index] = max(mxn[j][index], sample->scans[j]->intensity[k]);
+    int mxnCount = 0;
+    for(auto scan: sample->scans) {
+        if(mp->stop) return (true);
+        if(scan->mslevel == 1 ) {
+            rtPoints.push_back(scan->originalRt);
+            mxn.push_back(vector<float> (mzPoints.size()));
         }
     }
+
+    for(auto scan: sample->scans) {
+        if(scan->mslevel == 1) {
+            mxnCount++;
+            for(int indice = 0; indice <  scan->mz.size(); indice++) {
+                if (mp->stop) return (true);
+                if (scan->mz[indice] < mzPoints.front() || scan->mz[indice] > mzPoints.back())
+                    continue;
+                int index = upper_bound(mzPoints.begin(), mzPoints.end(), scan->mz[indice]) - mzPoints.begin() -1;
+                mxn[mxnCount - 1][index] = max(mxn[mxnCount -1][index], scan->intensity[indice]);
+            }
+        }
+    }
+
     
     if (setAsReference) {
         if (mp->stop) return (true);
@@ -482,7 +487,8 @@ bool Aligner::alignSampleRts(mzSample* sample,
         if (rtPoints.empty()) return(true);
         for(int j = 0; j < sample->scans.size(); ++j) {
             if (mp->stop) return (true);
-            sample->scans[j]->rt = rtPoints[j];
+            if(sample->scans[j]->mslevel == 1)
+                sample->scans[j]->rt = rtPoints[j];
         }
     }
     return (false);
@@ -515,9 +521,11 @@ bool Aligner::alignWithObiWarp(vector<mzSample*> samples,
     float minMzRange = 1e9;
     float maxMzRange = 0;
     for (int j = 0; j < refSample->scans.size(); ++j) {
-        for (int k = 0; k < refSample->scans[j]->mz.size(); ++k) {
-            minMzRange = min(minMzRange, refSample->scans[j]->mz[k]);
-            maxMzRange = max(maxMzRange, refSample->scans[j]->mz[k]);
+        if(refSample->scans[j]->mslevel  == 1 ){
+            for (int k = 0; k < refSample->scans[j]->mz.size(); ++k) {
+                minMzRange = min(minMzRange, refSample->scans[j]->mz[k]);
+                maxMzRange = max(maxMzRange, refSample->scans[j]->mz[k]);
+            }
         }
     }
 

--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -467,12 +467,12 @@ bool Aligner::alignSampleRts(mzSample* sample,
     for(auto scan: sample->scans) {
         if(scan->mslevel == 1) {
             mxnCount++;
-            for(int indice = 0; indice <  scan->mz.size(); indice++) {
+            for(int i = 0; i <  scan->mz.size(); i++) {
                 if (mp->stop) return (true);
-                if (scan->mz[indice] < mzPoints.front() || scan->mz[indice] > mzPoints.back())
+                if (scan->mz[i] < mzPoints.front() || scan->mz[i] > mzPoints.back())
                     continue;
-                int index = upper_bound(mzPoints.begin(), mzPoints.end(), scan->mz[indice]) - mzPoints.begin() -1;
-                mxn[mxnCount - 1][index] = max(mxn[mxnCount -1][index], scan->intensity[indice]);
+                int index = upper_bound(mzPoints.begin(), mzPoints.end(), scan->mz[i]) - mzPoints.begin() -1;
+                mxn[mxnCount - 1][index] = max(mxn[mxnCount -1][index], scan->intensity[i]);
             }
         }
     }

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -86,6 +86,11 @@ void mzSample::addScan(Scan *s)
         s->scannum = scans.size() - 1;
 }
 
+mzSample::SampleType  mzSample::getSampleType()
+{
+    return sType;
+}
+
 string mzSample::getFileName(const string &filename)
 {
 

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -186,7 +186,7 @@ void mzSample::loadSample(const char *filename)
 
     // assign a type to sample
     if(ms1ScanCount() && ms2ScanCount())
-        sType = SampleType::PRM;
+        sType = SampleType::DDA;
 
     if(ms1ScanCount() && ms2ScanCount() == 0)
         sType = SampleType::MS;

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -10,7 +10,9 @@ int mzSample::filter_polarity = 0;
 int mzSample::filter_mslevel = 0;
 
 mzSample::mzSample()
-	: _setName(""), injectionOrder(0)
+    : _setName(""),
+      injectionOrder(0),
+      sType(SampleType::NONE)
 {
     _id = -1;
     _numMS1Scans = 0;
@@ -181,6 +183,17 @@ void mzSample::loadSample(const char *filename)
 
 	//Checking if a sample is blank or not
 	checkSampleBlank(filename);
+
+    // assign a type to sample
+    if(ms1ScanCount() && ms2ScanCount())
+        sType = SampleType::PRM;
+
+    if(ms1ScanCount() && ms2ScanCount() == 0)
+        sType = SampleType::MS;
+
+    if(ms1ScanCount() == 0 && ms2ScanCount())
+        // either srm or mrm
+        sType = SampleType::SRM;
 }
 
 void mzSample::parseMzCSV(const char *filename)

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -11,8 +11,7 @@ int mzSample::filter_mslevel = 0;
 
 mzSample::mzSample()
     : _setName(""),
-      injectionOrder(0),
-      sType(SampleType::NONE)
+      injectionOrder(0)
 {
     _id = -1;
     _numMS1Scans = 0;
@@ -84,11 +83,6 @@ void mzSample::addScan(Scan *s)
 
         scans.push_back(s);
         s->scannum = scans.size() - 1;
-}
-
-mzSample::SampleType  mzSample::getSampleType()
-{
-    return sType;
 }
 
 string mzSample::getFileName(const string &filename)
@@ -188,17 +182,6 @@ void mzSample::loadSample(const char *filename)
 
 	//Checking if a sample is blank or not
 	checkSampleBlank(filename);
-
-    // assign a type to sample
-    if(ms1ScanCount() && ms2ScanCount())
-        sType = SampleType::DDA;
-
-    if(ms1ScanCount() && ms2ScanCount() == 0)
-        sType = SampleType::MS;
-
-    if(ms1ScanCount() == 0 && ms2ScanCount())
-        // either srm or mrm
-        sType = SampleType::SRM;
 }
 
 void mzSample::parseMzCSV(const char *filename)

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -218,15 +218,6 @@ class mzSample
     * @param filename Sample file name
     */
 
-    enum class SampleType: int {
-        NONE = 0,
-        MS,
-        SRM,
-        MRM,
-        DDA, // Data Dependent Acquisition
-        DIA, // Data Independent Acquisition
-    };
-
     void loadSample(const char *filename);
 
     /**
@@ -738,10 +729,7 @@ class mzSample
 
     vector<double> polynomialAlignmentTransformation; //parameters for polynomial transform
 
-    SampleType getSampleType();
-
   private:
-    SampleType sType;
     int _id;
     unsigned int _numMS1Scans;
     unsigned int _numMS2Scans;

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -218,7 +218,7 @@ class mzSample
     * @param filename Sample file name
     */
 
-    enum SampleType: int {
+    enum class SampleType: int {
         NONE = 0,
         MS,
         SRM,

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -217,6 +217,15 @@ class mzSample
     * @brief Load sample (supported formats: .mzxml, .mzml, .mzdata, .mzcsv and .cdf)
     * @param filename Sample file name
     */
+
+    enum SampleType: int {
+        NONE = 0,
+        MS,
+        SRM,
+        MRM,
+        PRM
+    };
+
     void loadSample(const char *filename);
 
     /**
@@ -685,6 +694,7 @@ class mzSample
 
     vector<float> getIntensityDistribution(int mslevel);
 
+    SampleType sType;
     deque<Scan *> scans;
     string sampleName;
     string fileName;

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -695,7 +695,6 @@ class mzSample
 
     vector<float> getIntensityDistribution(int mslevel);
 
-    SampleType sType;
     deque<Scan *> scans;
     string sampleName;
     string fileName;
@@ -739,7 +738,10 @@ class mzSample
 
     vector<double> polynomialAlignmentTransformation; //parameters for polynomial transform
 
+    SampleType getSampleType();
+
   private:
+    SampleType sType;
     int _id;
     unsigned int _numMS1Scans;
     unsigned int _numMS2Scans;

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -223,7 +223,8 @@ class mzSample
         MS,
         SRM,
         MRM,
-        PRM
+        DDA, // Data Dependent Acquisition
+        DIA, // Data Independent Acquisition
     };
 
     void loadSample(const char *filename);

--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -201,17 +201,17 @@ void AlignmentDialog::algoChanged()
     refSampleLabel->setVisible(obiWarp);
 
     auto samples = _mw->getSamples();
-    auto srmMrmData = false;
+    auto mrmData = false;
     for (const auto sample : samples) {
-        if (sample->sType == mzSample::SampleType::SRM || sample->sType == mzSample::SampleType::MRM ) {
+        if (sample->getSampleType() == mzSample::SampleType::SRM || sample->getSampleType() == mzSample::SampleType::MRM ) {
             showInfo("Obi-warp does not work with SRM/MRM data at the moment.\nWe "
                      "will inform you once this functionality has been added.");
-            srmMrmData = true;
+            mrmData = true;
             alignButton->setDisabled(true);
             break;
         }
     }
-    if (!srmMrmData || !obiWarp) {
+    if (!mrmData || !obiWarp) {
         alignButton->setDisabled(false);
         setProgressBar("Status", 0, 1);
     }

--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -203,7 +203,7 @@ void AlignmentDialog::algoChanged()
     auto samples = _mw->getSamples();
     auto srmMrmData = false;
     for (const auto sample : samples) {
-        if (sample->sType == mzSample::SRM || sample->sType == mzSample::MRM ) {
+        if (sample->sType == mzSample::SampleType::SRM || sample->sType == mzSample::SampleType::MRM ) {
             showInfo("Obi-warp does not work with SRM/MRM data at the moment.\nWe "
                      "will inform you once this functionality has been added.");
             srmMrmData = true;

--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -203,9 +203,9 @@ void AlignmentDialog::algoChanged()
     auto samples = _mw->getSamples();
     auto mrmData = false;
     for (const auto sample : samples) {
-        if (sample->getSampleType() == mzSample::SampleType::SRM || sample->getSampleType() == mzSample::SampleType::MRM ) {
-            showInfo("Obi-warp does not work with SRM/MRM data at the moment.\nWe "
-                     "will inform you once this functionality has been added.");
+        if(sample->ms1ScanCount() == 0 && sample->ms2ScanCount()) {
+            showInfo("No MS1 scans found. Obi-warp works only with MS1 scans.\nWe "
+                     "will inform you once the support for MS2 scans has been added.");
             mrmData = true;
             alignButton->setDisabled(true);
             break;

--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -201,17 +201,17 @@ void AlignmentDialog::algoChanged()
     refSampleLabel->setVisible(obiWarp);
 
     auto samples = _mw->getSamples();
-    auto ms2SamplesDetected = false;
+    auto srmMrmData = false;
     for (const auto sample : samples) {
-        if (sample->ms2ScanCount() > 0) {
-            showInfo("Obi-warp does not work with MS2 scans at the moment.\nWe "
+        if (sample->sType == mzSample::SRM || sample->sType == mzSample::MRM ) {
+            showInfo("Obi-warp does not work with SRM/MRM data at the moment.\nWe "
                      "will inform you once this functionality has been added.");
-            ms2SamplesDetected = true;
+            srmMrmData = true;
             alignButton->setDisabled(true);
             break;
         }
     }
-    if (!ms2SamplesDetected || !obiWarp) {
+    if (!srmMrmData || !obiWarp) {
         alignButton->setDisabled(false);
         setProgressBar("Status", 0, 1);
     }


### PR DESCRIPTION
To make PRM data work with OBI-WARP, it's required that we filter out MS2 scans from the data. This is what this PR implements. 

Apart from that, a new type called `SampleType` has been added to `mzSample`. The type can be **MS** for MS1 data, **SRM**, **MRM**, **PRM** for MS2 data. This is mainly done to add more readability to the code. I am aware that `ms1Counts()` and  `ms2Counts()` exists and can achieve the same functionality, but types just make the code more readable imo