### PR TITLE
Add support for compound notes

### DIFF
--- a/src/core/libmaven/Compound.h
+++ b/src/core/libmaven/Compound.h
@@ -105,9 +105,16 @@ class Compound{
         // Also maybe use an enum.
         int ionizationMode;
 
-        string db;			/**@param -   name of database for example KEGG, ECOCYC.. etc..    */
+        /**
+         * @brief Name of database this compound belongs to for example KEGG,
+         * ECOCYC, etc.
+         */
+        string db;
 
-        int transition_id;  /**  TODO */
+        /**
+         * TODO
+         */
+        int transition_id;
 
         /**
          * @brief Vector of m/z values of fragments generated from this compund.
@@ -127,7 +134,8 @@ class Compound{
         map<int, string>fragmentIonTypes;
 
         /**
-         * @brief categories of this compund or peptide etc.
+         * @brief Categories of this compound. For e.g., amino acids, nucleic
+         * acids, peptide, etc.
          */
         vector<string> category;
 
@@ -137,6 +145,11 @@ class Compound{
          * @return Type of the compound as a `Compound::Type` enum.
          */
         Type type() const;
+
+        /**
+         * @brief A note containing any miscellaneous details for this compound.
+         */
+        string note;
 
         FragmentationMatchScore scoreCompoundHit(Fragment* expFrag,
                                                  float productPpmTolr = 20,

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -94,6 +94,7 @@ void CSVReports::insertGroupReportColumnNamesintoCSVFile(string outputfile,
                             << "compound"
                             << "compoundId"
                             << "formula"
+                            << "note"
                             << "expectedRtDiff"
                             << "ppmDiff"
                             << "parent";
@@ -115,36 +116,60 @@ void CSVReports::insertGroupReportColumnNamesintoCSVFile(string outputfile,
         QString header = groupReportcolnames.join(SEP.c_str());
         groupReport << header.toStdString();
         for (unsigned int i = 0; i < samples.size(); i++) {
-            groupReport << SEP << sanitizeString(samples[i]->sampleName.c_str()).toStdString();
+            string name = samples[i]->getSampleName();
+            groupReport << SEP
+                        << sanitizeString(name.c_str()).toStdString();
         }
         groupReport << endl;
 
-        //TODO: Remove this to remove row in csv reports --@Giridhari
-        if (includeSetNamesLine){
-             for(unsigned int i = 0; i < cohort_offset; i++) { groupReport << SEP; }
-             for(unsigned int i = 0; i < samples.size(); i++) { groupReport << SEP << sanitizeString(samples[i]->getSetName().c_str()).toStdString(); }
-             groupReport << endl;
-         }
+        if (includeSetNamesLine) {
+            for(unsigned int i = 0; i < cohort_offset; i++)
+                groupReport << SEP;
+
+            for(unsigned int i = 0; i < samples.size(); i++) {
+                string name = samples[i]->getSetName();
+                groupReport << SEP
+                            << sanitizeString(name.c_str()).toStdString();
+            }
+            groupReport << endl;
+        }
     }
     else {
         errorReport = "Unable to write to file \""
-                      + QString::fromStdString(outputfile)
-                      + "\"\n";
-        errorReport += "Please check if you have permission to write to the "
-                       "specified location or the file is not in use";
+            + QString::fromStdString(outputfile)
+            + "\"\n"
+            + "Please check if you have permission to write to the specified "
+            + "location or the file is not in use";
     }
 }
 
-void CSVReports::insertPeakReportColumnNamesintoCSVFile(){
-
+void CSVReports::insertPeakReportColumnNamesintoCSVFile()
+{
     if (peakReport.is_open()) {
         QStringList peakReportcolnames;
-        peakReportcolnames << "groupId" << "compound" << "compoundId" << "formula" << "sample" << "peakMz"
-                << "medianMz" << "baseMz" << "rt" << "rtmin" << "rtmax" << "quality"
-                << "peakIntensity" << "peakArea" << "peakSplineArea" << "peakAreaTop"
-                << "peakAreaCorrected" << "peakAreaTopCorrected"
-                << "noNoiseObs" << "signalBaseLineRatio"
-                << "fromBlankSample";
+        peakReportcolnames << "groupId"
+                           << "compound"
+                           << "compoundId"
+                           << "formula"
+                           << "note"
+                           << "sample"
+                           << "peakMz"
+                           << "medianMz"
+                           << "baseMz"
+                           << "rt"
+                           << "rtmin"
+                           << "rtmax"
+                           << "quality"
+                           << "peakIntensity"
+                           << "peakArea"
+                           << "peakSplineArea"
+                           << "peakAreaTop"
+                           << "peakAreaCorrected"
+                           << "peakAreaTopCorrected"
+                           << "noNoiseObs"
+                           << "signalBaseLineRatio"
+                           << "fromBlankSample";
+
         QString header = peakReportcolnames.join(SEP.c_str());
         peakReport << header.toStdString() << endl;
     }
@@ -277,15 +302,16 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
     string compoundName = "";
     string compoundID = "";
     string formula = "";
+    string compoundNote = "";
     string categoryString;
     float expectedRtDiff = 0;
     float ppmDist = 0;
-
 
     if (group->compound != NULL) {
         compoundName = sanitizeString(group->compound->name.c_str()).toStdString();
         compoundID   = sanitizeString(group->compound->id.c_str()).toStdString();
         formula = sanitizeString(group->compound->formula.c_str()).toStdString();
+        compoundNote = sanitizeString(group->compound->note.c_str()).toStdString();
         if (!group->compound->formula.empty()) {
             int charge = getMavenParameters()->getCharge(group->compound);
             if (group->parent != NULL) {
@@ -318,6 +344,7 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
     groupReport << SEP << compoundName
                 << SEP << compoundID
                 << SEP << formula
+                << SEP << compoundNote
                 << SEP << setprecision(3) << expectedRtDiff
                 << SEP << setprecision(6) << ppmDist;
 
@@ -371,10 +398,12 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
     string compoundName = "";
     string compoundID = "";
     string formula = "";
+    string compoundNote = "";
     if (group->compound != NULL) {
         compoundName = sanitizeString(group->compound->name.c_str()).toStdString();
         compoundID   = sanitizeString(group->compound->id.c_str()).toStdString();
         formula = sanitizeString(group->compound->formula.c_str()).toStdString();
+        compoundNote = sanitizeString(group->compound->note.c_str()).toStdString();
     } else {
         // absence of a group compound means this group was created using untargeted detection,
         // we set compound name and ID to {mz}@{rt} strings for untargeted sets.
@@ -411,6 +440,7 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
                    << SEP << compoundName
                    << SEP << compoundID
                    << SEP << formula
+                   << SEP << compoundNote
                    << SEP << sampleName
                    << SEP << peak.peakMz
                    << SEP << peak.medianMz

--- a/src/core/libmaven/databases.cpp
+++ b/src/core/libmaven/databases.cpp
@@ -59,6 +59,7 @@ int Databases::loadCompoundCSVFile(string filename) {
 
 Compound* Databases::extractCompoundfromEachLine(vector<string>& fields, map<string, int> & header, int loadCount, string filename) {
     string id, name, formula, polarityString;
+    string note;
     float rt = 0, mz = 0, charge = 0, collisionenergy = 0, precursormz = 0, productmz = 0;
     int NumOfFields = fields.size();
     vector<string> categorylist;
@@ -110,6 +111,9 @@ Compound* Databases::extractCompoundfromEachLine(vector<string>& fields, map<str
     if (header.count("CE") && header["CE"] < NumOfFields) 
         collisionenergy=string2float(fields[header["CE"]]);
 
+    if (header.count("note") && header["note"] < NumOfFields)
+        note = fields[header["note"]];
+
     categorylist = getCategoryFromDB(fields, header);
 
     charge = getChargeFromDB(fields, header);
@@ -139,6 +143,7 @@ Compound* Databases::extractCompoundfromEachLine(vector<string>& fields, map<str
         compound->precursorMz = precursormz;
         compound->productMz = productmz;
         compound->collisionEnergy = collisionenergy;
+        compound->note = note;
 
         for(unsigned int i=0; i < categorylist.size(); i++) 
             compound->category.push_back(categorylist[i]);

--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -639,8 +639,8 @@ int Database::loadCompoundCSVFile(string filename){
     int lineCount=0;
     map<string, int>header;
     vector<string> headers;
-    static const string allHeadersarr[] = {"mz", "rt", "expectedrt", "charge", "formula", "id", "name", 
-    "compound", "precursormz", "productmz", "collisionenergy", "Q1", "Q3", "CE", "category", "polarity"};
+    static const string allHeadersarr[] = {"mz", "rt", "expectedrt", "charge", "formula", "id", "name",
+        "compound", "precursormz", "productmz", "collisionenergy", "Q1", "Q3", "CE", "category", "polarity", "note"};
     vector<string> allHeaders (allHeadersarr, allHeadersarr + sizeof(allHeadersarr) / sizeof(allHeadersarr[0]) );
 
     //assume that files are tab delimited, unless matched ".csv", then comma delimited
@@ -685,6 +685,7 @@ int Database::loadCompoundCSVFile(string filename){
         }
 
         string id, name, formula;
+        string note;
         float rt=0;
         float mz=0;
         float charge=0;
@@ -711,6 +712,9 @@ int Database::loadCompoundCSVFile(string filename){
         if ( header.count("Q1") && header["Q1"]<N) precursormz=string2float(fields[ header["Q1"]]);
         if ( header.count("Q3") && header["Q3"]<N)  productmz = string2float(fields[header["Q3"]]);
         if ( header.count("CE") && header["CE"]<N) collisionenergy=string2float(fields[ header["CE"]]);
+
+        if (header.count("note") && header["note"] < N)
+            note = fields[header["note"]];
 
         //cerr << lineCount << " " << endl;
         //for(int i=0; i<headers.size(); i++) cerr << headers[i] << ", ";
@@ -747,14 +751,12 @@ int Database::loadCompoundCSVFile(string filename){
 
             if (mz == 0) mz = MassCalculator::computeMass(formula,charge);
             compound->mass = mz;
-
-
-
             compound->db = dbname;
             compound->expectedRt=rt;
             compound->precursorMz=precursormz;
             compound->productMz=productmz;
             compound->collisionEnergy=collisionenergy;
+            compound->note = note;
             for(int i=0; i < categorylist.size(); i++) compound->category.push_back(categorylist[i]);
             if (addCompound(compound))
                 loadCount++;

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -19,9 +19,15 @@ LigandWidget::LigandWidget(MainWindow* mw) {
   treeWidget->setHeaderHidden(false);
   treeWidget->setObjectName("CompoundTable");
   treeWidget->setDragDropMode(QAbstractItemView::DragOnly);
+  treeWidget->setMouseTracking(true);
 
-  connect(treeWidget,SIGNAL(itemClicked(QTreeWidgetItem*, int)), SLOT(showLigand()));
-  connect(treeWidget,SIGNAL(itemSelectionChanged()), SLOT(showLigand()));
+  connect(treeWidget, SIGNAL(itemSelectionChanged()), SLOT(showLigand()));
+  connect(treeWidget,
+          SIGNAL(itemClicked(QTreeWidgetItem*, int)),
+          SLOT(showLigand()));
+  connect(treeWidget,
+          SIGNAL(itemEntered(QTreeWidgetItem*, int)),
+          SLOT(_setTooltipForItem(QTreeWidgetItem*)));
 
   QToolBar *toolBar = new QToolBar(this);
   toolBar->setFloatable(false);
@@ -758,4 +764,14 @@ void LigandWidget::matchFragmentation() {
 	_mw->spectraMatchingForm->precursorMz->setText(QString::number(precursorMz,'f',6));
 
 //	_mw->spectraMatchingForm->show();
+}
+
+void LigandWidget::_setTooltipForItem(QTreeWidgetItem* item)
+{
+    QVariant v = item->data(0, Qt::UserRole);
+    Compound* c = v.value<Compound*>();
+    QString note(c->note.c_str());
+    setToolTip(note);
+    if (note.isEmpty())
+        QToolTip::hideText();
 }

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -25,9 +25,6 @@ LigandWidget::LigandWidget(MainWindow* mw) {
   connect(treeWidget,
           SIGNAL(itemClicked(QTreeWidgetItem*, int)),
           SLOT(showLigand()));
-  connect(treeWidget,
-          SIGNAL(itemEntered(QTreeWidgetItem*, int)),
-          SLOT(_setTooltipForItem(QTreeWidgetItem*)));
 
   QToolBar *toolBar = new QToolBar(this);
   toolBar->setFloatable(false);
@@ -345,7 +342,8 @@ void LigandWidget::showTable() {
     //	treeWidget->clear();
     treeWidget->clear();
     treeWidget->setColumnCount(4);
-    QStringList header; header << "name" << "m/z" << "rt" << "category";
+    QStringList header;
+    header << "name" << "m/z" << "rt" << "category" << "notes";
     treeWidget->setHeaderLabels( header );
     treeWidget->setSortingEnabled(false);
 
@@ -403,6 +401,10 @@ void LigandWidget::showTable() {
                 catList << compound->category[i].c_str();
             }
             parent->setText(3,catList.join(";"));
+        }
+
+        if (!compound->note.empty()) {
+            parent->setText(4, QString::fromStdString(compound->note));
         }
 
         if (compound->fragmentMzValues.size()) {
@@ -764,14 +766,4 @@ void LigandWidget::matchFragmentation() {
 	_mw->spectraMatchingForm->precursorMz->setText(QString::number(precursorMz,'f',6));
 
 //	_mw->spectraMatchingForm->show();
-}
-
-void LigandWidget::_setTooltipForItem(QTreeWidgetItem* item)
-{
-    QVariant v = item->data(0, Qt::UserRole);
-    Compound* c = v.value<Compound*>();
-    QString note(c->note.c_str());
-    setToolTip(note);
-    if (note.isEmpty())
-        QToolTip::hideText();
 }

--- a/src/gui/mzroll/ligandwidget.h
+++ b/src/gui/mzroll/ligandwidget.h
@@ -104,13 +104,6 @@ private Q_SLOTS:
     void fetchRemoteCompounds();
     QList<Compound*> parseXMLRemoteCompounds();
 
-    /**
-     * @brief This sets the tooltip for the tree-widget to show the note for the
-     * compound being hovered over.
-     * @param item The item for the compound entered.
-     */
-    void _setTooltipForItem(QTreeWidgetItem* item);
-
 private:
 
     QTreeWidget *treeWidget;

--- a/src/gui/mzroll/ligandwidget.h
+++ b/src/gui/mzroll/ligandwidget.h
@@ -104,6 +104,13 @@ private Q_SLOTS:
     void fetchRemoteCompounds();
     QList<Compound*> parseXMLRemoteCompounds();
 
+    /**
+     * @brief This sets the tooltip for the tree-widget to show the note for the
+     * compound being hovered over.
+     * @param item The item for the compound entered.
+     */
+    void _setTooltipForItem(QTreeWidgetItem* item);
+
 private:
 
     QTreeWidget *treeWidget;

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -389,7 +389,8 @@ void ProjectDatabase::saveCompounds(const set<Compound*>& seenCompounds)
                       , :category              \
                       , :fragment_mzs          \
                       , :fragment_intensity    \
-                      , :fragment_ion_types    )");
+                      , :fragment_ion_types    \
+                      , :note                  )");
 
     _connection->begin();
 
@@ -450,6 +451,7 @@ void ProjectDatabase::saveCompounds(const set<Compound*>& seenCompounds)
         compoundsQuery->bind(":fragment_intensity", fragIntensity.str());
         compoundsQuery->bind(":fragment_ion_types", fragIonType.str());
 
+        compoundsQuery->bind(":note", c->note);
         if (!compoundsQuery->execute())
             cerr << "Error: failed to save compound " << c->name << endl;
     }
@@ -1106,6 +1108,7 @@ vector<Compound*> ProjectDatabase::loadCompounds(const string databaseName)
         compound->smileString = compoundsQuery->stringValue("smile_string");
         compound->logP = compoundsQuery->floatValue("log_p");
         compound->ionizationMode = compoundsQuery->floatValue("ionization_mode");
+        compound->note = compoundsQuery->stringValue("note");
 
         // mark compound as decoy if names contains DECOY string
         if (compound->name.find("DECOY") != string::npos)

--- a/src/projectDB/projectversioning.cpp
+++ b/src/projectDB/projectversioning.cpp
@@ -68,6 +68,7 @@ map<int, string> dbVersionUpgradeScripts = {
         "                       , fragment_mzs          TEXT                 "
         "                       , fragment_intensity    TEXT                 "
         "                       , fragment_ion_types    TEXT                 "
+        "                       , note                  TEXT                 "
         "                       , PRIMARY KEY (compound_id, name, db_name) );"
         "INSERT INTO compounds ( compound_id           "
         "                      , db_name               "
@@ -275,7 +276,7 @@ int getDbVersionForApp(const Version& currentVersion)
 int getLatestDbVersion()
 {
     if (!appDbVersionMap.empty()) {
-        auto lastElement = --end(appDbVersionMap);
+        auto lastElement = appDbVersionMap.rbegin();
         return lastElement->second;
     }
     return -1;
@@ -338,6 +339,9 @@ bool backupFile(const string& originalFilepath, const string& newFilepath)
 
     bfs::path originalPath(originalFilepath);
     bfs::path newPath(newFilepath);
+    if (bfs::exists(newPath))
+        return false;
+
     try {
         bfs::copy_file(originalPath, newPath);
     } catch(boost::system::error_code) {

--- a/src/projectDB/schema.h
+++ b/src/projectDB/schema.h
@@ -128,6 +128,7 @@
                                           , fragment_mzs          TEXT               \
                                           , fragment_intensity    TEXT               \
                                           , fragment_ion_types    TEXT               \
+                                          , note                  TEXT               \
                                           , PRIMARY KEY (compound_id, name, db_name) );"
 
 #define CREATE_ALIGNMENT_TABLE \

--- a/tests/MavenTests/testCSVReports.cpp
+++ b/tests/MavenTests/testCSVReports.cpp
@@ -49,10 +49,23 @@ void TestCSVReports::testopenGroupReport() {
     
 
     QStringList colnames;
-    colnames << "label" << "metaGroupId" << "groupId" << "goodPeakCount"
-                << "medMz" << "medRt" << "maxQuality" << "isotopeLabel" << "compound"
-                << "compoundId" << "formula" << "expectedRtDiff" << "ppmDiff" 
-                << "parent" << "testsample_1" << "bk_#sucyxpe_1_10";
+    colnames << "label"
+             << "metaGroupId"
+             << "groupId"
+             << "goodPeakCount"
+             << "medMz"
+             << "medRt"
+             << "maxQuality"
+             << "isotopeLabel"
+             << "compound"
+             << "compoundId"
+             << "formula"
+             << "note"
+             << "expectedRtDiff"
+             << "ppmDiff"
+             << "parent"
+             << "testsample_1"
+             << "bk_#sucyxpe_1_10";
 
     QString header = colnames.join(",");
     QVERIFY(header.toStdString()==temp);
@@ -60,7 +73,7 @@ void TestCSVReports::testopenGroupReport() {
     colnames.clear();
     getline(ifile, temp);
     remove(outputfile.c_str());
-    for(unsigned int i=0; i < 15; i++) { colnames << ","; }
+    for(unsigned int i=0; i < 16; i++) { colnames << ","; }
     header = colnames.join("");
     QVERIFY(header.toStdString()==temp);
 }
@@ -78,10 +91,27 @@ void TestCSVReports::testopenPeakReport() {
 
 
     QStringList colnames;
-    colnames << "groupId" << "compound" << "compoundId" << "formula" << "sample" << "peakMz"
-             << "medianMz" << "baseMz" << "rt" << "rtmin" << "rtmax" << "quality"
-             << "peakIntensity" << "peakArea" << "peakSplineArea" << "peakAreaTop"
-             << "peakAreaCorrected" << "peakAreaTopCorrected" << "noNoiseObs" << "signalBaseLineRatio"
+    colnames << "groupId"
+             << "compound"
+             << "compoundId"
+             << "formula"
+             << "note"
+             << "sample"
+             << "peakMz"
+             << "medianMz"
+             << "baseMz"
+             << "rt"
+             << "rtmin"
+             << "rtmax"
+             << "quality"
+             << "peakIntensity"
+             << "peakArea"
+             << "peakSplineArea"
+             << "peakAreaTop"
+             << "peakAreaCorrected"
+             << "peakAreaTopCorrected"
+             << "noNoiseObs"
+             << "signalBaseLineRatio"
              << "fromBlankSample";
 
     QString header = colnames.join(",");
@@ -155,12 +185,12 @@ void TestCSVReports::verifyTargetedGroupReport(vector<mzSample*>& samplesToLoad,
     //check if number of columns is correct
     vector<std::string> header;
     mzUtils::splitNew(headersString, "," , header);
-    QVERIFY(header.size() == 16);
+    QVERIFY(header.size() == 17);
 
     // check if parent group values are correctly written
     vector<std::string> parentValues;
     mzUtils::splitNew(parentString, "," , parentValues);
-    QVERIFY(parentValues.size() == 16);
+    QVERIFY(parentValues.size() == 17);
     QVERIFY(parentValues[0] == "");
     QVERIFY(parentValues[1] == "1");
     QVERIFY(parentValues[2] == "1");
@@ -172,16 +202,17 @@ void TestCSVReports::verifyTargetedGroupReport(vector<mzSample*>& samplesToLoad,
     QVERIFY(parentValues[8] == "Stachyose");
     QVERIFY(parentValues[9] == "HMDB03553");
     QVERIFY(parentValues[10] == "C24H42O21");
-    // QVERIFY(parentValues[11] == "0.646118");
-    // QVERIFY(parentValues[12] == "2.018557");
-    // QVERIFY(parentValues[13] == "665.215942");
-    // QVERIFY(parentValues[14] == "58567.76");
-    // QVERIFY(parentValues[15] == "38766.77");
+    QVERIFY(parentValues[11] == "");
+    // QVERIFY(parentValues[12] == "0.646118");
+    // QVERIFY(parentValues[13] == "2.018557");
+    // QVERIFY(parentValues[14] == "665.215942");
+    // QVERIFY(parentValues[15] == "58567.76");
+    // QVERIFY(parentValues[16] == "38766.77");
 
     // check if labelled child values are correctly written
     vector<std::string> childValues;
     mzUtils::splitNew(labelString, "," , childValues);
-    QVERIFY(childValues.size() == 16);
+    QVERIFY(childValues.size() == 17);
     QVERIFY(childValues[0] == "");
     QVERIFY(childValues[1] == "1");
     QVERIFY(childValues[2] == "2");
@@ -193,11 +224,12 @@ void TestCSVReports::verifyTargetedGroupReport(vector<mzSample*>& samplesToLoad,
     QVERIFY(childValues[8] == "Stachyose");
     QVERIFY(childValues[9] == "HMDB03553");
     QVERIFY(childValues[10] == "C24H42O21");
-    // QVERIFY(childValues[11] == "0.634977");
-    // QVERIFY(childValues[12] == "2.565203");
-    // QVERIFY(childValues[13] == "665.215942");
-    // QVERIFY(childValues[14] == "6103.33");
-    // QVERIFY(childValues[15] == "0.00");
+    QVERIFY(childValues[11] == "");
+    // QVERIFY(childValues[12] == "0.634977");
+    // QVERIFY(childValues[13] == "2.565203");
+    // QVERIFY(childValues[14] == "665.215942");
+    // QVERIFY(childValues[15] == "6103.33");
+    // QVERIFY(childValues[16] == "0.00");
 }
 
 void TestCSVReports::verifyUntargetedGroupReport(vector<mzSample*>& samplesToLoad,
@@ -226,12 +258,12 @@ void TestCSVReports::verifyUntargetedGroupReport(vector<mzSample*>& samplesToLoa
     //check if number of columns is correct
     vector<std::string> header;
     mzUtils::splitNew(headersString, "," , header);
-    QVERIFY(header.size() == 16);
+    QVERIFY(header.size() == 17);
 
     // check if group values are correctly written
     vector<std::string> parentValues;
     mzUtils::splitNew(parentString, "," , parentValues);
-    QVERIFY(parentValues.size() == 16);
+    QVERIFY(parentValues.size() == 17);
     QVERIFY(parentValues[0] == "");
     QVERIFY(parentValues[1] == "15");
     QVERIFY(parentValues[2] == "1");
@@ -243,11 +275,12 @@ void TestCSVReports::verifyUntargetedGroupReport(vector<mzSample*>& samplesToLoa
     QVERIFY(parentValues[8] == "210.150269@16.714417");
     QVERIFY(parentValues[9] == "210.150269@16.714417");
     QVERIFY(parentValues[10] == "");
-    QVERIFY(parentValues[11] == "0.000");
-    QVERIFY(parentValues[12] == "0.000000");
-    // QVERIFY(parentValues[13] == "210.150269");
-    // QVERIFY(parentValues[14] == "1234094464.00");
-    // QVERIFY(parentValues[15] == "1199781760.00");
+    QVERIFY(parentValues[11] == "");
+    QVERIFY(parentValues[12] == "0.000");
+    QVERIFY(parentValues[13] == "0.000000");
+    // QVERIFY(parentValues[14] == "210.150269");
+    // QVERIFY(parentValues[15] == "1234094464.00");
+    // QVERIFY(parentValues[16] == "1199781760.00");
 }
 
 void TestCSVReports::verifyTargetedPeakReport(vector<mzSample*>& samplesToLoad,
@@ -276,59 +309,61 @@ void TestCSVReports::verifyTargetedPeakReport(vector<mzSample*>& samplesToLoad,
     //check if number of columns is correct
     vector<std::string> header;
     mzUtils::splitNew(headersString, "," , header);
-    QVERIFY(header.size() == 21);
+    QVERIFY(header.size() == 22);
 
     // check if parent group values are correctly written
     vector<std::string> peakValues1;
     mzUtils::splitNew(peakString1, "," , peakValues1);
-    QVERIFY(peakValues1.size() == 21);
+    QVERIFY(peakValues1.size() == 22);
     QVERIFY(peakValues1[0] == "1");
     QVERIFY(peakValues1[1] == "Stachyose");
     QVERIFY(peakValues1[2] == "HMDB03553");
     QVERIFY(peakValues1[3] == "C24H42O21");
-    // QVERIFY(peakValues1[4] == "testsample_2");
-    // QVERIFY(peakValues1[5] == "665.216309");
-    // QVERIFY(peakValues1[6] == "665.216431");
-    // QVERIFY(peakValues1[7] == "665.216736");
-    // QVERIFY(peakValues1[8] == "1.466");
-    // QVERIFY(peakValues1[9] == "1.426");
-    // QVERIFY(peakValues1[10] == "1.520");
-    // QVERIFY(peakValues1[11] == "0.667");
-    // QVERIFY(peakValues1[12] == "79580.98");
-    // QVERIFY(peakValues1[13] == "595991.69");
-    // QVERIFY(peakValues1[14] == "635897.38");
-    // QVERIFY(peakValues1[15] == "58567.76");
-    // QVERIFY(peakValues1[16] == "595991.69");
-    // QVERIFY(peakValues1[17] == "58567.76");
-    QVERIFY(peakValues1[18] == "18");
-    // QVERIFY(peakValues1[19] == "9.12");
-    QVERIFY(peakValues1[20] == "0");
+    QVERIFY(peakValues1[4] == "");
+    // QVERIFY(peakValues1[5] == "testsample_2");
+    // QVERIFY(peakValues1[6] == "665.216309");
+    // QVERIFY(peakValues1[7] == "665.216431");
+    // QVERIFY(peakValues1[8] == "665.216736");
+    // QVERIFY(peakValues1[9] == "1.466");
+    // QVERIFY(peakValues1[10] == "1.426");
+    // QVERIFY(peakValues1[11] == "1.520");
+    // QVERIFY(peakValues1[12] == "0.667");
+    // QVERIFY(peakValues1[13] == "79580.98");
+    // QVERIFY(peakValues1[14] == "595991.69");
+    // QVERIFY(peakValues1[15] == "635897.38");
+    // QVERIFY(peakValues1[16] == "58567.76");
+    // QVERIFY(peakValues1[17] == "595991.69");
+    // QVERIFY(peakValues1[18] == "58567.76");
+    QVERIFY(peakValues1[19] == "18");
+    // QVERIFY(peakValues1[20] == "9.12");
+    QVERIFY(peakValues1[21] == "0");
 
     // check if labelled child values are correctly written
     vector<std::string> peakValues2;
     mzUtils::splitNew(peakString2, "," , peakValues2);
-    QVERIFY(peakValues2.size() == 21);
+    QVERIFY(peakValues2.size() == 22);
     QVERIFY(peakValues2[0] == "1");
     QVERIFY(peakValues2[1] == "Stachyose");
     QVERIFY(peakValues2[2] == "HMDB03553");
     QVERIFY(peakValues2[3] == "C24H42O21");
-    // QVERIFY(peakValues2[4] == "testsample_3");
-    // QVERIFY(peakValues2[5] == "665.214966");
-    // QVERIFY(peakValues2[6] == "665.215210");
-    // QVERIFY(peakValues2[7] == "665.215088");
-    // QVERIFY(peakValues2[8] == "1.462");
-    // QVERIFY(peakValues2[9] == "1.377");
-    // QVERIFY(peakValues2[10] == "1.502");
-    // QVERIFY(peakValues2[11] == "0.848");
-    // QVERIFY(peakValues2[12] == "54565.93");
-    // QVERIFY(peakValues2[13] == "359001.78");
-    // QVERIFY(peakValues2[14] == "355344.88");
-    // QVERIFY(peakValues2[15] == "38766.77");
-    // QVERIFY(peakValues2[16] == "359001.78");
-    // QVERIFY(peakValues2[17] == "38766.77");
-    QVERIFY(peakValues2[18] == "16");
-    // QVERIFY(peakValues2[19] == "5456.59");
-    QVERIFY(peakValues2[20] == "0");
+    QVERIFY(peakValues2[4] == "");
+    // QVERIFY(peakValues2[5] == "testsample_3");
+    // QVERIFY(peakValues2[6] == "665.214966");
+    // QVERIFY(peakValues2[7] == "665.215210");
+    // QVERIFY(peakValues2[8] == "665.215088");
+    // QVERIFY(peakValues2[9] == "1.462");
+    // QVERIFY(peakValues2[10] == "1.377");
+    // QVERIFY(peakValues2[11] == "1.502");
+    // QVERIFY(peakValues2[12] == "0.848");
+    // QVERIFY(peakValues2[13] == "54565.93");
+    // QVERIFY(peakValues2[14] == "359001.78");
+    // QVERIFY(peakValues2[15] == "355344.88");
+    // QVERIFY(peakValues2[16] == "38766.77");
+    // QVERIFY(peakValues2[17] == "359001.78");
+    // QVERIFY(peakValues2[18] == "38766.77");
+    QVERIFY(peakValues2[19] == "16");
+    // QVERIFY(peakValues2[20] == "5456.59");
+    QVERIFY(peakValues2[21] == "0");
 }
 
 void TestCSVReports::verifyUntargetedPeakReport(vector<mzSample*>& samplesToLoad,
@@ -357,57 +392,59 @@ void TestCSVReports::verifyUntargetedPeakReport(vector<mzSample*>& samplesToLoad
     //check if number of columns is correct
     vector<std::string> header;
     mzUtils::splitNew(headersString, "," , header);
-    QVERIFY(header.size() == 21);
+    QVERIFY(header.size() == 22);
 
     // check if parent group values are correctly written
     vector<std::string> peakValues1;
     mzUtils::splitNew(peakString1, "," , peakValues1);
-    QVERIFY(peakValues1.size() == 21);
+    QVERIFY(peakValues1.size() == 22);
     QVERIFY(peakValues1[0] == "15");
     QVERIFY(peakValues1[1] == "210.150269@16.714417");
     QVERIFY(peakValues1[2] == "210.150269@16.714417");
     QVERIFY(peakValues1[3] == "");
-    // QVERIFY(peakValues1[4] == "testsample_2");
-    // QVERIFY(peakValues1[5] == "210.150375");
-    // QVERIFY(peakValues1[6] == "210.150452");
+    QVERIFY(peakValues1[4] == "");
+    // QVERIFY(peakValues1[5] == "testsample_2");
+    // QVERIFY(peakValues1[6] == "210.150375");
     // QVERIFY(peakValues1[7] == "210.150452");
-    // QVERIFY(peakValues1[8] == "16.710");
-    // QVERIFY(peakValues1[9] == "16.603");
-    // QVERIFY(peakValues1[10] == "17.392");
-    // QVERIFY(peakValues1[11] == "0.801");
-    // QVERIFY(peakValues1[12] == "1255329664.00");
-    // QVERIFY(peakValues1[13] == "30111416320.00");
-    // QVERIFY(peakValues1[14] == "30103683072.00");
-    // QVERIFY(peakValues1[15] == "1234160640.00");
-    // QVERIFY(peakValues1[16] == "30099625984.00");
-    // QVERIFY(peakValues1[17] == "1234094464.00");
-    QVERIFY(peakValues1[18] == "178");
-    // QVERIFY(peakValues1[19] == "116.51");
-    QVERIFY(peakValues1[20] == "0");
+    // QVERIFY(peakValues1[8] == "210.150452");
+    // QVERIFY(peakValues1[9] == "16.710");
+    // QVERIFY(peakValues1[10] == "16.603");
+    // QVERIFY(peakValues1[11] == "17.392");
+    // QVERIFY(peakValues1[12] == "0.801");
+    // QVERIFY(peakValues1[13] == "1255329664.00");
+    // QVERIFY(peakValues1[14] == "30111416320.00");
+    // QVERIFY(peakValues1[15] == "30103683072.00");
+    // QVERIFY(peakValues1[16] == "1234160640.00");
+    // QVERIFY(peakValues1[17] == "30099625984.00");
+    // QVERIFY(peakValues1[18] == "1234094464.00");
+    QVERIFY(peakValues1[19] == "178");
+    // QVERIFY(peakValues1[20] == "116.51");
+    QVERIFY(peakValues1[21] == "0");
 
     // check if labelled child values are correctly written
     vector<std::string> peakValues2;
     mzUtils::splitNew(peakString2, "," , peakValues2);
-    QVERIFY(peakValues2.size() == 21);
+    QVERIFY(peakValues2.size() == 22);
     QVERIFY(peakValues2[0] == "15");
     QVERIFY(peakValues2[1] == "210.150269@16.714417");
     QVERIFY(peakValues2[2] == "210.150269@16.714417");
     QVERIFY(peakValues2[3] == "");
-    // QVERIFY(peakValues2[4] == "testsample_3");
-    // QVERIFY(peakValues2[5] == "210.150055");
-    // QVERIFY(peakValues2[6] == "210.150101");
+    QVERIFY(peakValues2[4] == "");
+    // QVERIFY(peakValues2[5] == "testsample_3");
+    // QVERIFY(peakValues2[6] == "210.150055");
     // QVERIFY(peakValues2[7] == "210.150101");
-    // QVERIFY(peakValues2[8] == "16.719");
-    // QVERIFY(peakValues2[9] == "16.612");
-    // QVERIFY(peakValues2[10] == "17.401");
-    // QVERIFY(peakValues2[11] == "0.803");
-    // QVERIFY(peakValues2[12] == "1221961088.00");
-    // QVERIFY(peakValues2[13] == "29895890944.00");
-    // QVERIFY(peakValues2[14] == "29900089344.00");
-    // QVERIFY(peakValues2[15] == "1199850368.00");
-    // QVERIFY(peakValues2[16] == "29883682816.00");
-    // QVERIFY(peakValues2[17] == "1199781760.00");
-    QVERIFY(peakValues2[18] == "178");
-    // QVERIFY(peakValues2[19] == "114.35");
-    QVERIFY(peakValues2[20] == "0");
+    // QVERIFY(peakValues2[8] == "210.150101");
+    // QVERIFY(peakValues2[9] == "16.719");
+    // QVERIFY(peakValues2[10] == "16.612");
+    // QVERIFY(peakValues2[11] == "17.401");
+    // QVERIFY(peakValues2[12] == "0.803");
+    // QVERIFY(peakValues2[13] == "1221961088.00");
+    // QVERIFY(peakValues2[14] == "29895890944.00");
+    // QVERIFY(peakValues2[15] == "29900089344.00");
+    // QVERIFY(peakValues2[16] == "1199850368.00");
+    // QVERIFY(peakValues2[17] == "29883682816.00");
+    // QVERIFY(peakValues2[18] == "1199781760.00");
+    QVERIFY(peakValues2[19] == "178");
+    // QVERIFY(peakValues2[20] == "114.35");
+    QVERIFY(peakValues2[21] == "0");
 }


### PR DESCRIPTION
Some compounds require additional review, since automated detection might not be able to assess them. For this the user could load in a compound database having notes about these special-case compounds. These notes will be visible to the user when the pointer hovers on these compounds. These notes will also be available in the CSV reports exported from peak table.
