### PR TITLE
FIx "peak area spline" not being saved in emDB

### DIFF
--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -287,7 +287,8 @@ void ProjectDatabase::saveGroupPeaks(PeakGroup* group, const int groupId)
                      , :group_overlap_frac      \
                      , :local_max_flag          \
                      , :from_blank_sample       \
-                     , :label                   )");
+                     , :label                   \
+                     , :peak_spline_area        )");
 
     for (Peak p : group->peaks) {
         peaksQuery->bind(":group_id", groupId);
@@ -304,6 +305,7 @@ void ProjectDatabase::saveGroupPeaks(PeakGroup* group, const int groupId)
         peaksQuery->bind(":minscan", static_cast<int>(p.minscan));
         peaksQuery->bind(":maxscan", static_cast<int>(p.maxscan));
         peaksQuery->bind(":peak_area", p.peakArea);
+        peaksQuery->bind(":peak_spline_area", p.peakSplineArea);
         peaksQuery->bind(":peak_area_corrected", p.peakAreaCorrected);
         peaksQuery->bind(":peak_area_top", p.peakAreaTop);
         peaksQuery->bind(":peak_area_top_corrected", p.peakAreaTopCorrected);
@@ -985,6 +987,7 @@ void ProjectDatabase::loadGroupPeaks(PeakGroup* parentGroup,
         peak.maxscan =
             static_cast<unsigned int>(peaksQuery->integerValue("maxscan"));
         peak.peakArea = peaksQuery->floatValue("peak_area");
+        peak.peakSplineArea = peaksQuery->floatValue("peak_spline_area");
         peak.peakAreaCorrected = peaksQuery->floatValue("peak_area_corrected");
         peak.peakAreaTop = peaksQuery->floatValue("peak_area_top");
         peak.peakAreaTopCorrected =

--- a/src/projectDB/projectversioning.cpp
+++ b/src/projectDB/projectversioning.cpp
@@ -43,6 +43,9 @@ map<int, string> dbVersionUpgradeScripts = {
         "ALTER TABLE peakgroups ADD COLUMN fragmentation_tic_matched REAL;"
         "ALTER TABLE peakgroups ADD COLUMN fragmentation_num_matches REAL;"
 
+        // changes to peaks table
+        "ALTER TABLE peaks ADD COLUMN peak_spline_area REAL;"
+
         // due to change in primary key, the entire table needs to be recreated
         "ALTER TABLE compounds RENAME TO compounds_old;"
         "CREATE TABLE compounds ( compound_id           TEXT                 "

--- a/src/projectDB/schema.h
+++ b/src/projectDB/schema.h
@@ -74,7 +74,8 @@
                                       , group_overlap_frac      REAL                              \
                                       , local_max_flag          REAL                              \
                                       , from_blank_sample       INTEGER                           \
-                                      , label                   INTEGER                           );"
+                                      , label                   INTEGER                           \
+                                      , peak_spline_area        REAL                              );"
 
 #define CREATE_PEAK_GROUPS_TABLE \
     "CREATE TABLE IF NOT EXISTS peakgroups ( group_id                           INTEGER PRIMARY KEY AUTOINCREMENT \


### PR DESCRIPTION
Peak spline area was being missed out in emDB saves (and hence
also not being read in when later restored). This patch fixes the
issue.

Issue: #994