### PR TITLE
Fix expected RT diff and abundance swapped in emDB

### DIFF
--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -160,8 +160,8 @@ int ProjectDatabase::saveGroupAndPeaks(PeakGroup* group,
                      , :meta_group_id                      \
                      , :tag_string                         \
                      , :expected_mz                        \
-                     , :expected_rt_diff                   \
                      , :expected_abundance                 \
+                     , :expected_rt_diff                   \
                      , :group_rank                         \
                      , :label                              \
                      , :type                               \


### PR DESCRIPTION
Because of the positioning of expected RT difference and expected abundance variables in insertion statement, the wrong values were being bound and saved in (and read from) SQLite databases. This
has been fixed.

Issue: #962