### PR TITLE
Calculate MS2 score and num of Events for bookmarked groups

### DIFF
--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -853,6 +853,7 @@ void EIC::removeLowRankGroups(vector<PeakGroup> &groups, unsigned int rankLimit)
 
 //TODO: Lots of parameters. Refactor this code - Sahil
 vector<PeakGroup> EIC::groupPeaks(vector<EIC *> &eics,
+                                  Compound* compound,
                                   int smoothingWindow,
                                   float maxRtDiff,
                                   double minQuality,
@@ -860,7 +861,9 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC *> &eics,
                                   double distYWeight,
                                   double overlapWeight,
                                   bool useOverlap,
-                                  double minSignalBaselineDifference)
+                                  double minSignalBaselineDifference,
+                                  float productPpmTolerance,
+                                  string scoringAlgo)
 {
     vector<mzSample*> samples;
     for(int i=0;i<eics.size();++i){
@@ -900,6 +903,7 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC *> &eics,
     {
         PeakGroup grp;
         grp.groupId = i;
+        grp.compound = compound;
         grp.setSelectedSamples(samples);
         pgroups.push_back(grp);
     }
@@ -994,7 +998,10 @@ vector<PeakGroup> EIC::groupPeaks(vector<EIC *> &eics,
         //Feng note: fillInPeaks is unecessary
         grp.groupStatistics();
         grp.computeAvgBlankArea(eics);
-
+        if (grp.getFragmentationEvents().size()) {
+            grp.computeFragPattern(productPpmTolerance);
+            grp.matchFragmentation(productPpmTolerance, scoringAlgo);
+        }
     }
 
     //now merge overlapping groups

--- a/src/core/libmaven/EIC.h
+++ b/src/core/libmaven/EIC.h
@@ -15,6 +15,7 @@ class PeakGroup;
 class mzSample;
 class mzPoint;
 class Scan;
+class Compound;
 
 class EIC
 {
@@ -248,6 +249,7 @@ class EIC
      * @return vector of peak groups found
     **/
     static vector<PeakGroup> groupPeaks(vector<EIC *> &eics,
+                                        Compound* compound,
                                         int smoothingWindow,
                                         float maxRtDiff,
                                         double minQuality,
@@ -255,7 +257,9 @@ class EIC
                                         double distYWeight,
                                         double overlapWeight,
                                         bool useOverlap,
-                                        double minSignalBaselineDifference);
+                                        double minSignalBaselineDifference,
+                                        float fragmentPpmTolerance,
+                                        string scoringAlgo);
     /**
          * [eicMerge ]
          * @method eicMerge

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -378,6 +378,7 @@ void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)
 
         vector<PeakGroup> peakgroups =
             EIC::groupPeaks(eics,
+                            compound,
                             mavenParameters->eic_smoothingWindow,
                             mavenParameters->grouping_maxRtWindow,
                             mavenParameters->minQuality,
@@ -385,8 +386,10 @@ void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)
                             mavenParameters->distYWeight,
                             mavenParameters->overlapWeight,
                             mavenParameters->useOverlap,
-                            mavenParameters->minSignalBaselineDifference);
-
+                            mavenParameters->minSignalBaselineDifference,
+                            mavenParameters->fragmentTolerance,
+                            mavenParameters->scoringAlgo);
+        
         GroupFiltering groupFiltering(mavenParameters, slice);
         groupFiltering.filter(peakgroups);
 

--- a/src/core/libmaven/eiclogic.cpp
+++ b/src/core/libmaven/eiclogic.cpp
@@ -59,15 +59,19 @@ PeakGroup* EICLogic::selectGroupNearRt(float rt,
 }
 
 void EICLogic::groupPeaks(float eic_smoothingWindow,
+                          Compound* compound,
 							float grouping_maxRtWindow,
 							double minQuality,
 							double distXWeight,
 							double distYWeight,
 							double overlapWeight,
 							bool useOverlap,
-							double minSignalBaselineDifference) {
+							double minSignalBaselineDifference,
+							float productPpmTolerance,
+							string scoringAlgo) {
 
 	peakgroups = EIC::groupPeaks(eics,
+                                compound,
 								eic_smoothingWindow,
 								grouping_maxRtWindow,
 								minQuality,
@@ -75,7 +79,9 @@ void EICLogic::groupPeaks(float eic_smoothingWindow,
                                 distYWeight,
                                 overlapWeight,
                                 useOverlap,
-								minSignalBaselineDifference);
+								minSignalBaselineDifference,
+								productPpmTolerance,
+								scoringAlgo);
 
 
 	//keep only top X groups ( ranked by intensity )

--- a/src/core/libmaven/eiclogic.cpp
+++ b/src/core/libmaven/eiclogic.cpp
@@ -60,32 +60,32 @@ PeakGroup* EICLogic::selectGroupNearRt(float rt,
 
 void EICLogic::groupPeaks(float eic_smoothingWindow,
                           Compound* compound,
-							float grouping_maxRtWindow,
-							double minQuality,
-							double distXWeight,
-							double distYWeight,
-							double overlapWeight,
-							bool useOverlap,
-							double minSignalBaselineDifference,
-							float productPpmTolerance,
-							string scoringAlgo) {
-
-	peakgroups = EIC::groupPeaks(eics,
+                          float grouping_maxRtWindow,
+                          double minQuality,
+                          double distXWeight,
+                          double distYWeight,
+                          double overlapWeight,
+                          bool useOverlap,
+                          double minSignalBaselineDifference,
+                          float productPpmTolerance,
+                          string scoringAlgo)
+{
+    peakgroups = EIC::groupPeaks(eics,
                                 compound,
-								eic_smoothingWindow,
-								grouping_maxRtWindow,
-								minQuality,
+                                eic_smoothingWindow,
+                                grouping_maxRtWindow,
+                                minQuality,
                                 distXWeight,
                                 distYWeight,
                                 overlapWeight,
                                 useOverlap,
-								minSignalBaselineDifference,
-								productPpmTolerance,
-								scoringAlgo);
+                                minSignalBaselineDifference,
+                                productPpmTolerance,
+                                scoringAlgo);
 
 
-	//keep only top X groups ( ranked by intensity )
-	EIC::removeLowRankGroups(peakgroups, 50);
+    //keep only top X groups ( ranked by intensity )
+    EIC::removeLowRankGroups(peakgroups, 50);
 }
 
 mzSlice EICLogic::setMzSlice(float mz1,MassCutoff *massCutoff, float mz2) {

--- a/src/core/libmaven/eiclogic.h
+++ b/src/core/libmaven/eiclogic.h
@@ -34,14 +34,17 @@ public:
 								int intensityWeight,
 								int deltaRTWeight);
 
-	void groupPeaks(float eic_smoothingWindow,
-					float grouping_maxRtWindow,
-					double minQuality,
-					double distXWeight,
-					double distYWeight,
-					double overlapWeight,
-					bool useOverlap,
-					double minSignalBaselineDifference);
+    void groupPeaks(float eic_smoothingWindow,
+                    Compound* compound,
+                    float grouping_maxRtWindow,
+                    double minQuality,
+                    double distXWeight,
+                    double distYWeight,
+                    double overlapWeight,
+                    bool useOverlap,
+                    double minSignalBaselineDifference,
+                    float productPpmTolerance,
+                    string scoringAlgo);
 
 	mzSlice setMzSlice(float mz1, MassCutoff *massCutoff, float mz2 = 0.0);
 

--- a/src/core/libmaven/groupFiltering.cpp
+++ b/src/core/libmaven/groupFiltering.cpp
@@ -39,6 +39,7 @@ void GroupFiltering::filter(vector<PeakGroup> &peakgroups)
 bool GroupFiltering::filterByMS1(PeakGroup &peakgroup)
 {
 
+    //TODO: remove compound assignment from filtering
     Compound* compound = _slice->compound;
     peakgroup.setQuantitationType((PeakGroup::QType)_mavenParameters->peakQuantitation);
     peakgroup.minQuality = _mavenParameters->minQuality;
@@ -96,6 +97,8 @@ bool GroupFiltering::filterByMS1(PeakGroup &peakgroup)
 
 bool GroupFiltering::filterByMS2(PeakGroup& peakgroup)
 {
+    //TODO: remove MS2 stats calculation from filtering.
+    //Already calculated during grouping
     peakgroup.computeFragPattern(_mavenParameters->fragmentTolerance);
     peakgroup.matchFragmentation(_mavenParameters->fragmentTolerance,
                                  _mavenParameters->scoringAlgo);

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -197,16 +197,16 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
 		}
 	}
 
-	eicParameters->_integratedGroup.groupStatistics();
+    eicParameters->_integratedGroup.groupStatistics();
     int ms2Events = eicParameters->_integratedGroup.getFragmentationEvents().size();
     if (ms2Events) {
-		float ppm = getMainWindow()->mavenParameters->fragmentTolerance;
-		string scoringAlgo = getMainWindow()->mavenParameters->scoringAlgo;
+        float ppm = getMainWindow()->mavenParameters->fragmentTolerance;
+        string scoringAlgo = getMainWindow()->mavenParameters->scoringAlgo;
         eicParameters->_integratedGroup.computeFragPattern(ppm);
-		eicParameters->_integratedGroup.matchFragmentation(ppm, scoringAlgo);
+        eicParameters->_integratedGroup.matchFragmentation(ppm, scoringAlgo);
     }
-	getMainWindow()->isotopeWidget->updateIsotopicBarplot(&eicParameters->_integratedGroup);
-	getMainWindow()->isotopeWidget->setPeakGroupAndMore(&eicParameters->_integratedGroup, true);
+    getMainWindow()->isotopeWidget->updateIsotopicBarplot(&eicParameters->_integratedGroup);
+    getMainWindow()->isotopeWidget->setPeakGroupAndMore(&eicParameters->_integratedGroup, true);
 }
 
 void EicWidget::mouseDoubleClickEvent(QMouseEvent* event) {

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -198,6 +198,13 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
 	}
 
 	eicParameters->_integratedGroup.groupStatistics();
+    int ms2Events = eicParameters->_integratedGroup.getFragmentationEvents().size();
+    if (ms2Events) {
+		float ppm = getMainWindow()->mavenParameters->fragmentTolerance;
+		string scoringAlgo = getMainWindow()->mavenParameters->scoringAlgo;
+        eicParameters->_integratedGroup.computeFragPattern(ppm);
+		eicParameters->_integratedGroup.matchFragmentation(ppm, scoringAlgo);
+    }
 	getMainWindow()->isotopeWidget->updateIsotopicBarplot(&eicParameters->_integratedGroup);
 	getMainWindow()->isotopeWidget->setPeakGroupAndMore(&eicParameters->_integratedGroup, true);
 }
@@ -1536,15 +1543,17 @@ void EicWidget::groupPeaks() {
     int eic_smoothingWindow = getMainWindow()->mavenParameters->eic_smoothingWindow;
     float grouping_maxRtWindow = getMainWindow()->mavenParameters->grouping_maxRtWindow;
 
-	eicParameters->groupPeaks(eic_smoothingWindow,
-								grouping_maxRtWindow,
-                                getMainWindow()->mavenParameters->minQuality,
-								getMainWindow()->mavenParameters->distXWeight,
-								getMainWindow()->mavenParameters->distYWeight,
-								getMainWindow()->mavenParameters->overlapWeight,
-								getMainWindow()->mavenParameters->useOverlap,
-								getMainWindow()->mavenParameters->minSignalBaselineDifference);
-
+    eicParameters->groupPeaks(eic_smoothingWindow,
+                              eicParameters->_slice.compound,
+                              grouping_maxRtWindow,
+                              getMainWindow()->mavenParameters->minQuality,
+                              getMainWindow()->mavenParameters->distXWeight,
+                              getMainWindow()->mavenParameters->distYWeight,
+                              getMainWindow()->mavenParameters->overlapWeight,
+                              getMainWindow()->mavenParameters->useOverlap,
+                              getMainWindow()->mavenParameters->minSignalBaselineDifference,
+                              getMainWindow()->mavenParameters->fragmentTolerance,
+                              getMainWindow()->mavenParameters->scoringAlgo);
 
 }
 

--- a/src/gui/mzroll/spectralhitstable.cpp
+++ b/src/gui/mzroll/spectralhitstable.cpp
@@ -978,6 +978,7 @@ void SpectralHitsDockWidget::integrateMS1() {
 
         vector<PeakGroup> peakgroups =
             EIC::groupPeaks(eics,
+                            nullptr,
                             mp->eic_smoothingWindow,
                             mp->grouping_maxRtWindow,
                             mp->minQuality,
@@ -985,7 +986,9 @@ void SpectralHitsDockWidget::integrateMS1() {
                             mp->distYWeight,
                             mp->overlapWeight,
                             mp->useOverlap,
-                            mp->minSignalBaselineDifference);
+                            mp->minSignalBaselineDifference,
+                            mp->fragmentTolerance,
+                            mp->scoringAlgo);
 
 
        PeakGroup* nearestGrp = NULL;

--- a/tests/MavenTests/testEIC.cpp
+++ b/tests/MavenTests/testEIC.cpp
@@ -320,6 +320,7 @@ void TestEIC:: testgroupPeaks() {
                                                mavenparameters);
 
     vector<PeakGroup> peakgroups = EIC::groupPeaks(eics,
+                                                   slice->compound,
                                                    mavenparameters->eic_smoothingWindow,
                                                    mavenparameters->grouping_maxRtWindow,
                                                    mavenparameters->minQuality,
@@ -327,7 +328,9 @@ void TestEIC:: testgroupPeaks() {
                                                    mavenparameters->distYWeight,
                                                    mavenparameters->overlapWeight,
                                                    mavenparameters->useOverlap,
-                                                   mavenparameters->minSignalBaselineDifference);
+                                                   mavenparameters->minSignalBaselineDifference,
+                                                   mavenparameters->fragmentTolerance,
+                                                   mavenparameters->scoringAlgo);
 
     QVERIFY(peakgroups.size() == 3);
     QVERIFY(13.2378 < peakgroups[0].meanRt < 13.238);


### PR DESCRIPTION
The 'MS2 Score" and "#MS2 Events" columns were zero for all bookmarked groups (double-click bookmark and shift-drag integrated). These scores are now being calculated during peak grouping and updated in the table.