### PR TITLE
Crash on peak Table deletion

### DIFF
--- a/src/gui/mzroll/spectrawidget.h
+++ b/src/gui/mzroll/spectrawidget.h
@@ -60,7 +60,7 @@ public:
                     EICLogic* eicparameters;
                     MainWindow* mainwindow;
                     Scan* _currentScan;
-                    PeakGroup* _currentGroup;
+                    PeakGroup _currentGroup;
                     Scan* _avgScan;
                     vector<Scan*>_scanset;
 


### PR DESCRIPTION
Spectra widget used to store a pointer to the currently selected peakGroup from the peakTable.
On deleting the peakTable, the peakGroup is also deleted and therefore accessing it through the pointer make the app crash.

The peakGroup object will now be copied and stored as the _currentGroup to prevent such crashes.