### PR TITLE
Add option to export only good groups to Polly

### DIFF
--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -312,8 +312,8 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         if(lab !='g') return;
     } else if (selectionFlag == 3) {
         if(lab !='b') return;
-    } else {
-
+    } else if (selectionFlag == 4) {
+        if (lab == 'b') return;
     }
 
     vector<float> yvalues = group->getOrderedIntensityVector(samples, qtype);
@@ -447,6 +447,8 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
         if(group->label !='g') return;
     } else if (selectionFlag == 3) {
         if(group->label !='b') return;
+    } else if (selectionFlag == 4) {
+        if (group->label == 'b') return;
     }
 
     // sort the peaks in the group according to the sample names using a comparison function

--- a/src/gui/mzroll/forms/pollyelmaveninterface.ui
+++ b/src/gui/mzroll/forms/pollyelmaveninterface.ui
@@ -13,7 +13,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>550</height>
+    <height>590</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,13 +25,13 @@
   <property name="minimumSize">
    <size>
     <width>400</width>
-    <height>550</height>
+    <height>590</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>400</width>
-    <height>550</height>
+    <height>590</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -66,7 +66,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>460</y>
+     <y>500</y>
      <width>381</width>
      <height>41</height>
     </rect>
@@ -105,7 +105,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>500</y>
+     <y>540</y>
      <width>381</width>
      <height>41</height>
     </rect>
@@ -150,7 +150,7 @@
    <property name="geometry">
     <rect>
      <x>7</x>
-     <y>340</y>
+     <y>380</y>
      <width>389</width>
      <height>111</height>
     </rect>
@@ -521,6 +521,54 @@
    <property name="text">
     <string>Select App</string>
    </property>
+  </widget>
+  <widget class="QWidget" name="horizontalLayoutWidget_6">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>330</y>
+     <width>381</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="tableOptions_2">
+    <item>
+     <widget class="QLabel" name="label_3">
+      <property name="text">
+       <string>Select Groups</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <spacer name="horizontalSpacer_8">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>40</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QComboBox" name="groupSetCombo">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>134</width>
+        <height>16777215</height>
+       </size>
+      </property>
+     </widget>
+    </item>
+   </layout>
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -43,6 +43,11 @@ PollyElmavenInterfaceDialog::PollyElmavenInterfaceDialog(MainWindow* mw)
     gotoPollyButton->setVisible(false);
     gotoPollyButton->setDefault(true);
 
+    groupSetCombo->addItem("All Groups");
+    groupSetCombo->addItem("Only Good Groups");
+    groupSetCombo->addItem("Exclude Bad Groups");
+    groupSetCombo->setCurrentIndex(0);
+
     connect(logoutButton, SIGNAL(clicked(bool)), SLOT(_logout()));
     connect(workflowMenu,
             SIGNAL(currentItemChanged(QListWidgetItem*, QListWidgetItem*)),
@@ -396,6 +401,7 @@ void PollyElmavenInterfaceDialog::_uploadDataToPolly()
     gotoPollyButton->setVisible(false);
     uploadButton->setEnabled(false);
     peakTableCombo->setEnabled(false);
+    groupSetCombo->setEnabled(false);
     projectOptions->setEnabled(false);
     workflowMenu->setEnabled(false);
 
@@ -697,7 +703,14 @@ QStringList PollyElmavenInterfaceDialog::_prepareFilesToUpload(QDir qdir,
     // Preparing the CSV file
     QCoreApplication::processEvents();
 
-    peakTable->wholePeakSet();
+    if (groupSetCombo->currentIndex() == 0) {
+        peakTable->wholePeakSet();
+    } else if (groupSetCombo->currentIndex() == 1) {
+        peakTable->goodPeakSet();
+    } else if (groupSetCombo->currentIndex() == 2) {
+        peakTable->excludeBadPeakSet();
+    }
+
     peakTable->treeWidget->selectAll();
     peakTable->prepareDataForPolly(_writeableTempDir,
                                    "Groups Summary Matrix Format "
@@ -772,6 +785,7 @@ void PollyElmavenInterfaceDialog::_performPostUploadTasks(bool uploadSuccessful)
     _uploadInProgress = false;
     uploadButton->setEnabled(true);
     peakTableCombo->setEnabled(true);
+    groupSetCombo->setEnabled(true);
     projectOptions->setEnabled(true);
     workflowMenu->setEnabled(true);
 }

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -49,7 +49,13 @@ public:
   int uploadCount = 0;
 
   enum tableViewType { groupView = 0, peakView = 1 };
-  enum peakTableSelectionType { Selected = 0, Whole = 1, Good = 2, Bad = 3 };
+  enum peakTableSelectionType {
+      Selected = 0,
+      Whole = 1,
+      Good = 2,
+      Bad = 3,
+      NotBad = 4
+  };
 
   /**
    * @brief Construct and initialize a TableDockWidget.
@@ -129,6 +135,10 @@ public Q_SLOTS:
 
   inline void badPeakSet() {
     peakTableSelection = peakTableSelectionType::Bad;
+  };
+
+  inline void excludeBadPeakSet() {
+      peakTableSelection = peakTableSelectionType::NotBad;
   };
 
   void exportJson();


### PR DESCRIPTION
The EPI dialog lacked an option to export only good groups or
groups not marked bad. The entire selected table was being pushed
to Polly. This patch will allow the user to select only good or not
bad groups to be sent to Polly for further analysis.

Issue: #904