### PR TITLE
Use clang provided by https://clang.llvm.org

### DIFF
--- a/.qmake.conf
+++ b/.qmake.conf
@@ -1,3 +1,4 @@
 top_srcdir=$$PWD
 top_builddir=$$top_srcdir/../build
 mzroll_pri=$$top_srcdir/mzroll.pri
+mac_compiler=$$top_srcdir/mac-compiler.pri

--- a/3rdparty/3rdparty.pro
+++ b/3rdparty/3rdparty.pro
@@ -1,3 +1,5 @@
+include($$mac_compiler)
+
 TEMPLATE = subdirs
 CONFIG += ordered qt thread
 

--- a/3rdparty/ErrorHandling/ErrorHandling.pro
+++ b/3rdparty/ErrorHandling/ErrorHandling.pro
@@ -1,3 +1,4 @@
+include($$mac_compiler)
 TEMPLATE = lib
 
 DESTDIR=$$top_builddir/libs/

--- a/3rdparty/Logger/Logger.pro
+++ b/3rdparty/Logger/Logger.pro
@@ -1,3 +1,4 @@
+include($$mac_compiler)
 TEMPLATE = lib
 
 CONFIG += staticlib

--- a/3rdparty/google-breakpad/google-breakpad.pro
+++ b/3rdparty/google-breakpad/google-breakpad.pro
@@ -1,3 +1,4 @@
+include($$mac_compiler)
 TEMPLATE = lib
 DESTDIR=$$top_builddir/libs/
 MOC_DIR=$$top_builddir/tmp/breakpad

--- a/3rdparty/libcdfread/libcdfread.pro
+++ b/3rdparty/libcdfread/libcdfread.pro
@@ -1,4 +1,4 @@
-
+include($$mac_compiler)
 
 MOC_DIR=$$top_builddir/tmp/cdfread/
 OBJECTS_DIR=$$top_builddir/tmp/cdfread/

--- a/3rdparty/libcsvparser/libcsvparser.pro
+++ b/3rdparty/libcsvparser/libcsvparser.pro
@@ -1,5 +1,4 @@
-
-
+include($$mac_compiler)
 
 MOC_DIR=$$top_builddir/tmp/csv_parser/
 OBJECTS_DIR=$$top_builddir/tmp/csv_parser/

--- a/3rdparty/libdate/libdate.pro
+++ b/3rdparty/libdate/libdate.pro
@@ -1,4 +1,4 @@
-
+include($$mac_compiler)
 
 MOC_DIR=$$top_builddir/tmp/date/
 OBJECTS_DIR=$$top_builddir/tmp/date/

--- a/3rdparty/libneural/libneural.pro
+++ b/3rdparty/libneural/libneural.pro
@@ -1,4 +1,4 @@
-
+include($$mac_compiler)
 
 MOC_DIR=$$top_builddir/tmp/neural/
 OBJECTS_DIR=$$top_builddir/tmp/neural/

--- a/3rdparty/libpillow/libpillow.pro
+++ b/3rdparty/libpillow/libpillow.pro
@@ -1,4 +1,4 @@
-
+include($$mac_compiler)
 include(config.pri)
 
 MOC_DIR=$$top_builddir/tmp/pillow/

--- a/3rdparty/libpls/libpls.pro
+++ b/3rdparty/libpls/libpls.pro
@@ -1,4 +1,4 @@
-
+include($$mac_compiler)
 DESTDIR=$$top_builddir/libs/
 
 MOC_DIR=$$top_builddir/tmp/pls/

--- a/3rdparty/obiwarp/obiwarp.pro
+++ b/3rdparty/obiwarp/obiwarp.pro
@@ -1,3 +1,4 @@
+include($$mac_compiler)
 include($$mzroll_pri)
 
 MOC_DIR=$$top_builddir/tmp/obiwarp/

--- a/3rdparty/pugixml/src/src.pro
+++ b/3rdparty/pugixml/src/src.pro
@@ -1,3 +1,4 @@
+include($$mac_compiler)
 MOC_DIR=$$top_builddir/tmp/pugixml/
 OBJECTS_DIR=$$top_builddir/tmp/pugixml/
 include($$mzroll_pri)

--- a/CrashReporter/CrashReporter.pro
+++ b/CrashReporter/CrashReporter.pro
@@ -7,6 +7,7 @@
 TEMPLATE = app
 TARGET = CrashReporter
 
+include($$mac_compiler)
 
 QT       += widgets core gui network
 CONFIG += console

--- a/README.md
+++ b/README.md
@@ -92,11 +92,20 @@ This is will give you the Qt5.6.2 dmg file. Using the dmg file install Qt under 
 
 `cd ~`
 
-`touch .profile`
+_Not required if the file already exists_
+`touch .bash_profile`
 
-`echo "PATH=/Users/$USER/Qt5.6.2/5.6/clang_64/bin/:$PATH" > .profile`
 
-`source .profile`
+> e.g. PATH_TO_LLVM_DIR = /usr/local/opt/llvm@6/
+
+`echo "export PATH=/Users/$USER/Qt5.6.2/5.6/clang_64/bin/:/PATH_TO_LLVM_DIR/bin/:$PATH" >> .bash_profile`
+
+`echo "export LDFLAGS="-L/PATH_TO_LLVM_DIR/lib -Wl,-rpath,/PATH_TO_LLVM_DIR/lib" >> .bash_profile`
+
+`echo "export CPPFLAGS+="-I/PATH_TO_LLVM_DIR/include  -I/PATH_TO_LLVM_DIR/c++/v1/" >> .bash_profile`
+
+`source .bash_profile`
+
 
 `mkdir ~/maven_repo`
 
@@ -105,8 +114,6 @@ This is will give you the Qt5.6.2 dmg file. Using the dmg file install Qt under 
 `git clone https://github.com/ElucidataInc/ElMaven.git`
 
 `cd ElMaven`
-
-`source ~/.profile`
 
 `qmake CONFIG+=debug -o Makefile build.pro`
 
@@ -131,7 +138,7 @@ For Windows and Ubuntu:
 `./run.sh`
 
 For Mac:  
-`source ~/.profile`
+`source ~/.bash_profile`
 
 `qmake CONFIG+=debug -o Makefile build.pro`
 

--- a/build.pro
+++ b/build.pro
@@ -1,3 +1,20 @@
+macx {
+
+    compiler_version = $$system( clang -v 2>&1 | head -n1 | ggrep -Po  "[0-9\.]+" | head -n1 | ggrep -Po "[0-9]+" | head -n1 )
+    message("compiler major version $$compiler_version")
+    if(greaterThan(compiler_version, 5):lessThan(compiler_version, 7)) {
+        message("Clang Version : $$system( clang -v 2>&1 | head -n1 )")
+    }
+    else {
+        warning("Make sure you have installed clang using brew and are not using clang that comes along with XCode.")
+        warning("If you have installed clang using brew, please make sure it's added correctly in the PATH variable")
+        message("exiting now")
+        error("Compiler not found")
+    }
+}
+
+include($$mac_compiler)
+
 TEMPLATE = subdirs
 CONFIG += ordered qt thread
 

--- a/mac-compiler.pri
+++ b/mac-compiler.pri
@@ -1,0 +1,6 @@
+macx {
+    # Although the user is using llvm/clang, Qt might still choose to use XCode's clang
+    # We can't use XCode's clang since it lacks OpenMP support
+    QMAKE_CC = $$system( which clang)
+    QMAKE_CXX = $$system( which clang++)
+}

--- a/mzWatcher/mzWatcher.pro
+++ b/mzWatcher/mzWatcher.pro
@@ -1,4 +1,4 @@
-
+include($$mac_compiler)
 
 TEMPLATE = app
 TARGET = mzWatcher

--- a/mzroll.pri
+++ b/mzroll.pri
@@ -11,12 +11,6 @@ CONFIG(debug, debug|release){
 
 QT += sql core  xml gui opengl
 
-macx {
-
-    QMAKE_CXX = /usr/local/Cellar/llvm/6.0.1/bin/clang++
-    QMAKE_CC = /usr/local/Cellar/llvm/6.0.1/bin/clang
-}
-
 CONFIG += silent exceptions
 
 # this is important. Used in mzUtils to make use of correct mkdir function

--- a/src/cli/peakdetector/peakdetector.pro
+++ b/src/cli/peakdetector/peakdetector.pro
@@ -1,3 +1,4 @@
+include($$mac_compiler)
 DESTDIR = $$top_srcdir/bin
 
 MOC_DIR=$$top_builddir/tmp/peakdetector/
@@ -22,8 +23,6 @@ QMAKE_LFLAGS  +=  -L$$top_builddir/libs/
 LIBS +=  -lmaven -lpugixml -lneural -lcsvparser -lpls -lErrorHandling -lLogger -lcdfread -lnetcdf -lz -lobiwarp -lpollyCLI
 macx {
     QMAKE_CXXFLAGS += -fopenmp
-    INCLUDEPATH += /usr/local/Cellar/llvm/6.0.1/lib/clang/6.0.1/include/
-    QMAKE_LFLAGS +=-L/usr/local/Cellar/llvm/6.0.1/lib/
     LIBS += -lomp
     LIBS -= -lnetcdf -lcdfread
 }

--- a/src/cli/peakdetector/peakdetector.pro
+++ b/src/cli/peakdetector/peakdetector.pro
@@ -20,8 +20,16 @@ INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  $$top_srcdir/3rdparty/pugixml/sr
 
 QMAKE_LFLAGS  +=  -L$$top_builddir/libs/
 
+
 LIBS +=  -lmaven -lpugixml -lneural -lcsvparser -lpls -lErrorHandling -lLogger -lcdfread -lnetcdf -lz -lobiwarp -lpollyCLI
 macx {
+
+    DYLIBPATH = $$(LDFLAGS)
+    isEmpty(DYLIBPATH) {
+        warning("LDFLAGS variable is not set. Linking operation might complain about missing OMP library")
+        warning("Please follow the README to make sure you have correctly set the LDFLAGS variable")
+    }
+    QMAKE_LFLAGS += $$(LDFLAGS)
     QMAKE_CXXFLAGS += -fopenmp
     LIBS += -lomp
     LIBS -= -lnetcdf -lcdfread

--- a/src/core/libmaven/libmaven.pro
+++ b/src/core/libmaven/libmaven.pro
@@ -1,3 +1,4 @@
+include($$mac_compiler)
 MOC_DIR=$$top_builddir/tmp/maven/
 OBJECTS_DIR=$$top_builddir/tmp/maven/
 include($$mzroll_pri)
@@ -36,8 +37,7 @@ LIBS += -lobiwarp
 
 macx{
 
-    INCLUDEPATH += /usr/local/include/ \
-                   /usr/local/Cellar/llvm/6.0.1/lib/clang/6.0.1/include/
+    INCLUDEPATH += /usr/local/include/
     QMAKE_LFLAGS += -L/usr/local/lib/
     LIBS +=  -lboost_signals
 }

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -51,6 +51,12 @@ win32 {
 mac {
     QMAKE_CXXFLAGS += -fopenmp
     INCLUDEPATH  += $$top_srcdir/3rdparty/google-breakpad/src/
+    DYLIBPATH = $$(LDFLAGS)
+    isEmpty(DYLIBPATH) {
+        warning("LDFLAGS variable is not set. Linking operation might complain about missing OMP library")
+        warning("Please follow the README to make sure you have correctly set the LDFLAGS variable")
+    }
+    QMAKE_LFLAGS += $$(LDFLAGS)
     QMAKE_LFLAGS += -L$$top_builddir/libs/
     LIBS += /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
     LIBS += /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -1,3 +1,5 @@
+include($$mac_compiler)
+
 MOC_DIR=$$top_builddir/tmp/mzroll/
 OBJECTS_DIR=$$top_builddir/tmp/mzroll/
 include($$mzroll_pri)
@@ -48,8 +50,8 @@ win32 {
 
 mac {
     QMAKE_CXXFLAGS += -fopenmp
-    INCLUDEPATH  += $$top_srcdir/3rdparty/google-breakpad/src/ /usr/local/Cellar/llvm/6.0.1/lib/clang/6.0.1/include/
-    QMAKE_LFLAGS += -L$$top_builddir/libs/ -L/usr/local/Cellar/llvm/6.0.1/lib/
+    INCLUDEPATH  += $$top_srcdir/3rdparty/google-breakpad/src/
+    QMAKE_LFLAGS += -L$$top_builddir/libs/
     LIBS += /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
     LIBS += /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
     LIBS += -lgoogle-breakpad -lobjc -pthread

--- a/src/pollyCLI/pollyCLI.pro
+++ b/src/pollyCLI/pollyCLI.pro
@@ -1,4 +1,4 @@
-
+include($$mac_compiler)
 MOC_DIR=$$top_builddir/tmp/pollyCLI/
 OBJECTS_DIR=$$top_builddir/tmp/pollyCLI/
 

--- a/src/projectDB/projectDB.pro
+++ b/src/projectDB/projectDB.pro
@@ -1,3 +1,4 @@
+include($$mac_compiler)
 TEMPLATE = lib
 
 OBJECTS_DIR = $$top_builddir/tmp/projectDB/

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,3 +1,4 @@
+include($$mac_compiler)
 TEMPLATE = subdirs
 CONFIG += ordered qt thread
 

--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -1,3 +1,4 @@
+include($$mac_compiler)
 DESTDIR = $$top_srcdir/bin/
 
 MOC_DIR=$$top_builddir/tmp/maven_tests/
@@ -29,8 +30,6 @@ LIBS += -lmaven -lpugixml -lneural -lcsvparser -lpls -lErrorHandling -lLogger -l
 !macx: LIBS += -fopenmp
 
 macx {
-    INCLUDEPATH += /usr/local/Cellar/llvm/6.0.1/lib/clang/6.0.1/include/
-    QMAKE_LFLAGS +=-L/usr/local/Cellar/llvm/6.0.1/lib/
     LIBS += -lomp
     LIBS -= -lnetcdf -lcdfread
 }

--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -22,8 +22,15 @@ INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  $$top_srcdir/3rdparty/pugixml/sr
 				$$top_srcdir/3rdparty/libcsvparser $$top_srcdir/src/cli/peakdetector $$top_srcdir/3rdparty/libdate $$top_srcdir/3rdparty/libcdfread \
                 $$top_srcdir/3rdparty/obiwarp $$top_srcdir/src/pollyCLI \
                 $$top_srcdir/3rdparty/Eigen
+macx {
 
-
+    DYLIBPATH = $$(LDFLAGS)
+    isEmpty(DYLIBPATH) {
+        warning("LDFLAGS variable is not set. Linking operation might complain about missing OMP library")
+        warning("Please follow the README to make sure you have correctly set the LDFLAGS variable")
+    }
+    QMAKE_LFLAGS += $$(LDFLAGS)
+}
 QMAKE_LFLAGS += -L$$top_builddir/libs/
 
 LIBS += -lmaven -lpugixml -lneural -lcsvparser -lpls -lErrorHandling -lLogger -lcdfread -lz -lnetcdf -lobiwarp -lpollyCLI


### PR DESCRIPTION
This commit makes sure that our code never uses the default clang compiler that comes with XCode

In case the user has not installed clang from brew, the compilation process will exit informing the user
about the missing compiler. 

For now, we are checking if the version of clang is 6.  This is done because  we don't want to be changing the versions of compilers often. So, this check will have to be changed whenever we change our compiler version.Also, these kind of checks will also be added for Qt/gcc versions in future

**EDIT**
For now, the solution is to make a common pri file that defines `QMAKE_CC` and `QMAKE_CXX`
and include that file in all the pro files.  I am sure qmake provides a way to define such things on a global level but at the moment I am unable to find a way to do this