### PR TITLE
[Fix] Make CSV exports compatible with Polly apps

### DIFF
--- a/src/cli/peakdetector/peakdetectorcli.cpp
+++ b/src/cli/peakdetector/peakdetectorcli.cpp
@@ -721,7 +721,7 @@ void PeakDetectorCLI::writeReport(string setName,
         saveMzRoll(fileName);
 
         // save output CSV
-        saveCSV(fileName);
+        saveCSV(fileName, false);
     } else {
         // try uploading to Polly
         QMap<QString, QString> creds = _readCredentialsFromXml(pollyArgs);
@@ -769,7 +769,7 @@ void PeakDetectorCLI::writeReport(string setName,
         saveJson(jsonFilename.toStdString());
 
         // save output CSV
-        saveCSV(csvFilename.toStdString());
+        saveCSV(csvFilename.toStdString(), true);
 
         try {
             // add more files to upload, if desired…
@@ -1085,7 +1085,7 @@ void PeakDetectorCLI::saveMzRoll(string setName)
     }
 }
 
-void PeakDetectorCLI::saveCSV(string setName)
+void PeakDetectorCLI::saveCSV(string setName, bool pollyExport)
 {
 #ifndef __APPLE__
     double startSavingCSV = getTime();
@@ -1093,7 +1093,7 @@ void PeakDetectorCLI::saveCSV(string setName)
 
     string fileName = setName + ".csv";
 
-    CSVReports* csvreports = new CSVReports(mavenParameters->samples);
+    CSVReports* csvreports = new CSVReports(mavenParameters->samples, pollyExport);
     csvreports->setMavenParameters(mavenParameters);
 
     if (mavenParameters->allgroups.size() == 0) {

--- a/src/cli/peakdetector/peakdetectorcli.h
+++ b/src/cli/peakdetector/peakdetectorcli.h
@@ -139,7 +139,7 @@ public:
      * @brief save project as .mzroll
      * @param setName file name with full path
      */
-    void saveCSV(string setName);
+    void saveCSV(string setName, bool pollyExport);
 
     /**
      * [Uploads Maven data to Polly and redirects the user to polly]

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -1,7 +1,7 @@
 #include "csvreports.h"
 
 
-CSVReports::CSVReports(vector<mzSample*>&insamples)
+CSVReports::CSVReports(vector<mzSample*>&insamples, bool pollyExport)
 {
     /*
     *@detail -   constructor for instantiating class by all samples uploaded,
@@ -14,6 +14,7 @@ CSVReports::CSVReports(vector<mzSample*>&insamples)
     */
     samples = insamples;
     groupId = 0;
+    _pollyExport = pollyExport;
     /**@brief-  set user quant type-  generally represent intensity but not always check QType enum in PeaKGroup.h  */
     setUserQuantType(PeakGroup::AreaTop);
     setTabDelimited();      /**@brief-  set output file separator as tab*/
@@ -102,7 +103,7 @@ void CSVReports::insertGroupReportColumnNamesintoCSVFile(string outputfile,
                             << "parent";
 
         // if this is a PRM report, add PRM specific columns
-        if (prmReport) {
+        if (prmReport && !_pollyExport) {
             groupReportcolnames << "ms2EventCount"
                                 << "fragNumIonsMatched"
                                 << "fragmentFractionMatched"
@@ -387,7 +388,7 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
         groupReport << SEP << group->meanMz;
     }
 
-    if (group->compound && group->compound->type() == Compound::Type::PRM) {
+    if (group->compound && group->compound->type() == Compound::Type::PRM && !_pollyExport) {
         auto groupToWrite = group;
 
         // if this is a C12 PARENT, then all PRM attributes should be taken from

--- a/src/core/libmaven/csvreports.h
+++ b/src/core/libmaven/csvreports.h
@@ -30,7 +30,7 @@ public:
     *@brief-    creating CSVReports by all the samples uploaded
     *@see -     see details in its definition
     */
-    CSVReports(vector<mzSample*>& insamples);
+    CSVReports(vector<mzSample*>& insamples, bool pollyExport = false);
     /**
     *@brief-    destructor, just close all open output files opened for writing csv or tab file
     */
@@ -171,7 +171,7 @@ private:
     PeakGroup::QType qtype;             /**@param-  user quant type, represents intensity of peaks*/
     MavenParameters * mavenparameters;
     int selectionFlag;      /**@param-  TODO*/
-    bool _uploadToPolly;
+    bool _pollyExport;
 };
 
 #endif

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -647,7 +647,7 @@ void TableDockWidget::prepareDataForPolly(QString writableTempDir,
                                           QString userFilename) {
 
   vector<mzSample *> samples = _mainwindow->getSamples();
-  CSVReports *csvreports = new CSVReports(samples);
+  CSVReports *csvreports = new CSVReports(samples, true);
   csvreports->setMavenParameters(_mainwindow->mavenParameters);
   if (allgroups.size() == 0) {
     QString msg = "Peaks Table is Empty";

--- a/tests/MavenTests/testCLI.cpp
+++ b/tests/MavenTests/testCLI.cpp
@@ -177,7 +177,7 @@ void TestCLI::testWriteReport() {
         QFileInfo mzrollFile(QString::fromStdString(peakdetectorCLI->mavenParameters->outputdir + "testmzRoll" + ".mzroll"));
         QVERIFY(mzrollFile.exists() && mzrollFile.isFile());
 
-        peakdetectorCLI->saveCSV(peakdetectorCLI->mavenParameters->outputdir + "testcsv");
+        peakdetectorCLI->saveCSV(peakdetectorCLI->mavenParameters->outputdir + "testcsv", false);
         QFileInfo csvFile(QString::fromStdString(peakdetectorCLI->mavenParameters->outputdir + "testcsv" + ".csv"));
         QVERIFY(csvFile.exists() && csvFile.isFile());
 


### PR DESCRIPTION
Polly apps accept a specific format from El-MAVEN. The additional columns for MSMS info in CSV files can cause major errors on Polly apps. These columns will therefore be dropped from the CSV export before sending to Polly.
The local CSV exports will continue to behave as earlier.