### PR TITLE
Fix Match Fragmentation filters

### DIFF
--- a/src/core/libmaven/Fragment.cpp
+++ b/src/core/libmaven/Fragment.cpp
@@ -360,7 +360,6 @@ vector<float> Fragment::asDenseVector(float mzmin, float mzmax, int nbins)
             continue;
 
         int bin = int(((mzValues[i] - mzmin) / mzrange ) * nbins);
-        cerr << bin << endl;
         if (bin > 0 && bin < nbins)
             v[bin] += intensityValues[i];
     }

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -197,6 +197,12 @@ void  MavenParameters::setPeakDetectionSettings(const char* key, const char* val
     if(strcmp(key, "fragmentTolerance") == 0)
         fragmentTolerance = atof(value);
 
+    if (strcmp(key, "minFragMatch") == 0)
+        minFragMatch = atof(value);
+
+    if (strcmp(key, "minFragMatchScore") == 0)
+        minFragMatchScore = atof(value);
+
     if(strcmp(key,"timeDomainResolution") == 0)
         rtStepSize = atof(value);
 

--- a/src/gui/mzroll/forms/peakdetectiondialog.ui
+++ b/src/gui/mzroll/forms/peakdetectiondialog.ui
@@ -402,10 +402,10 @@
              <string/>
             </property>
             <property name="maximum">
-             <double>1.000000000000000</double>
+             <double>1000.000000000000000</double>
             </property>
             <property name="singleStep">
-             <double>0.100000000000000</double>
+             <double>5.000000000000000</double>
             </property>
            </widget>
           </item>

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2645,6 +2645,11 @@ void MainWindow::createMenus() {
     aj->setCheckable(true); 
 	aj->setChecked(false);
     connect(aj, SIGNAL(toggled(bool)), fragPanel, SLOT(setVisible(bool)));
+	connect(aj, &QAction::toggled, [this]()
+    {
+        analytics->hitEvent("MS2 Events List",
+                                  "Clicked");
+    });
 
     QAction* al = widgetsMenu->addAction("Peptide Fragmentation");
     al->setCheckable(true);  al->setChecked(false);

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -136,6 +136,17 @@ PeakDetectionDialog::PeakDetectionDialog(QWidget *parent) :
                                    "Isotope Detection Switched",
                                    state);
                 });
+        connect(matchFragmentationOptions,
+                &QGroupBox::toggled,
+                [this](const bool checked)
+                {
+                    QString state = checked? "On" : "Off";
+                    this->mainwindow
+                        ->getAnalytics()
+                        ->hitEvent("Peak Detection",
+                                   "Match Fragmentation Switched",
+                                   state);
+                });
         connect(saveMethodButton,SIGNAL(clicked()),this,SLOT(saveMethod())); //TODO: Sahil - Kiran, Added while merging mainwindow
         connect(loadMethodButton,SIGNAL(clicked()),this,SLOT(loadMethod())); //TODO: Sahil - Kiran, Added while merging mainwindow
         connect(loadModelButton,SIGNAL(clicked()),this,SLOT(loadModel()));


### PR DESCRIPTION
This PR has 3 changes:
1. It fixes the MS2 Fragmentation filters in peaks dialog. Two filters, "Match at least X peaks" and "Min Match Score", were not being used for filtering groups.
2. The input range for the "Min Match Score" has been corrected.
3. GA has been added for MS2 Events list and the Match Fragmentation checkbox.