### PR TITLE
Use a wider m/z resolution for spectra widget

### DIFF
--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -643,7 +643,7 @@ void SpectraWidget::drawGraph()
 
     if (_spectralHit.mzList.size() > 0) {
         setGroupTitle();
-        if (mzUtils::almostEqual(_spectralHit.precursorMz, _currentScan->precursorMz))
+        if (fabs(_spectralHit.precursorMz - _currentScan->precursorMz) < 0.1f)
             drawSpectralHit(_spectralHit);
         else {
             //TODO: either remove the check or inform user on the UI in case of failure


### PR DESCRIPTION
The Fragmentation spectra widget shows group fragment pattern overlaid by the compound fragment pattern from the library. The overlay was not happening in most cases because the conditional check for drawing the compound frag pattern was too strict. This has been fixed in this PR.