### PR TITLE
Fix automated peak detection failure

### DIFF
--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -332,7 +332,10 @@ void BackgroundPeakUpdate::writeCSVRep(string setName)
     auto prmGroupAt = find_if(begin(mavenParameters->allgroups),
                               end(mavenParameters->allgroups),
                               [] (PeakGroup& group) {
-                                  return group.compound->type() == Compound::Type::PRM;
+                                  if (group.compound)
+                                    return (group.compound->type()
+                                            == Compound::Type::PRM);
+                                  return false;
                               });
     bool prmGroupExists = prmGroupAt != end(mavenParameters->allgroups);
 


### PR DESCRIPTION
A new check was added to the method `BackgroundPeakUpdate::writeCSVRep` which checks whether peak groups found have a PRM compound associated with them or not. This filtering was indiscriminately made, even for groups that may not have a compound associated with them at all. This has been fixed.