### PR TITLE
Check dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,32 @@ Contributers can build El-MAVEN on Windows, Ubuntu or Mac systems by following t
 ### Windows
 
 - Download [MSYS2](http://www.msys2.org/) installer and follow the installation instructions provided on their website.
-- Open MSYS2 and give the following commands to set up libraries and tool chains for El-MAVEN. Reopen MSYS2 when required:  
-- **For 64 bit**:  
-`pacman --force -Sy`  
-`pacman --force -Syu`  
-`pacman --force -Su`  
-`pacman --force -Sy base-devel msys2-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-hdf5 mingw64/mingw-w64-x86_64-netcdf mingw64/mingw-w64-x86_64-boost msys/git mingw-w64-x86_64-curl`
+- Open MSYS2 and give the following commands to set up libraries and tool chains for El-MAVEN. Reopen MSYS2 when required:
+##### **For 64 bit**:  _Following commands needs to be executed from msys2 shell_
 
-- Open mingw64.exe from the MSYS2 folder and give the following commands:  
-`cd <PathToInstallationFolder>    #for example: cd /c/User/Admin/Desktop`  
-`git clone https://github.com/ElucidataInc/ElMaven.git`  
-`./run.sh`  
-`./bin/El_Maven_0.x    #for example: ./bin/El_Maven_0.2`  
+- `pacman --force -Sy`
+- `pacman --force -Syu`
+- `pacman --force -Su`
+- `pacman --force -Sy base-devel msys2-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-hdf5 mingw64/mingw-w64-x86_64-netcdf mingw64/mingw-w64-x86_64-boost msys/git mingw-w64-x86_64-curl`
+- `export PATH=/c/msys64/mingw64/bin/:$PATH`. It will be benefical if this change is made permanent. To do so, you will have to make changes
+in the .bashrc file. It can be achieved by either manually editing the .bashrc file or via command line.
 
-El-MAVEN loads with two windows: one for logging the application status and another El-MAVEN application window for data analysis.  
+  **For manually editing:**
+    - Open .bashrc(located in C:\msys64\home\USERNAME\\) in any text editor
+    - Add `export PATH=/c/msys64/mingw64/bin/:$PATH` at the end of the file
+    - Save and exit the editor
+    - From msys2 shell: `source ~/.bashrc`
+
+  **For editing the file via command line:**
+    - `echo export PATH=/c/msys64/mingw64/bin/:$PATH > ~/.bashrc`
+    - `source ~/.bashrc`
+
+- `cd <PathToInstallationFolder>    #for example: cd /c/User/Admin/Desktop`
+- `git clone https://github.com/ElucidataInc/ElMaven.git`
+- `./run.sh`
+- `./bin/El_Maven_0.x    #for example: ./bin/El_Maven_0.2`
+
+El-MAVEN loads with two windows: one for logging the application status and another El-MAVEN application window for data analysis.
 
 ### Ubuntu  
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Contributers can build El-MAVEN on Windows, Ubuntu or Mac systems by following t
 `pacman --force -Sy`  
 `pacman --force -Syu`  
 `pacman --force -Su`  
-`pacman --force -Sy base-devel msys2-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-hdf5 mingw64/mingw-w64-x86_64-netcdf mingw64/mingw-w64-x86_64-boost msys/git`  
+`pacman --force -Sy base-devel msys2-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-hdf5 mingw64/mingw-w64-x86_64-netcdf mingw64/mingw-w64-x86_64-boost msys/git mingw-w64-x86_64-curl`
 
 - **For 32 bit**:  
 `pacman --force -Sy`  

--- a/README.md
+++ b/README.md
@@ -43,12 +43,6 @@ Contributers can build El-MAVEN on Windows, Ubuntu or Mac systems by following t
 `pacman --force -Su`  
 `pacman --force -Sy base-devel msys2-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-hdf5 mingw64/mingw-w64-x86_64-netcdf mingw64/mingw-w64-x86_64-boost msys/git mingw-w64-x86_64-curl`
 
-- **For 32 bit**:  
-`pacman --force -Sy`  
-`pacman --force -Syu`  
-`pacman --force -Su`  
-`pacman --force -Sy base-devel msys2-devel mingw-i686-toolchain mingw-i686-qt5 mingw32/mingw-i686-hdf5 mingw32/mingw-i686-netcdf mingw32/mingw-i686-boost msys/git`  
-
 - Open mingw64.exe from the MSYS2 folder and give the following commands:  
 `cd <PathToInstallationFolder>    #for example: cd /c/User/Admin/Desktop`  
 `git clone https://github.com/ElucidataInc/ElMaven.git`  

--- a/build.pro
+++ b/build.pro
@@ -13,6 +13,12 @@ macx {
     }
 }
 
+win32 {
+    #package 'mingw-w64-x86_64-curl' is required by libnetcdf.
+    CONFIG += link_pkgconfig
+    PKGCONFIG = libcurl
+}
+
 include($$mac_compiler)
 
 TEMPLATE = subdirs


### PR DESCRIPTION
[pkg-confg](https://www.freedesktop.org/wiki/Software/pkg-config/) is a helper tool used when compiling applications and libraries. We will be using it to check if all the dependencies are installed before compilation process actually starts. 
Currently, the check is just for `libcurl`,  it also  has been implemented in a very immature way(no custom error messages if a particular dependency is not found). In future, we can add checks for other libs as well etc