### PR TITLE
Build tests conditionally

### DIFF
--- a/build.pro
+++ b/build.pro
@@ -24,3 +24,5 @@ include($$mac_compiler)
 TEMPLATE = subdirs
 CONFIG += ordered qt thread
 SUBDIRS += 3rdparty crashhandler src tests/MavenTests 
+
+equals(NOTESTS, "yes"): SUBDIRS-=tests/MavenTests


### PR DESCRIPTION
Tests are not required be to deployed on user's system. Our build
scripts at the moment have no way of checking if it's actually
required to build tests or not.

NOTESTS variable will be used to check if tests are to be built or
not