### PR TITLE
Fix session autosave on windows

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -842,7 +842,7 @@ void MainWindow::createPeakTable(QString filenameNew) {
 QString MainWindow::_newAutosaveFile()
 {
     auto now = QDateTime::currentDateTime();
-    auto tempFilename = now.toString(Qt::ISODate) + ".emDB";
+    auto tempFilename = now.toString("dd_MM_yyyy_hh_mm_ss") + ".emDB";
     auto firstSampleFile = getSamples()[0]->fileName;
     auto sampleFileInfo = QFileInfo(QString::fromStdString(firstSampleFile));
     auto samplePath = sampleFileInfo.absolutePath();

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -921,8 +921,10 @@ QString MainWindow::getLatestUserProject()
 
 void MainWindow::resetAutosave()
 {
-    if (this->timestampFileExists)
+    if (this->timestampFileExists) {
+        fileLoader->closeSQLiteProject();
         QFile::remove(_currentProjectName);
+    }
     this->timestampFileExists = false;
     this->peaksMarked = 0;
     _currentProjectName = "";
@@ -994,6 +996,7 @@ void MainWindow::saveProject(bool explicitSave)
                                           QMessageBox::Yes);
 
             // remove timestamp autosave file in any case
+            fileLoader->closeSQLiteProject();
             QFile::remove(_currentProjectName);
             if (reply != QMessageBox::Yes)
                 return;
@@ -1021,8 +1024,10 @@ void MainWindow::saveProject(bool explicitSave)
             msgBox.exec();
 
             // remove current project file only if it was created by autosave
-            if (this->timestampFileExists)
+            if (this->timestampFileExists) {
+                fileLoader->closeSQLiteProject();
                 QFile::remove(_currentProjectName);
+            }
 
             if (msgBox.clickedButton() == newButton) {
                 _currentProjectName = "";

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -727,18 +727,30 @@ bool mzFileIO::writeSQLiteProject(QString filename)
     if (sampleSet.size() == 0)
         return false;
 
-    if (_currentProject
-            and _currentProject->projectName() == filename.toStdString()) {
+    auto projectIsAlreadyOpen = false;
+    if (_currentProject) {
+        auto currentName = QString::fromStdString(_currentProject->projectName());
+        auto currentPath = QString::fromStdString(_currentProject->projectPath());
+        auto currentFilename = currentPath + QDir::separator() + currentName;
+        qDebug() << currentFilename;
+        qDebug() << filename;
+        if (currentFilename == filename)
+            projectIsAlreadyOpen = true;
+    }
+
+    if (projectIsAlreadyOpen) {
         qDebug() << "saving in existing project…";
     } else {
-        qDebug() << "creating new project to save…";
-        auto version = _mainwindow->appVersion().toStdString();
+        qDebug() << "closing the current project…";
+        closeSQLiteProject();
 
         // if file already exists, delete it before opening a new one
         QFile projectFile(filename);
         if (projectFile.exists())
             projectFile.remove();
 
+        qDebug() << "creating new project to save…";
+        auto version = _mainwindow->appVersion().toStdString();
         _currentProject = new ProjectDatabase(filename.toStdString(), version);
     }
 


### PR DESCRIPTION
This pair of commits include the following changes:
1. Use an alternative timestamp format for autosave files, thereby allowing creation of files that have filnames compatible with the Windows filesystem.
2. Close autosave emDB projects before deleting them - which itself involved fixing an always failing check that was supposed to prevent new connections to already open projects.

With this patch, autosave should have the same behavior on Windows, Linux and MacOS platforms.