### PR TITLE
Save sample IDs associated with groups in emDB

### DIFF
--- a/src/projectDB/projectdatabase.h
+++ b/src/projectDB/projectdatabase.h
@@ -196,7 +196,7 @@ public:
      * loaded group and try to associate with it. If not found, the group will
      * be added as a top-level group itself.
      * @param loaded A vector of loaded samples which will be associated with
-     * peaks.
+     * peak groups and their peaks.
      * @return A vector of PeakGroup objects that were successfully loaded.
      */
     vector<PeakGroup*> loadGroups(const vector<mzSample*>& loaded);

--- a/src/projectDB/projectversioning.cpp
+++ b/src/projectDB/projectversioning.cpp
@@ -42,6 +42,7 @@ map<int, string> dbVersionUpgradeScripts = {
         "ALTER TABLE peakgroups ADD COLUMN fragmentation_spearman_rank_corr REAL;"
         "ALTER TABLE peakgroups ADD COLUMN fragmentation_tic_matched REAL;"
         "ALTER TABLE peakgroups ADD COLUMN fragmentation_num_matches REAL;"
+        "ALTER TABLE peakgroups ADD COLUMN sample_ids TEXT;"
 
         // changes to peaks table
         "ALTER TABLE peaks ADD COLUMN peak_spline_area REAL;"

--- a/src/projectDB/schema.h
+++ b/src/projectDB/schema.h
@@ -105,7 +105,8 @@
                                            , fragmentation_weighted_dot_product REAL                              \
                                            , fragmentation_spearman_rank_corr   REAL                              \
                                            , fragmentation_tic_matched          REAL                              \
-                                           , fragmentation_num_matches          REAL                              );"
+                                           , fragmentation_num_matches          REAL                              \
+                                           , sample_ids                         TEXT                              );"
 
 #define CREATE_COMPOUNDS_TABLE \
     "CREATE TABLE IF NOT EXISTS compounds ( compound_id           TEXT               \


### PR DESCRIPTION
Groups have a vector of mzSamples which is referred to (for intensities) when they are exported to CSV. These samples were not being stored in emDB format which led to missing intensity values in CSV files exported from emDB-restored peak tables. This behavior has been corrected.

Issue: #976