### PR TITLE
Support samples containing zlib compressed data

### DIFF
--- a/mzroll.pri
+++ b/mzroll.pri
@@ -9,13 +9,13 @@ win32 {
     DEFINES += MINGW
     DEFINES += WIN32
     DEFINES += CDFPARSER
-    LIBS += -lcdfread -lnetcdf -lz
+    LIBS += -lcdfread -lnetcdf -lz -lboost_iostreams-mt
 }
 
 unix: {
     INCLUDEPATH += /usr/local/include/ $$top_srcdir/3rdparty/obiwarp
     QMAKE_LFLAGS += -L/usr/local/lib/ -L$$top_builddir/libs/
-    LIBS +=  -lboost_signals -lErrorHandling -lobiwarp
+    LIBS +=  -lboost_signals -lErrorHandling -lobiwarp -lboost_iostreams
 }
 
 !isEmpty(ON_TRAVIS)|!isEmpty(ON_APPVEYOR) {

--- a/mzroll.pri
+++ b/mzroll.pri
@@ -1,6 +1,7 @@
 QT += sql core  xml gui
 
 CONFIG += silent exceptions
+DEFINES += ZLIB
 
 # this is important. Used in mzUtils to make use of correct mkdir function
 win32 {
@@ -8,7 +9,6 @@ win32 {
     DEFINES += MINGW
     DEFINES += WIN32
     DEFINES += CDFPARSER
-    DEFINES += ZLIB
     LIBS += -lcdfread -lnetcdf -lz
 }
 

--- a/mzroll.pri
+++ b/mzroll.pri
@@ -1,7 +1,7 @@
 QT += sql core  xml gui
 
 CONFIG += silent exceptions
-DEFINES += ZLIB
+DEFINES += ZLIB BOOST_IOSTREAMS_NO_LIB
 
 # this is important. Used in mzUtils to make use of correct mkdir function
 win32 {

--- a/src/core/libmaven/base64.cpp
+++ b/src/core/libmaven/base64.cpp
@@ -53,7 +53,7 @@ namespace base64 {
 
         if (decompress) {
 #ifdef ZLIB
-            destStr =mzUtils::decompress_string(destStr);
+            destStr = mzUtils::decompressString(destStr);
 #endif
         }
 

--- a/src/core/libmaven/base64.cpp
+++ b/src/core/libmaven/base64.cpp
@@ -4,216 +4,98 @@
 using namespace std;
 
 namespace base64 {
+    string decodeString(const char *data, const size_t len)
+    {
+        unsigned char* p = (unsigned char*)data;
+        int pad = len > 0 && (len % 4 || p[len - 1] == '=');
+        const size_t L = ((len + 3) / 4 - pad) * 4;
+        std::string str(L / 4 * 3 + pad, '\0');
 
-    char encode(unsigned char u) {
-        //Merged to 776
-        if(u < 26) return 'A'+u;
-        if(u < 52) return 'a'+(u-26);
-        if(u < 62) return '0'+(u-52);
-        if(u == 62) return '+';
-        return '/';
-    }
+        const int B64index[256] = {
+            0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+            0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+            0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  62, 63, 62, 62, 63,
+            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0,  0,  0,  0,  0,  0,
+            0,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 0,  0,  0,  0,  63,
+            0,  26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51
+        };
 
-    unsigned char decode(char c){
-        //Merged to 776
-        if(c >= 'A' && c <= 'Z') return(c - 'A');
-        if(c >= 'a' && c <= 'z') return(c - 'a' + 26);
-        if(c >= '0' && c <= '9') return(c - '0' + 52);
-        if(c == '+') return 62;
-        return 63;
-    }
-
-    int is_base64(char c) {
-        //Merged to 776
-        if((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
-                (c >= '0' && c <= '9') || (c == '+')             ||
-                (c == '/')             || (c == '=')) {
-            return true;
+        for (size_t i = 0, j = 0; i < L; i += 4)
+        {
+            int n = B64index[p[i]] << 18 | B64index[p[i + 1]] << 12
+                    | B64index[p[i + 2]] << 6 | B64index[p[i + 3]];
+            str[j++] = n >> 16;
+            str[j++] = n >> 8 & 0xFF;
+            str[j++] = n & 0xFF;
         }
-        return false;
-    }
+        if (pad)
+        {
+            int n = B64index[p[L]] << 18 | B64index[p[L + 1]] << 12;
+            str[str.size() - 1] = n >> 16;
 
-    char *decodeString(const string &src) {
-        // Merged to 776
-        int k, l = src.length();
-        char *buf = (char *)calloc(sizeof(char), l);
-        char *dest = (char *)calloc(sizeof(char), l);
-        char *p = dest;
-
-        /* Ignore non base64 chars as per the POSIX standard */
-        for (k = 0, l = 0; src[k]; k++) {
-            if (is_base64(src[k])) {
-                buf[l++] = src[k];
+            if (len > L + 2 && p[L + 2] != '=')
+            {
+                n |= B64index[p[L + 2]] << 6;
+                str.push_back(n >> 8 & 0xFF);
             }
         }
-
-        for (k = 0; k < l; k += 4) {
-            char c1 = 'A', c2 = 'A', c3 = 'A', c4 = 'A';
-            unsigned char b1 = 0, b2 = 0, b3 = 0, b4 = 0;
-
-            c1 = buf[k];
-            if (k + 1 < l) c2 = buf[k + 1];
-            if (k + 2 < l) c3 = buf[k + 2];
-            if (k + 3 < l) c4 = buf[k + 3];
-
-            b1 = decode(c1);
-            b2 = decode(c2);
-            b3 = decode(c3);
-            b4 = decode(c4);
-
-            *p++ = ((b1 << 2) | (b2 >> 4));
-
-            if (c3 != '=') *p++ = (((b2 & 0xf) << 4) | (b3 >> 2));
-            if (c4 != '=') *p++ = (((b3 & 0x3) << 6) | b4);
-        }
-        free(buf);
-        return dest;
+        return str;
     }
 
-    vector<float> convertDecodedDataBackToFloat(char *dest, int float_size,
-            bool neworkorder, int size) {
-        //Merged to 776
+    vector<float> decodeBase64(const string& src,
+                               int float_size,
+                               bool neworkorder,
+                               bool decompress)
+    {
+        string destStr = decodeString(src.c_str(), src.size());
+
+        if (decompress) {
+#ifdef ZLIB
+            destStr =mzUtils::decompress_string(destStr);
+#endif
+        }
+
 #if (LITTLE_ENDIAN == 1)
-        neworkorder = !neworkorder;
+         cerr << "INFO: little endian… inverted network order.";
+         neworkorder=!neworkorder;
 #endif
 
-        // we will cast everything as a float may be this is not wise, but have not
-        // found a need for double
-        // precission yet
-        vector<float> decodedArray(size);
+        int size = 1 + (destStr.size() - 4) / float_size;
 
-        if (float_size == 8) {
-            if (neworkorder == false) {
-                for (int i = 0; i < size; i++)
-                    decodedArray[i] = (float)((double *)dest)[i];
+        // we will cast everything as a float may be this is not wise,
+        // but have not found a need for double precission yet.
+        vector<float> decodedArray(size);
+        const char* dest = destStr.c_str();
+
+        if ( float_size == 8 ) {
+            if ( neworkorder == false ) {
+                for (int i=0; i<size; i++)
+                    decodedArray[i] = (float) ((double*) dest)[i];
             } else {
-                uint64_t *u = (uint64_t *)dest;
-                double data = 0;
-                for (int i = 0; i < size; i++) {
+                uint64_t *u = (uint64_t *) dest;
+                double data=0;
+                for (int i=0; i<size; i++) {
                     uint64_t t = swapbytes64(u[i]);
-                    memcpy(&data, &t, 8);
-                    decodedArray[i] = (float)data;
+                    memcpy(&data,&t,8);
+                    decodedArray[i] = (float) data;
                 }
             }
-        } else if (float_size == 4) {
-            if (neworkorder == false) {
-                for (int i = 0; i < size; i++)
-                    decodedArray[i] = ((float *)dest)[i];
+        } else if (float_size == 4 ) {
+            if ( neworkorder == false) {
+                for (int i=0; i<size; i++) decodedArray[i] = ((float*)dest)[i];
             } else {
-                uint32_t *u = (uint32_t *)dest;
-                float data = 0;
-                for (int i = 0; i < size; i++) {
+                uint32_t *u = (uint32_t *) dest;
+                float data=0;
+                for (int i=0; i<size; i++) {
                     uint32_t t = swapbytes(u[i]);
-                    memcpy(&data, &t, 4);
+                    memcpy(&data,&t,4);
                     decodedArray[i] = data;
                 }
             }
         }
 
-        free(dest);
         return decodedArray;
     }
-
-    vector<float> decode_base64(const string& src, int float_size, bool neworkorder, bool decompress) {
-        //Merged to 776
-        int size = 1 + (src.length() * 3 / 4 - 4) / float_size;
-
-        char *dest = decodeString(src);
-        if (decompress) {
-            decompressString(&dest, size, float_size);
-        }
-
-        vector<float> decodedArray =
-            convertDecodedDataBackToFloat(dest, float_size, neworkorder, size);
-
-        return decodedArray;
-
-    }
-
-    void decompressString(char **dest, int &size, int float_size) {
-        //Merged to 776
-        string decodedStr(*dest);
-        string uncompStr(mzUtils::decompress_string(decodedStr));
-
-        free(*dest);
-        *dest = (char *)calloc(sizeof(char), uncompStr.size());
-        for (unsigned int i = 0; i < uncompStr.size(); i++)
-            *dest[i] = uncompStr[i];
-
-        size = 1 + (uncompStr.size() * 3 / 4 - 4) / float_size;
-    }
-
-    unsigned char *convertFromFloatToCharacter(float *srcF,
-            const vector<float> &farray) {
-        //Merged to 776
-        int i;
-        int sizeF = farray.size();
-
-        // copy vector to C array
-        for (i = 0; i < sizeF; i++) {
-            srcF[i] = farray[i];
-        }
-
-        unsigned char *src = (unsigned char *)srcF;
-        return src;
-    }
-
-    unsigned char *encodeString(unsigned char *src, int size) {
-        //Merge to 776
-        unsigned char *out =
-            (unsigned char *)calloc(sizeof(char), size * 4 / 3 + 4);
-        unsigned char *p = out;
-        int i;
-        for (i = 0; i < size; i += 3) {
-
-            unsigned char b1=0, b2=0, b3=0, b4=0, b5=0, b6=0, b7=0;
-
-            b1 = src[i];
-
-            if(i+1<size)
-                b2 = src[i+1];
-
-            if(i+2<size)
-                b3 = src[i+2];
-
-            b4 = b1>>2;
-            b5 = ((b1&0x3)<<4)|(b2>>4);
-            b6 = ((b2&0xf)<<2)|(b3>>6);
-            b7 = b3&0x3f;
-
-            *p++= encode(b4);
-            *p++= encode(b5);
-
-            if(i+1<size) {
-                *p++= encode(b6);
-            } else {
-                *p++= '=';
-            }
-
-            if(i+2<size) {
-                *p++= encode(b7);
-            } else {
-                *p++= '=';
-            }
-
-        }
-        return out;
-    }
-
-    unsigned char *encode_base64(const vector<float>& farray) {
-        //Merged to 776
-
-        //copy vector t C array
-        int sizeF = farray.size();
-        int size = sizeF * 4;
-
-        float* srcF= (float*) calloc(sizeof(float), sizeF);
-        unsigned char *src = convertFromFloatToCharacter(srcF, farray);
-
-        unsigned char* out = encodeString(src, size);
-
-        free(srcF);
-        return out;
-    }
-
-} //namespace
+} // namespace

--- a/src/core/libmaven/base64.h
+++ b/src/core/libmaven/base64.h
@@ -12,78 +12,27 @@
 using namespace std;
 
 namespace base64 {
-
-    /**
-     * [Decode a base64 character]
-     * @method decode
-     * @param  c      [char to be decoded]
-     * @return [ASCII value]
-     */
-    unsigned char decode(char c);
-
-    /**
-     * [Base64 encode one byte]
-     * @method encode
-     * @param  u      [ASCII to be encoded]
-     * @return [base64 encoded character]
-     */
-    char encode(unsigned char u);
-
-    /**
-     * @return TRUE if 'c' is a valid base64 character, otherwise FALSE
-     */
-    int is_base64(char c);
-
-    /**
-     * [Decode a base64 string]
-     * @method decode
-     * @param  src      				[string to be decoded]
-     * @param  float_size      	[float size; 4 for 32 bit machines, 8 for 64 bit machines]
-     * @param  networkorder			[networkorder, LITTLE_ENDIAN or BIG_ENDIAN]
-     * @return [float array in binary representation]
-     */
-    vector<float> decode_base64(const string& src, int float_size, bool neworkorder, bool decompress);
-    /**
-     * [Base64 encode a float array in binary representation]
-     * @method encode_base64
-     * @param  farray        [float array in binary representation]
-     * @return [Base64 encoded string]
-     */
-    unsigned char *encode_base64(const vector<float>& farray);
-
-    /**
-     * [swap bytes .. borrowed from xmms  GNU]
-     * @method swapbytes
-     * @param  x         []
-     * @return []
-     */
-    inline uint32_t swapbytes(uint32_t x) {
-        return ((x & 0x000000ffU) << 24) |
-            ((x & 0x0000ff00U) <<  8) |
-            ((x & 0x00ff0000U) >>  8) |
-            ((x & 0xff000000U) >> 24);
+    // borrowed from xmms GNU
+    inline uint32_t swapbytes(uint32_t x)
+    {
+        return   ((x & 0x000000ffU) << 24)
+               | ((x & 0x0000ff00U) <<  8)
+               | ((x & 0x00ff0000U) >>  8)
+               | ((x & 0xff000000U) >> 24);
     }
 
-    /**
-     * [swap bytes .. borrowed from xmms  GNU]
-     * @method swapbytes64
-     * @param  x           []
-     * @return []
-     */
-    inline uint64_t swapbytes64(uint64_t x) {
+    // borrowed from xmms GNU
+    inline uint64_t swapbytes64(uint64_t x)
+    {
         return ((((uint64_t)swapbytes((uint32_t)(x & 0xffffffffU)) << 32) |
-                    (uint64_t)swapbytes((uint32_t)(x >> 32))));
+                 (uint64_t)swapbytes((uint32_t)(x >> 32))));
     }
 
-    void decompressString(char** dest, int& size, int float_size);
+    vector<float> decodeBase64(const string& src,
+                               int float_size,
+                               bool neworkorder,
+                               bool decompress);
 
-    char* decodeString(const string& src);
-    vector<float> convertDecodedDataBackToFloat(unsigned char* dest,
-            int float_size,
-            bool neworkorder,
-            int size);
-    unsigned char* convertFromFloatToCharacter(
-            float* srcF, const vector<float>& farray);
-    unsigned char* encodeString(unsigned char* src, int size);
+    string decodeString(const char* data, const size_t len);
 }
 #endif

--- a/src/core/libmaven/base64.h
+++ b/src/core/libmaven/base64.h
@@ -12,7 +12,11 @@
 using namespace std;
 
 namespace base64 {
-    // borrowed from xmms GNU
+    /**
+     * @brief Reverse the order of bytes of a 32-bit word. Borrowed from xmms GNU.
+     * @param x The 32-bit structure whose order of bytes is to be reversed.
+     * @return A new 32-bit structure with bytes stored in a reverse order.
+     */
     inline uint32_t swapbytes(uint32_t x)
     {
         return   ((x & 0x000000ffU) << 24)
@@ -21,18 +25,41 @@ namespace base64 {
                | ((x & 0xff000000U) >> 24);
     }
 
-    // borrowed from xmms GNU
+    /**
+     * @brief Reverse the order of bytes of a 64-bit word. Borrowed from xmms GNU.
+     * @param x The 64-bit structure whose order of bytes is to be reversed.
+     * @return A new 64-bit structure with bytes stored in a reverse order.
+     */
     inline uint64_t swapbytes64(uint64_t x)
     {
         return ((((uint64_t)swapbytes((uint32_t)(x & 0xffffffffU)) << 32) |
                  (uint64_t)swapbytes((uint32_t)(x >> 32))));
     }
 
+    /**
+     * @brief Decode a base64 encoded binary data string. If the string is
+     * zlib compressed then it is uncompressed after decoding, and then
+     * converted to an array of floating point values.
+     * @param src A base64 encoded data string.
+     * @param float_size Value denoting precision of floating point data.
+     * @param neworkorder Boolean indication network order.
+     * @param decompress Whether the string needs to be decompressed after
+     * decoding step.
+     * @return A vector of floating point values extracted from undecoded binary
+     * data.
+     */
     vector<float> decodeBase64(const string& src,
                                int float_size,
                                bool neworkorder,
                                bool decompress);
 
+    /**
+     * @brief Decode a plain base64-encoded string.
+     * @param data A raw base64-encoded buffer.
+     * @param len Length of the buffer containing base64 data.
+     * @return A decoded form of input base64- encoded string.
+     */
     string decodeString(const char* data, const size_t len);
 }
+
 #endif

--- a/src/core/libmaven/libmaven.pro
+++ b/src/core/libmaven/libmaven.pro
@@ -96,7 +96,8 @@ SOURCES = 	base64.cpp \
                 datastructures/mzSlice.cpp \
                 groupClassifier.cpp \
                 groupFeatures.cpp \
-                svmPredictor.cpp
+                svmPredictor.cpp \
+    zlib.cpp
 
 HEADERS += 	constants.h \
 		base64.h \

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -13,84 +13,84 @@
 
 #include <MavenException.h>
 
-//global options
+// global options
 int mzSample::filter_minIntensity = -1;
 bool mzSample::filter_centroidScans = false;
 int mzSample::filter_intensityQuantile = 0;
 int mzSample::filter_polarity = 0;
 int mzSample::filter_mslevel = 0;
 
-mzSample::mzSample()
-    : _setName(""),
-      injectionOrder(0)
+mzSample::mzSample() : _setName(""), injectionOrder(0)
 {
     _id = -1;
     _numMS1Scans = 0;
     _numMS2Scans = 0;
-        maxMz = maxRt = 0;
-	minMz = minRt = 0;
-	isBlank = false;
-	isSelected = true;
-	maxIntensity = 0;
-	minIntensity = 0;
-	totalIntensity = 0;
-	_normalizationConstant = 1; //TODO: Sahil Not being used anywhere
-	injectionTime = 0;
-        _sampleOrder = -1;
-	sampleNumber = -1;
-	_C13Labeled = false;
-	_N15Labeled = false;
-	_S34Labeled = false; //Feng note: added to track S34 labeling state
-	_D2Labeled = false;  //Feng note: added to track D2 labeling state
-	// _setName =  "A"; //naman     Variable '_setName' is assigned in constructor body.
-	// Consider performing initialization in initialization list.
-	color[0] = color[1] = color[2] = 0;
-	color[3] = 1.0;
+    maxMz = maxRt = 0;
+    minMz = minRt = 0;
+    isBlank = false;
+    isSelected = true;
+    maxIntensity = 0;
+    minIntensity = 0;
+    totalIntensity = 0;
+    _normalizationConstant = 1;  // TODO: Sahil Not being used anywhere
+    injectionTime = 0;
+    _sampleOrder = -1;
+    sampleNumber = -1;
+    _C13Labeled = false;
+    _N15Labeled = false;
+    _S34Labeled = false;  // Feng note: added to track S34 labeling state
+    _D2Labeled = false;   // Feng note: added to track D2 labeling state
+    // _setName =  "A"; //naman     Variable '_setName' is assigned in
+    // constructor body. Consider performing initialization in initialization
+    // list.
+    color[0] = color[1] = color[2] = 0;
+    color[3] = 1.0;
 }
 
 mzSample::~mzSample()
 {
-	for (unsigned int i = 0; i < scans.size(); i++)
-		if (scans[i] != NULL)
-			delete (scans[i]);
-	scans.clear();
+    for (unsigned int i = 0; i < scans.size(); i++)
+        if (scans[i] != NULL)
+            delete (scans[i]);
+    scans.clear();
 }
 
-void mzSample::addScan(Scan *s)
+void mzSample::addScan(Scan* s)
 {
-	if (!s)
-		return;
-
-	//skip scans that do not match mslevel
-	if (mzSample::filter_mslevel and s->mslevel != mzSample::filter_mslevel)
-        return;
-	//skip scans that do not match polarity
-	if (mzSample::filter_polarity and s->getPolarity() != mzSample::filter_polarity)
+    if (!s)
         return;
 
-	//unsigned int sizeBefore = s->intensity.size();
-	if (mzSample::filter_centroidScans == true)
-	{
-		s->simpleCentroid();
-	}
+    // skip scans that do not match mslevel
+    if (mzSample::filter_mslevel and s->mslevel != mzSample::filter_mslevel)
+        return;
+    // skip scans that do not match polarity
+    if (mzSample::filter_polarity
+        and s->getPolarity() != mzSample::filter_polarity)
+        return;
 
-	//unsigned int sizeAfter1 = s->intensity.size();
+    // unsigned int sizeBefore = s->intensity.size();
+    if (mzSample::filter_centroidScans == true) {
+        s->simpleCentroid();
+    }
 
-	if (mzSample::filter_intensityQuantile > 0)
-	{
-		s->quantileFilter(mzSample::filter_intensityQuantile);
-	}
-	//unsigned int sizeAfter2 = s->intensity.size();
+    // unsigned int sizeAfter1 = s->intensity.size();
 
-	if (mzSample::filter_minIntensity > 0)
-	{
-		s->intensityFilter(mzSample::filter_minIntensity);
-	}
-	//unsigned int sizeAfter3 = s->intensity.size();
-        //cerr << "addScan " << sizeBefore <<  " " << sizeAfter1 << " " << sizeAfter2 << " " << sizeAfter3 << endl;
+    if (mzSample::filter_intensityQuantile > 0) {
+        s->quantileFilter(mzSample::filter_intensityQuantile);
+    }
+    // unsigned int sizeAfter2 = s->intensity.size();
 
-    if (s->mslevel == 1) ++_numMS1Scans;
-    if (s->mslevel == 2) ++_numMS2Scans;
+    if (mzSample::filter_minIntensity > 0) {
+        s->intensityFilter(mzSample::filter_minIntensity);
+    }
+    // unsigned int sizeAfter3 = s->intensity.size();
+    // cerr << "addScan " << sizeBefore <<  " " << sizeAfter1 << " " <<
+    // sizeAfter2 << " " << sizeAfter3 << endl;
+
+    if (s->mslevel == 1)
+        ++_numMS1Scans;
+    if (s->mslevel == 2)
+        ++_numMS2Scans;
 
     scans.push_back(s);
     s->scannum = scans.size() - 1;
@@ -100,907 +100,871 @@ void mzSample::addScan(Scan *s)
         float ppm = 10;
         s->recalculatePrecursorMz(ppm);
     }
-
 }
 
-string mzSample::getFileName(const string &filename)
+string mzSample::getFileName(const string& filename)
 {
-
-	char sep = '/';
+    char sep = '/';
 #ifdef _WIN32
-	sep = '\\';
+    sep = '\\';
 #endif
 
-	size_t i = filename.rfind(sep, filename.length());
+    size_t i = filename.rfind(sep, filename.length());
 
-	if (i != string::npos)
-	{
-		string fullname = filename.substr(i + 1, filename.length() - i);
-		return (fullname.substr(0, fullname.find_last_of(".")));
-	}
+    if (i != string::npos) {
+        string fullname = filename.substr(i + 1, filename.length() - i);
+        return (fullname.substr(0, fullname.find_last_of(".")));
+    }
 
-	return ("");
+    return ("");
 }
 
-void mzSample::loadAnySample(const char *filename)
+void mzSample::loadAnySample(const char* filename)
 {
-
-	if (mystrcasestr(filename, "mzCSV") != NULL)
-	{
-		parseMzCSV(filename);
-	}
-	else if (mystrcasestr(filename, "mzdata") != NULL)
-	{
-		parseMzData(filename);
-	}
-	else if (mystrcasestr(filename, "mzxml") != NULL)
-	{
-		parseMzXML(filename);
-	}
-	else if (mystrcasestr(filename, "mzml") != NULL)
-	{
+    if (mystrcasestr(filename, "mzCSV") != NULL) {
+        parseMzCSV(filename);
+    } else if (mystrcasestr(filename, "mzdata") != NULL) {
+        parseMzData(filename);
+    } else if (mystrcasestr(filename, "mzxml") != NULL) {
+        parseMzXML(filename);
+    } else if (mystrcasestr(filename, "mzml") != NULL) {
         parseMzML(filename);
-	}
-	else if (mystrcasestr(filename, "cdf") != NULL)
-	{
-		parseCDF(filename, 1);
-	}
-	else
-	{
-		parseMzData(filename);
-	}
+    } else if (mystrcasestr(filename, "cdf") != NULL) {
+        parseCDF(filename, 1);
+    } else {
+        parseMzData(filename);
+    }
 }
 
-void mzSample::sampleNaming(const char *filename)
+void mzSample::sampleNaming(const char* filename)
 {
-	string filenameString = string(filename);
+    string filenameString = string(filename);
 
-	//This is the complete file name
-	this->sampleName = getFileName(filenameString);
+    // This is the complete file name
+    this->sampleName = getFileName(filenameString);
 
-	// This is the sample name
-	this->fileName = filenameString;
+    // This is the sample name
+    this->fileName = filenameString;
 }
 
-void mzSample::checkSampleBlank(const char *filename)
+void mzSample::checkSampleBlank(const char* filename)
 {
-	string filenameString = string(filename);
-	this->isBlank = false;
+    string filenameString = string(filename);
+    this->isBlank = false;
 
-	makeLowerCase(filenameString);
-	if (filenameString.find("blank") != string::npos)
-	{
-		this->isBlank = true;
-	}
+    makeLowerCase(filenameString);
+    if (filenameString.find("blank") != string::npos) {
+        this->isBlank = true;
+    }
 }
 
-void mzSample::loadSample(const char *filename)
+void mzSample::loadSample(const char* filename)
 {
-
-	//Loading and Decoding the file
-    //catch any error while parsing
+    // Loading and Decoding the file
+    // catch any error while parsing
     try {
-
         loadAnySample(filename);
     }
 
-    catch(MavenException& excp) {
+    catch (MavenException& excp) {
         cerr << endl << "Error: " << excp.what() << endl;
     }
 
+    // getting the SRM scan type
+    enumerateSRMScans();
 
-	//getting the SRM scan type
-	enumerateSRMScans();
+    // set min and max values for rt and mz
+    calculateMzRtRange();
 
-	//set min and max values for rt and mz
-	calculateMzRtRange();
+    // Setting Sample name
+    sampleNaming(filename);
 
-	//Setting Sample name
-	sampleNaming(filename);
-
-	//Checking if a sample is blank or not
-	checkSampleBlank(filename);
+    // Checking if a sample is blank or not
+    checkSampleBlank(filename);
 }
 
-void mzSample::parseMzCSV(const char *filename)
+void mzSample::parseMzCSV(const char* filename)
 {
+    // file structure:
+    // scannum,rt,mz,intensity,mslevel,precursorMz,polarity,srmid
+    int lineNum = 0;
 
-	// file structure: scannum,rt,mz,intensity,mslevel,precursorMz,polarity,srmid
-	int lineNum = 0;
+    ifstream myfile(filename);
+    if (!myfile.is_open())
+        throw(MavenException(ErrorMsg::FileNotFound));
 
-	ifstream myfile(filename);
-	if (!myfile.is_open())
-        throw (MavenException(ErrorMsg::FileNotFound));
+    std::stringstream ss;
+    std::string line;
+    std::string polarity;
 
+    int lastScanNum = -1;
+    int scannum = 0;
+    float rt = 0;
+    float intensity = 0;
+    float mz = 0;
+    float precursorMz = 0;
+    int mslevel = 0;
 
-	std::stringstream ss;
-	std::string line;
-	std::string polarity;
+    Scan* scan = NULL;
+    int newscannum = 0;
 
-	int lastScanNum = -1;
-	int scannum = 0;
-	float rt = 0;
-	float intensity = 0;
-	float mz = 0;
-	float precursorMz = 0;
-	int mslevel = 0;
+    while (getline(myfile, line)) {
+        lineNum++;
+        vector<string> fields;
+        mzUtils::split(line, ',', fields);
+        if (fields.size() >= 5 && lineNum > 1) {
+            ss.clear();
 
-	Scan *scan = NULL;
-	int newscannum = 0;
+            ss << fields[0] << " " << fields[1] << " " << fields[2] << " "
+               << fields[3] << " " << fields[4] << " " << fields[5] << " "
+               << fields[6];
 
-	while (getline(myfile, line))
-	{
-		lineNum++;
-		vector<string> fields;
-		mzUtils::split(line, ',', fields);
-		if (fields.size() >= 5 && lineNum > 1)
-		{
+            ss >> scannum >> rt >> mz >> intensity >> mslevel >> precursorMz
+                >> polarity;
 
-			ss.clear();
+            if (scannum != lastScanNum) {
+                newscannum++;
+                if (mslevel <= 0)
+                    mslevel = 1;
+                int scanpolarity = 0;
+                if (polarity.empty() && fields.size() > 7)
+                    polarity = fields[7];
+                if (!polarity.empty() && polarity[0] == '+')
+                    scanpolarity = 1;
+                if (!polarity.empty() && polarity[0] == '-')
+                    scanpolarity = -1;
+                scan = new Scan(this,
+                                newscannum,
+                                mslevel,
+                                rt / 60,
+                                precursorMz,
+                                scanpolarity);
+                if (mslevel > 1)
+                    scan->productMz = mz;
 
-			ss << fields[0] << " "
-			   << fields[1] << " "
-			   << fields[2] << " "
-			   << fields[3] << " "
-			   << fields[4] << " "
-			   << fields[5] << " "
-			   << fields[6];
+                addScan(scan);
+                if (fields.size() > 7)
+                    scan->filterLine = fields[7];  // last field is srmId
+            }
 
-			ss >> scannum >> rt >> mz >> intensity >> mslevel >> precursorMz >> polarity;
-
-			if (scannum != lastScanNum)
-			{
-				newscannum++;
-				if (mslevel <= 0)
-					mslevel = 1;
-				int scanpolarity = 0;
-				if (polarity.empty() && fields.size() > 7)
-					polarity = fields[7];
-				if (!polarity.empty() && polarity[0] == '+')
-					scanpolarity = 1;
-				if (!polarity.empty() && polarity[0] == '-')
-					scanpolarity = -1;
-				scan = new Scan(this, newscannum, mslevel, rt / 60, precursorMz, scanpolarity);
-				if (mslevel > 1)
-					scan->productMz = mz;
-
-				addScan(scan);
-				if (fields.size() > 7)
-					scan->filterLine = fields[7]; //last field is srmId
-			}
-
-			scan->mz.push_back(mz);
-			scan->intensity.push_back(intensity);
-			lastScanNum = scannum;
-		}
-	}
+            scan->mz.push_back(mz);
+            scan->intensity.push_back(intensity);
+            lastScanNum = scannum;
+        }
+    }
 }
 
 // void mzSample::writeMzCSV(const char* filename) const {
-void mzSample::writeMzCSV(const char *filename)
+void mzSample::writeMzCSV(const char* filename)
 {
-	//TODO naman unused function
+    // TODO naman unused function
 
-	ofstream mzCSV;
-	mzCSV.open(filename);
-	if (!mzCSV.is_open())
-	{
-		cerr << "Unable to write to a file" << filename;
-		return;
-	}
+    ofstream mzCSV;
+    mzCSV.open(filename);
+    if (!mzCSV.is_open()) {
+        cerr << "Unable to write to a file" << filename;
+        return;
+    }
 
-	mzCSV << "scannum,rt,mz,intensity,mslevel,precursorMz,polarity,srmid" << endl;
-	for (unsigned int i = 0; i < scans.size(); i++)
-	{
-		Scan *scan = scans[i];
-		for (unsigned int j = 0; j < scan->nobs(); j++)
-		{
-			mzCSV << scan->scannum + 1 << ","
-				  << scan->rt * 60 << ","
-				  << scan->mz[j] << ","
-				  << scan->intensity[j] << ","
-				  << scan->mslevel << ","
-				  << scan->precursorMz << ","
-				  << (scan->getPolarity() > 0 ? "+" : "-") << ","
-				  << scan->filterLine << endl;
-		}
-	}
+    mzCSV << "scannum,rt,mz,intensity,mslevel,precursorMz,polarity,srmid"
+          << endl;
+    for (unsigned int i = 0; i < scans.size(); i++) {
+        Scan* scan = scans[i];
+        for (unsigned int j = 0; j < scan->nobs(); j++) {
+            mzCSV << scan->scannum + 1 << "," << scan->rt * 60 << ","
+                  << scan->mz[j] << "," << scan->intensity[j] << ","
+                  << scan->mslevel << "," << scan->precursorMz << ","
+                  << (scan->getPolarity() > 0 ? "+" : "-") << ","
+                  << scan->filterLine << endl;
+        }
+    }
 }
 
 int mzSample::getPolarity()
 {
-	if (scans.size() > 0)
-		return scans[0]->getPolarity();
-	return 0;
+    if (scans.size() > 0)
+        return scans[0]->getPolarity();
+    return 0;
 }
-void mzSample::parseMzML(const char *filename)
+void mzSample::parseMzML(const char* filename)
 {
-	xml_document doc;
+    xml_document doc;
 
-	const unsigned int parse_options = parse_minimal;
+    const unsigned int parse_options = parse_minimal;
 
     pugi::xml_parse_result parseResult = doc.load_file(filename, parse_options);
-    if (parseResult.status != pugi::xml_parse_status::status_ok)
-	{
+    if (parseResult.status != pugi::xml_parse_status::status_ok) {
         throw MavenException(ErrorMsg::ParsemzMl);
-	}
+    }
 
-	//Get injection time stamp
-	xml_node experimentRun = doc.first_child().first_element_by_path("mzML/run");
-	if (!experimentRun.empty())
-	{
+    // Get injection time stamp
+    xml_node experimentRun =
+        doc.first_child().first_element_by_path("mzML/run");
+    if (!experimentRun.empty()) {
         parseMzMLInjectionTimeStamp(experimentRun.attribute("startTimeStamp"));
-	}
+    }
 
-	//Get a spectrumstore node
-	xml_node chromatogramList = doc.first_child().first_element_by_path("mzML/run/chromatogramList");
-	xml_node spectrumList = doc.first_child().first_element_by_path("mzML/run/spectrumList");
+    // Get a spectrumstore node
+    xml_node chromatogramList =
+        doc.first_child().first_element_by_path("mzML/run/chromatogramList");
+    xml_node spectrumList =
+        doc.first_child().first_element_by_path("mzML/run/spectrumList");
 
-	if (!spectrumList.empty())
-	{
-		parseMzMLSpectrumList(spectrumList);
-	}
-	else if (!chromatogramList.empty())
-	{
-		parseMzMLChromatogramList(chromatogramList);
-	}
+    if (!spectrumList.empty()) {
+        parseMzMLSpectrumList(spectrumList);
+    } else if (!chromatogramList.empty()) {
+        parseMzMLChromatogramList(chromatogramList);
+    }
 }
 
-void mzSample::parseMzMLInjectionTimeStamp(const xml_attribute &injectionTimeStamp)
+void mzSample::parseMzMLInjectionTimeStamp(
+    const xml_attribute& injectionTimeStamp)
 {
-
-	if (!injectionTimeStamp.empty())
-	{
-		using namespace date;
-		string time_details = injectionTimeStamp.value();
-		istringstream in;
-		in.str(time_details);
-		sys_seconds timeStamp;
-		in >> parse("%Y-%m-%dT%T", timeStamp);
-		injectionTime = timeStamp.time_since_epoch().count();
-  
-	}
+    if (!injectionTimeStamp.empty()) {
+        using namespace date;
+        string time_details = injectionTimeStamp.value();
+        istringstream in;
+        in.str(time_details);
+        sys_seconds timeStamp;
+        in >> parse("%Y-%m-%dT%T", timeStamp);
+        injectionTime = timeStamp.time_since_epoch().count();
+    }
 }
 
-void mzSample::parseMzMLChromatogramList(const xml_node &chromatogramList)
+void mzSample::parseMzMLChromatogramList(const xml_node& chromatogramList)
 {
-
-	int scannum = 0;
-	for (xml_node chromatogram = chromatogramList.child("chromatogram");
-		 chromatogram; chromatogram = chromatogram.next_sibling("chromatogram"))
-	{
-
-		string chromatogramId = chromatogram.attribute("id").value();
-		int sampleNo = getSampleNoChromatogram(chromatogramId);
+    int scannum = 0;
+    for (xml_node chromatogram = chromatogramList.child("chromatogram");
+         chromatogram;
+         chromatogram = chromatogram.next_sibling("chromatogram")) {
+        string chromatogramId = chromatogram.attribute("id").value();
+        int sampleNo = getSampleNoChromatogram(chromatogramId);
 
         filterChromatogramId(chromatogramId);
 
-		vector<float> timeVector;
-		vector<float> intsVector;
+        vector<float> timeVector;
+        vector<float> intsVector;
 
-		xml_node binaryDataArrayList = chromatogram.child("binaryDataArrayList");
-		string precursorMzStr = chromatogram.first_element_by_path("precursor/isolationWindow/cvParam").attribute("value").value();
-		string productMzStr = chromatogram.first_element_by_path("product/isolationWindow/cvParam").attribute("value").value();
-		float precursorMz = string2float(precursorMzStr);
-		float productMz = string2float(productMzStr);
-		// int mslevel=2;
+        xml_node binaryDataArrayList =
+            chromatogram.child("binaryDataArrayList");
+        string precursorMzStr =
+            chromatogram
+                .first_element_by_path("precursor/isolationWindow/cvParam")
+                .attribute("value")
+                .value();
+        string productMzStr =
+            chromatogram
+                .first_element_by_path("product/isolationWindow/cvParam")
+                .attribute("value")
+                .value();
+        float precursorMz = string2float(precursorMzStr);
+        float productMz = string2float(productMzStr);
+        // int mslevel=2;
 
-		for (xml_node binaryDataArray = binaryDataArrayList.child("binaryDataArray");
-			 binaryDataArray; binaryDataArray = binaryDataArray.next_sibling("binaryDataArray"))
-		{
-			map<string, string> attr = mzML_cvParams(binaryDataArray);
+        for (xml_node binaryDataArray =
+                 binaryDataArrayList.child("binaryDataArray");
+             binaryDataArray;
+             binaryDataArray =
+                 binaryDataArray.next_sibling("binaryDataArray")) {
 
-			int precision = 64;
-			if (attr.count("32-bit float"))
-				precision = 32;
+            map<string, string> attr = mzML_cvParams(binaryDataArray);
 
-			string binaryDataStr = binaryDataArray.child("binary").child_value();
-			vector<float> binaryData = base64::decode_base64(
-				binaryDataStr, precision / 8, false, false);
+            int precision = 64;
+            if (attr.count("32-bit float"))
+                precision = 32;
 
-			if (attr.count("time array"))
-			{
-				timeVector = binaryData;
-			}
-			if (attr.count("intensity array"))
-			{
-				intsVector = binaryData;
-			}
-		}
+            string binaryDataStr =
+                binaryDataArray.child("binary").child_value();
+            vector<float> binaryData = base64::decode_base64(
+                binaryDataStr, precision / 8, false, false);
 
-	//	cerr << chromatogramId << endl;
-	//	cerr << timeVector.size() << " ints=" << intsVector.size() << endl;
-	//	cerr << "pre: " << precursorMz << " prod=" << productMz << endl;
+            if (attr.count("time array")) {
+                timeVector = binaryData;
+            }
+            if (attr.count("intensity array")) {
+                intsVector = binaryData;
+            }
+        }
 
-		// if (precursorMz and precursorMz ) {
-		if (precursorMz)
-		{
-			int mslevel = 2; //msLevel information cannot be read from the sample?
-			for (unsigned int i = 0; i < timeVector.size(); i++)
-			{
-				Scan *scan = new Scan(this, scannum++, mslevel, timeVector[i], precursorMz, -1);
-				scan->productMz = productMz;
-				scan->mz.push_back(productMz);
-				scan->filterLine = chromatogramId;
-				sampleNumber = sampleNo;
-				scan->intensity.push_back(intsVector[i]);
-				addScan(scan);
-			}
-		}
-	}
+        //	cerr << chromatogramId << endl;
+        //	cerr << timeVector.size() << " ints=" << intsVector.size() <<
+        //endl; 	cerr << "pre: " << precursorMz << " prod=" << productMz << endl;
 
-	//renumber scans based on retention time
-	std::sort(scans.begin(), scans.end(), Scan::compRt);
-	for (unsigned int i = 0; i < scans.size(); i++)
-	{
-		scans[i]->scannum = i;
-	}
+        // if (precursorMz and precursorMz ) {
+        if (precursorMz) {  // naman Same expression on both sides of '&&'.
+            int mslevel =
+                2;  // naman The scope of the variable 'mslevel' can be reduced.
+            for (unsigned int i = 0; i < timeVector.size(); i++) {
+                Scan* scan = new Scan(
+                    this, scannum++, mslevel, timeVector[i], precursorMz, -1);
+                scan->productMz = productMz;
+                scan->mz.push_back(productMz);
+                scan->filterLine = chromatogramId;
+                sampleNumber = sampleNo;
+                scan->intensity.push_back(intsVector[i]);
+                addScan(scan);
+            }
+        }
+    }
+
+    // renumber scans based on retention time
+    std::sort(scans.begin(), scans.end(), Scan::compRt);
+    for (unsigned int i = 0; i < scans.size(); i++) {
+        scans[i]->scannum = i;
+    }
 }
 
-int mzSample::getSampleNoChromatogram(const string &chromatogramId) {
-
-	std::regex rxSampleNumber("sample\ *\=\ *([0-9]+)\ ");
-	std::vector<int> results;
-    for(std::sregex_iterator i = std::sregex_iterator(chromatogramId.begin(), chromatogramId.end(), rxSampleNumber);
-            i != std::sregex_iterator(); 
-            ++i) 
-    { 
+int mzSample::getSampleNoChromatogram(const string& chromatogramId)
+{
+    std::regex rxSampleNumber("sample\ *\=\ *([0-9]+)\ ");
+    std::vector<int> results;
+    for (std::sregex_iterator i = std::sregex_iterator(
+             chromatogramId.begin(), chromatogramId.end(), rxSampleNumber);
+         i != std::sregex_iterator();
+         ++i) {
         std::smatch m = *i;
-        results.push_back(std::stoi( m[1].str().c_str() ));
-    } 
+        results.push_back(std::stoi(m[1].str().c_str()));
+    }
 
-	if (results.size() > 0) return results[0];
-	else return -1;
-
+    if (results.size() > 0)
+        return results[0];
+    else
+        return -1;
 }
 
-void mzSample::filterChromatogramId(string &chromatogramId) {
-
+void mzSample::filterChromatogramId(string& chromatogramId)
+{
     string filterRegex;
     regex rx;
-    for(const string& filterId: filterChromatogram) {
+    for (const string& filterId : filterChromatogram) {
         filterRegex = filterId + "\ *\=\ *[0-9]*\.?[0-9]+";
         rx = filterRegex;
         chromatogramId = std::regex_replace(chromatogramId, rx, "");
-	}
+    }
 }
 
-void mzSample::parseMzMLSpectrumList(const xml_node &spectrumList)
+void mzSample::parseMzMLSpectrumList(const xml_node& spectrumList)
 {
+    // Iterate through spectrums
+    int scannum = 0;
 
-	//Iterate through spectrums
-	int scannum = 0;
+    for (xml_node spectrum = spectrumList.child("spectrum"); spectrum;
+         spectrum = spectrum.next_sibling("spectrum")) {
+        string spectrumId = spectrum.attribute("id").value();
+        cerr << "Processing: " << spectrumId << endl;
 
-	for (xml_node spectrum = spectrumList.child("spectrum");
-		 spectrum; spectrum = spectrum.next_sibling("spectrum"))
-	{
-		string spectrumId = spectrum.attribute("id").value();
-		cerr << "Processing: " << spectrumId << endl;
+        if (spectrum.empty())
+            continue;
+        map<string, string> cvParams = mzML_cvParams(spectrum);
 
-		if (spectrum.empty())
-			continue;
-		map<string, string> cvParams = mzML_cvParams(spectrum);
+        int mslevel = 1;
+        int scanpolarity = 0;
+        float rt = 0;
+        vector<float> mzVector;
+        vector<float> intsVector;
 
-		int mslevel = 1;
-		int scanpolarity = 0;
-		float rt = 0;
-		vector<float> mzVector;
-		vector<float> intsVector;
+        if (cvParams.count("ms level")) {
+            string msLevelStr = cvParams["ms level"];
+            mslevel = (int)string2float(msLevelStr);
+        }
 
-		if (cvParams.count("ms level"))
-		{
-			string msLevelStr = cvParams["ms level"];
-			mslevel = (int)string2float(msLevelStr);
-		}
+        if (cvParams.count("positive scan"))
+            scanpolarity = 1;
+        else if (cvParams.count("negative scan"))
+            scanpolarity = -1;
+        else
+            scanpolarity = 0;
 
-		if (cvParams.count("positive scan"))
-			scanpolarity = 1;
-		else if (cvParams.count("negative scan"))
-			scanpolarity = -1;
-		else
-			scanpolarity = 0;
+        xml_node scanNode = spectrum.first_element_by_path("scanList/scan");
+        map<string, string> scanAttr = mzML_cvParams(scanNode);
+        if (scanAttr.count("scan start time")) {
+            string rtStr = scanAttr["scan start time"];
+            rt = string2float(rtStr);
+        }
 
-		xml_node scanNode = spectrum.first_element_by_path("scanList/scan");
-		map<string, string> scanAttr = mzML_cvParams(scanNode);
-		if (scanAttr.count("scan start time"))
-		{
-			string rtStr = scanAttr["scan start time"];
-			rt = string2float(rtStr);
-		}
+        map<string, string> isolationWindow =
+            mzML_cvParams(spectrum.first_element_by_path(
+                "precursorList/precursor/isolationWindow"));
+        string precursorMzStr = isolationWindow["isolation window target m/z"];
+        float precursorMz = 0;
+        if (string2float(precursorMzStr) > 0)
+            precursorMz = string2float(precursorMzStr);
 
-		map<string, string> isolationWindow = mzML_cvParams(spectrum.first_element_by_path("precursorList/precursor/isolationWindow"));
-		string precursorMzStr = isolationWindow["isolation window target m/z"];
-		float precursorMz = 0;
-		if (string2float(precursorMzStr) > 0)
-			precursorMz = string2float(precursorMzStr);
+        string precursorIsolationStrLower =
+            isolationWindow["isolation window lower offset"];
+        string precursorIsolationStrUpper =
+            isolationWindow["isolation window upper offset"];
 
-        string precursorIsolationStrLower = isolationWindow["isolation window lower offset"];
-        string precursorIsolationStrUpper = isolationWindow["isolation window upper offset"];
-		
-		float precursorIsolationWindow = 0.0f;
-		if (string2float(precursorIsolationStrLower) > 0.0f)
-			precursorIsolationWindow += string2float(precursorIsolationStrLower);
+        float precursorIsolationWindow = 0.0f;
+        if (string2float(precursorIsolationStrLower) > 0.0f)
+            precursorIsolationWindow +=
+                string2float(precursorIsolationStrLower);
         if (string2float(precursorIsolationStrUpper) > 0.0f)
-            precursorIsolationWindow += string2float(precursorIsolationStrUpper);
-        if (precursorIsolationWindow <= 0.0f) precursorIsolationWindow = 1.0f;
+            precursorIsolationWindow +=
+                string2float(precursorIsolationStrUpper);
+        if (precursorIsolationWindow <= 0.0f)
+            precursorIsolationWindow = 1.0f;
 
-		string productMzStr = spectrum.first_element_by_path("product/isolationWindow/cvParam").attribute("value").value();
-		float productMz = 0;
-		if (string2float(productMzStr) > 0)
-			productMz = string2float(productMzStr);
+        string productMzStr =
+            spectrum.first_element_by_path("product/isolationWindow/cvParam")
+                .attribute("value")
+                .value();
+        float productMz = 0;
+        if (string2float(productMzStr) > 0)
+            productMz = string2float(productMzStr);
 
-		xml_node binaryDataArrayList = spectrum.child("binaryDataArrayList");
-		if (!binaryDataArrayList or binaryDataArrayList.empty())
-			continue;
+        xml_node binaryDataArrayList = spectrum.child("binaryDataArrayList");
+        if (!binaryDataArrayList or binaryDataArrayList.empty())
+            continue;
 
-		for (xml_node binaryDataArray = binaryDataArrayList.child("binaryDataArray");
-			 binaryDataArray; binaryDataArray = binaryDataArray.next_sibling("binaryDataArray"))
-		{
-			if (!binaryDataArray or binaryDataArray.empty())
-				continue;
+        for (xml_node binaryDataArray =
+                 binaryDataArrayList.child("binaryDataArray");
+             binaryDataArray;
+             binaryDataArray =
+                 binaryDataArray.next_sibling("binaryDataArray")) {
+            if (!binaryDataArray or binaryDataArray.empty())
+                continue;
 
-			map<string, string> attr = mzML_cvParams(binaryDataArray);
+            map<string, string> attr = mzML_cvParams(binaryDataArray);
 
-			int precision = 64;
-			if (attr.count("32-bit float"))
-				precision = 32;
+            int precision = 64;
+            if (attr.count("32-bit float"))
+                precision = 32;
 
-			string binaryDataStr = binaryDataArray.child("binary").child_value();
-			if (!binaryDataStr.empty())
-			{
-				vector<float> binaryData = base64::decode_base64(
-					binaryDataStr, precision / 8, false, false);
-				if (attr.count("m/z array"))
-				{
-					mzVector = binaryData;
-				}
-				if (attr.count("intensity array"))
-				{
-					intsVector = binaryData;
-				}
-			}
-		}
+            string binaryDataStr =
+                binaryDataArray.child("binary").child_value();
+            if (!binaryDataStr.empty()) {
+                vector<float> binaryData = base64::decode_base64(
+                    binaryDataStr, precision / 8, false, false);
+                if (attr.count("m/z array")) {
+                    mzVector = binaryData;
+                }
+                if (attr.count("intensity array")) {
+                    intsVector = binaryData;
+                }
+            }
+        }
 
-		cerr << " scan=" << scannum << "\tms=" << mslevel << "\tprecMz" << precursorMz << "\t rt=" << rt << endl;
-		Scan *scan = new Scan(this, scannum++, mslevel, rt, precursorMz, scanpolarity);
-		scan->isolationWindow = precursorIsolationWindow;
-		scan->productMz = productMz;
-		scan->filterLine = spectrumId;
-		scan->intensity = intsVector;
-		scan->mz = mzVector;
-		addScan(scan);
-	}
+        cerr << " scan=" << scannum << "\tms=" << mslevel << "\tprecMz"
+             << precursorMz << "\t rt=" << rt << endl;
+        Scan* scan =
+            new Scan(this, scannum++, mslevel, rt, precursorMz, scanpolarity);
+        scan->isolationWindow = precursorIsolationWindow;
+        scan->productMz = productMz;
+        scan->filterLine = spectrumId;
+        scan->intensity = intsVector;
+        scan->mz = mzVector;
+        addScan(scan);
+    }
 }
 
 map<string, string> mzSample::mzML_cvParams(xml_node node)
 {
-	map<string, string> attr;
-	if (!node || node.empty())
-		return attr;
-	for (xml_node cv = node.child("cvParam"); cv; cv = cv.next_sibling("cvParam"))
-	{
-		string name = cv.attribute("name").value();
-		string value = cv.attribute("value").value();
-		attr[name] = value;
-		//cerr << name << "->" << value << endl;
-	}
-	return (attr);
+    map<string, string> attr;
+    if (!node || node.empty())
+        return attr;
+    for (xml_node cv = node.child("cvParam"); cv;
+         cv = cv.next_sibling("cvParam")) {
+        string name = cv.attribute("name").value();
+        string value = cv.attribute("value").value();
+        attr[name] = value;
+        // cerr << name << "->" << value << endl;
+    }
+    return (attr);
 }
 
-void mzSample::parseMzData(const char *filename)
+void mzSample::parseMzData(const char* filename)
 {
+    xml_document doc;
 
-	xml_document doc;
-
-	const unsigned int parse_options = parse_minimal;
+    const unsigned int parse_options = parse_minimal;
 
     pugi::xml_parse_result parseResult = doc.load_file(filename, parse_options);
-    if (parseResult.status != pugi::xml_parse_status::status_ok)
-	{
-        throw (MavenException(ErrorMsg::ParsemzData));
-	}
+    if (parseResult.status != pugi::xml_parse_status::status_ok) {
+        throw(MavenException(ErrorMsg::ParsemzData));
+    }
 
-	//Get a spectrumstore node
-	xml_node spectrumstore = doc.first_child().child("spectrumList");
+    // Get a spectrumstore node
+    xml_node spectrumstore = doc.first_child().child("spectrumList");
 
-	//Iterate through spectrums
-	int scannum = 0;
+    // Iterate through spectrums
+    int scannum = 0;
 
-	for (xml_node spectrum = spectrumstore.child("spectrum"); spectrum; spectrum = spectrum.next_sibling("spectrum"))
-	{
+    for (xml_node spectrum = spectrumstore.child("spectrum"); spectrum;
+         spectrum = spectrum.next_sibling("spectrum")) {
+        scannum++;
+        float rt = 0;
+        float precursorMz = 0;
+        char scanpolarity = 0;  // default case
 
-		scannum++;
-		float rt = 0;
-		float precursorMz = 0;
-		char scanpolarity = 0; //default case
+        xml_node spectrumInstrument = spectrum.first_element_by_path(
+            "spectrumDesc/spectrumSettings/spectrumInstrument");
+        int mslevel = spectrumInstrument.attribute("msLevel").as_int();
+        // cerr << mslevel << " " << spectrum.attribute("msLevel").value() <<
+        // endl;
 
-		xml_node spectrumInstrument = spectrum.first_element_by_path("spectrumDesc/spectrumSettings/spectrumInstrument");
-		int mslevel = spectrumInstrument.attribute("msLevel").as_int();
-		//cerr << mslevel << " " << spectrum.attribute("msLevel").value() << endl;
+        for (xml_node cvParam = spectrumInstrument.child("cvParam"); cvParam;
+             cvParam = cvParam.next_sibling("cvParam")) {
+            //	cout << "cvParam=" << cvParam.attribute("name").value() << endl;
+            //
+            if (strncasecmp(
+                    cvParam.attribute("name").value(), "TimeInMinutes", 10)
+                == 0) {
+                rt = cvParam.attribute("value").as_float();
+                // cout << "rt=" << rt << endl;
+            }
 
-		for (xml_node cvParam = spectrumInstrument.child("cvParam"); cvParam; cvParam = cvParam.next_sibling("cvParam"))
-		{
-			//	cout << "cvParam=" << cvParam.attribute("name").value() << endl;
-			//
-			if (strncasecmp(cvParam.attribute("name").value(), "TimeInMinutes", 10) == 0)
-			{
-				rt = cvParam.attribute("value").as_float();
-				//cout << "rt=" << rt << endl;
-			}
+            if (strncasecmp(
+                    cvParam.attribute("name").value(), "time in seconds", 10)
+                == 0) {
+                rt = cvParam.attribute("value").as_float() / 60;
+                // cout << "rt=" << rt << endl;
+            }
 
-			if (strncasecmp(cvParam.attribute("name").value(), "time in seconds", 10) == 0)
-			{
-				rt = cvParam.attribute("value").as_float() / 60;
-				//cout << "rt=" << rt << endl;
-			}
+            if (strncasecmp(cvParam.attribute("name").value(), "polarity", 5)
+                == 0) {
+                if (cvParam.attribute("value").value()[0] == 'p'
+                    || cvParam.attribute("value").value()[0] == 'P') {
+                    scanpolarity = +1;
+                } else {
+                    scanpolarity = -1;
+                }
+            }
+        }
 
-			if (strncasecmp(cvParam.attribute("name").value(), "polarity", 5) == 0)
-			{
-				if (cvParam.attribute("value").value()[0] == 'p' || cvParam.attribute("value").value()[0] == 'P')
-				{
-					scanpolarity = +1;
-				}
-				else
-				{
-					scanpolarity = -1;
-				}
-			}
-		}
+        // cout <<
+        // spectrum.first_element_by_path("spectrumDesc/spectrumSettings/spectrumInstrument").child_value()
+        // << endl
+        if (mslevel <= 0)
+            mslevel = 1;
+        Scan* scan =
+            new Scan(this, scannum, mslevel, rt, precursorMz, scanpolarity);
+        addScan(scan);
 
-		//cout << spectrum.first_element_by_path("spectrumDesc/spectrumSettings/spectrumInstrument").child_value() << endl
-		if (mslevel <= 0)
-			mslevel = 1;
-		Scan *scan = new Scan(this, scannum, mslevel, rt, precursorMz, scanpolarity);
-		addScan(scan);
+        int precision1 = spectrum.child("intenArrayBinary")
+                             .child("data")
+                             .attribute("precision")
+                             .as_int();
+        string b64intensity =
+            spectrum.child("intenArrayBinary").child("data").child_value();
+        scan->intensity =
+            base64::decode_base64(b64intensity, precision1 / 8, false, false);
 
-		int precision1 = spectrum.child("intenArrayBinary").child("data").attribute("precision").as_int();
-		string b64intensity = spectrum.child("intenArrayBinary").child("data").child_value();
-		scan->intensity = base64::decode_base64(
-			b64intensity, precision1 / 8, false, false);
+        // cout << "mz" << endl;
+        int precision2 = spectrum.child("mzArrayBinary")
+                             .child("data")
+                             .attribute("precision")
+                             .as_int();
+        string b64mz =
+            spectrum.child("mzArrayBinary").child("data").child_value();
+        scan->mz = base64::decode_base64(b64mz, precision2 / 8, false, false);
 
-		// cout << "mz" << endl;
-		int precision2 = spectrum.child("mzArrayBinary")
-							 .child("data")
-							 .attribute("precision")
-							 .as_int();
-		string b64mz =
-			spectrum.child("mzArrayBinary").child("data").child_value();
-		scan->mz =
-			base64::decode_base64(b64mz, precision2 / 8, false, false);
-
-		//cout << "spectrum " << spectrum.attribute("title").value() << endl;
-	}
+        // cout << "spectrum " << spectrum.attribute("title").value() << endl;
+    }
 }
 
-xml_node mzSample::getmzXMLSpectrumData(xml_document &doc, const char *filename)
+xml_node mzSample::getmzXMLSpectrumData(xml_document& doc, const char* filename)
 {
+    // parse_minimal has all options turned off. This option mask means
+    // that pugixml does not add declaration nodes, document type declaration
+    // nodes, PI nodes, CDATA sections and comments to the resulting tree and
+    // does not perform any conversion for input data, so theoretically it is
+    // the fastest mode
+    bool loadok = doc.load_file(filename, pugi::parse_minimal);
 
-	//parse_minimal has all options turned off. This option mask means
-	//that pugixml does not add declaration nodes, document type declaration
-	//nodes, PI nodes, CDATA sections and comments to the resulting tree and
-	//does not perform any conversion for input data, so theoretically it is
-	//the fastest mode
-	bool loadok = doc.load_file(filename, pugi::parse_minimal);
+    // Checking if the file can be loaded if it can be loaded
+    if (!loadok) {
+        cerr << "Failed to load " << filename << endl;
+        // returning an empty node
+        return xml_node();
+    }
 
-	//Checking if the file can be loaded if it can be loaded
-	if (!loadok)
-	{
-		cerr << "Failed to load " << filename << endl;
-		//returning an empty node
-		return xml_node();
-	}
+    //"msRun" is the first child of the parent child "mzXML"
+    xml_node spectrumstore = doc.first_child().child("msRun");
 
-	//"msRun" is the first child of the parent child "mzXML"
-	xml_node spectrumstore = doc.first_child().child("msRun");
-
-	//Checking if the node is empty which means that msRun is not there
-	//but then it might have scan which contain the data
-	if (spectrumstore.empty())
-	{
-		cerr << "This is here" << endl;
-		//Getting the first child named "scan"
-		xml_node scan = doc.first_child().child("scan");
-		//If scan is not present then there is no data
-		// which means that there is no information in the
-		//mzXML file
-		if (!scan.empty())
-		{
-			cerr << "This is here1" << endl;
-			spectrumstore = doc.first_child();
-		}
-		else
-		{
-			//if the above condition is not satisfied return a empty spectrumstore
-			cerr << "parseMzXML: can't find <msRun> or <scan> section" << endl;
-			return xml_node();
-		}
-	}
-	return spectrumstore;
+    // Checking if the node is empty which means that msRun is not there
+    // but then it might have scan which contain the data
+    if (spectrumstore.empty()) {
+        cerr << "This is here" << endl;
+        // Getting the first child named "scan"
+        xml_node scan = doc.first_child().child("scan");
+        // If scan is not present then there is no data
+        // which means that there is no information in the
+        // mzXML file
+        if (!scan.empty()) {
+            cerr << "This is here1" << endl;
+            spectrumstore = doc.first_child();
+        } else {
+            // if the above condition is not satisfied return a empty
+            // spectrumstore
+            cerr << "parseMzXML: can't find <msRun> or <scan> section" << endl;
+            return xml_node();
+        }
+    }
+    return spectrumstore;
 }
 
-void mzSample::setInstrumentSettigs(xml_document &doc, xml_node spectrumstore)
+void mzSample::setInstrumentSettigs(xml_document& doc, xml_node spectrumstore)
 {
-	//Getting the instrument related information
-	xml_node msInstrument = spectrumstore.child("msInstrument");
-	if (!msInstrument.empty())
-	{
-		xml_node msManufacturer = msInstrument.child("msManufacturer");
-		xml_node msModel = msInstrument.child("msModel");
-		xml_node msIonisation = msInstrument.child("msIonisation");
-		xml_node msMassAnalyzer = msInstrument.child("msMassAnalyzer");
-		xml_node msDetector = msInstrument.child("msDetector");
-		instrumentInfo["msManufacturer"] = msManufacturer.attribute("value").value();
-		instrumentInfo["msModel"] = msModel.attribute("value").value();
-		instrumentInfo["msIonisation"] = msIonisation.attribute("value").value();
-		instrumentInfo["msMassAnalyzer"] = msMassAnalyzer.attribute("value").value();
-		instrumentInfo["msDetector"] = msDetector.attribute("value").value();
-	}
+    // Getting the instrument related information
+    xml_node msInstrument = spectrumstore.child("msInstrument");
+    if (!msInstrument.empty()) {
+        xml_node msManufacturer = msInstrument.child("msManufacturer");
+        xml_node msModel = msInstrument.child("msModel");
+        xml_node msIonisation = msInstrument.child("msIonisation");
+        xml_node msMassAnalyzer = msInstrument.child("msMassAnalyzer");
+        xml_node msDetector = msInstrument.child("msDetector");
+        instrumentInfo["msManufacturer"] =
+            msManufacturer.attribute("value").value();
+        instrumentInfo["msModel"] = msModel.attribute("value").value();
+        instrumentInfo["msIonisation"] =
+            msIonisation.attribute("value").value();
+        instrumentInfo["msMassAnalyzer"] =
+            msMassAnalyzer.attribute("value").value();
+        instrumentInfo["msDetector"] = msDetector.attribute("value").value();
+    }
 }
 
 void mzSample::parseMzXMLData(const xml_node& spectrumstore)
 {
-	//Iterate through spectrums
-	int scannum = 0;
+    // Iterate through spectrums
+    int scannum = 0;
 
-	for (xml_node scan = spectrumstore.child("scan"); scan; scan = scan.next_sibling("scan"))
-	{
-		scannum++;
-		if (strncasecmp(scan.name(), "scan", 4) == 0)
-		{
-			parseMzXMLScan(scan, scannum);
-		}
+    for (xml_node scan = spectrumstore.child("scan"); scan;
+         scan = scan.next_sibling("scan")) {
+        scannum++;
+        if (strncasecmp(scan.name(), "scan", 4) == 0) {
+            parseMzXMLScan(scan, scannum);
+        }
 
-		for (xml_node child = scan.first_child(); child; child = child.next_sibling())
-		{
-			scannum++;
-			if (strncasecmp(child.name(), "scan", 4) == 0)
-			{
-				parseMzXMLScan(child, scannum);
-			}
-		}
-	}
+        for (xml_node child = scan.first_child(); child;
+             child = child.next_sibling()) {
+            scannum++;
+            if (strncasecmp(child.name(), "scan", 4) == 0) {
+                parseMzXMLScan(child, scannum);
+            }
+        }
+    }
 }
 
-void mzSample::parseMzXML(const char *filename)
+void mzSample::parseMzXML(const char* filename)
 {
-	xml_document doc;
+    xml_document doc;
 
     xml_node spectrumstore = getmzXMLSpectrumData(doc, filename);
 
-    if (!spectrumstore.empty())
-    {
-        //Setting the instrument related information
+    if (!spectrumstore.empty()) {
+        // Setting the instrument related information
         setInstrumentSettigs(doc, spectrumstore);
-        //parse mzXML information from the scan
+        // parse mzXML information from the scan
         parseMzXMLData(spectrumstore);
-    }
-    else
+    } else
         throw MavenException(ErrorMsg::ParsemzXml);
 }
 
 /**
  * calculate the RT in minutes
  **/
-float mzSample::parseRTFromMzXML(xml_attribute &attr)
+float mzSample::parseRTFromMzXML(xml_attribute& attr)
 {
-	float rt = 0.0;
-	if (strncasecmp(attr.value(), "PT", 2) == 0)
-	{
-		rt = string2float(string(attr.value() + 2));
-	}
-	else if (strncasecmp(attr.value(), "P", 1) == 0)
-	{
-		rt = string2float(string(attr.value() + 1));
-	}
-	else
-	{
-		rt = string2float(attr.value());
-	}
-	rt /= 60.0;
-	return rt;
+    float rt = 0.0;
+    if (strncasecmp(attr.value(), "PT", 2) == 0) {
+        rt = string2float(string(attr.value() + 2));
+    } else if (strncasecmp(attr.value(), "P", 1) == 0) {
+        rt = string2float(string(attr.value() + 1));
+    } else {
+        rt = string2float(attr.value());
+    }
+    rt /= 60.0;
+    return rt;
 }
 
-int mzSample::parsePolarityFromMzXML(xml_attribute &attr)
+int mzSample::parsePolarityFromMzXML(xml_attribute& attr)
 {
-	char p = attr.value()[0];
-	//For polarity 0 is the default value
-	int scanpolarity = 0;
-	switch (p)
-	{
-	case '+':
-		scanpolarity = 1;
-		break;
-	case '-':
-		scanpolarity = -1;
-		break;
-	default:
-		scanpolarity = 0;
-		break;
-	}
+    char p = attr.value()[0];
+    // For polarity 0 is the default value
+    int scanpolarity = 0;
+    switch (p) {
+    case '+':
+        scanpolarity = 1;
+        break;
+    case '-':
+        scanpolarity = -1;
+        break;
+    default:
+        scanpolarity = 0;
+        break;
+    }
 
-	return scanpolarity;
+    return scanpolarity;
 }
 
 int mzSample::getPolarityFromfilterLine(string filterLine)
 {
-	int MIN_FILTER_LINE_LENGTH = 13;
-	int scanpolarity = 0;
+    int MIN_FILTER_LINE_LENGTH = 13;
+    int scanpolarity = 0;
 
-	if (filterLine.size() > MIN_FILTER_LINE_LENGTH)
-	{
+    if (filterLine.size() > MIN_FILTER_LINE_LENGTH) {
+        if (filterLine.find(" + ") != string::npos) {
+            scanpolarity = 1;
+        } else {
+            scanpolarity = -1;
+        }
+    }
 
-		if (filterLine.find(" + ") != string::npos)
-		{
-			scanpolarity = 1;
-		}
-		else
-		{
-			scanpolarity = -1;
-		}
-	}
-
-	return scanpolarity;
+    return scanpolarity;
 }
 
-vector<float> mzSample::parsePeaksFromMzXML(const xml_node &scan)
+vector<float> mzSample::parsePeaksFromMzXML(const xml_node& scan)
 {
-	xml_node peaks = scan.child("peaks");
-	vector<float> mzint;
+    xml_node peaks = scan.child("peaks");
+    vector<float> mzint;
 
-	if (!peaks.empty())
-	{
-		string b64String(peaks.child_value());
+    if (!peaks.empty()) {
+        string b64String(peaks.child_value());
 
-		//no m/z intensity values
-		if (b64String.empty())
-			return mzint;
+        // no m/z intensity values
+        if (b64String.empty())
+            return mzint;
 
-		bool decompress = false;
+        bool decompress = false;
 #ifdef ZLIB
-		// if the data is been compressed in zlib format this part will
-		// take care.
-		if (strncasecmp(peaks.attribute("compressionType").value(), "zlib",
-						4) == 0)
-		{
-			decompress = true;
-		}
+        // if the data is been compressed in zlib format this part will
+        // take care.
+        if (strncasecmp(peaks.attribute("compressionType").value(), "zlib", 4)
+            == 0) {
+            decompress = true;
+        }
 #endif
 
-		bool networkorder = false; // naman The scope of the variable
-								   // 'networkorder' can be reduced.
+        bool networkorder = false;  // naman The scope of the variable
+                                    // 'networkorder' can be reduced.
 
-		if (peaks.attribute("byteOrder").empty() || strncasecmp(peaks.attribute("byteOrder").value(), "network", 5) == 0)
-		{
-			networkorder = true;
-		}
+        if (peaks.attribute("byteOrder").empty()
+            || strncasecmp(peaks.attribute("byteOrder").value(), "network", 5)
+                   == 0) {
+            networkorder = true;
+        }
 
-		int precision = 32; //naman The scope of the variable 'precision' can be reduced.
+        int precision =
+            32;  // naman The scope of the variable 'precision' can be reduced.
 
-		if (!peaks.attribute("precision").empty())
-		{
-			precision = peaks.attribute("precision").as_int();
-		}
+        if (!peaks.attribute("precision").empty()) {
+            precision = peaks.attribute("precision").as_int();
+        }
 
-		// cerr << "new scan=" << scannum << " msL=" << msLevel << " rt=" << rt << " precMz=" << precursorMz << " polar=" << scanpolarity
-		//    << " prec=" << precision << endl;
+        // cerr << "new scan=" << scannum << " msL=" << msLevel << " rt=" << rt
+        // << " precMz=" << precursorMz << " polar=" << scanpolarity
+        //    << " prec=" << precision << endl;
 
-		mzint = base64::decode_base64(b64String, precision / 8, networkorder,
-									  decompress);
+        mzint = base64::decode_base64(
+            b64String, precision / 8, networkorder, decompress);
 
-		return mzint;
-	}
+        return mzint;
+    }
 
-	return mzint;
+    return mzint;
 }
 
-void mzSample::populateMzAndIntensity(const vector<float>& mzint, Scan *_scan)
+void mzSample::populateMzAndIntensity(const vector<float>& mzint, Scan* _scan)
 {
-	int j = 0, count = 0, size = mzint.size() / 2;
+    int j = 0, count = 0, size = mzint.size() / 2;
 
-	// sizing the mz variable and the intensity variable
-	_scan->mz.resize(size);
-	_scan->intensity.resize(size);
+    // sizing the mz variable and the intensity variable
+    _scan->mz.resize(size);
+    _scan->intensity.resize(size);
 
-	for (int i = 0; i < size; i++)
-	{
-		float mzValue = mzint[j++];
-		float intensityValue = mzint[j++];
-		//cerr << mzValue << " " << intensityValue << endl;
-		if (mzValue > 0 && intensityValue > 0)
-		{
-			_scan->mz[i] = mzValue;
-			_scan->intensity[i] = intensityValue;
-			count++;
-		}
-	}
+    for (int i = 0; i < size; i++) {
+        float mzValue = mzint[j++];
+        float intensityValue = mzint[j++];
+        // cerr << mzValue << " " << intensityValue << endl;
+        if (mzValue > 0 && intensityValue > 0) {
+            _scan->mz[i] = mzValue;
+            _scan->intensity[i] = intensityValue;
+            count++;
+        }
+    }
 
-	_scan->mz.resize(count);
-	_scan->intensity.resize(count);
+    _scan->mz.resize(count);
+    _scan->intensity.resize(count);
 }
 
-void mzSample::populateFilterline(const string& filterLine, Scan *_scan)
+void mzSample::populateFilterline(const string& filterLine, Scan* _scan)
 {
+    if (!filterLine.empty())
+        _scan->filterLine = filterLine;
 
-	if (!filterLine.empty())
-		_scan->filterLine = filterLine;
-
-	//TODO: why is this logic like this is
-	if (filterLine.empty() && _scan->precursorMz > 0)
-	{
-		_scan->filterLine = _scan->scanType + ":" + float2string(_scan->precursorMz, 4) + " [" + float2string(_scan->productMz, 4) + "]";
-	}
+    // TODO: why is this logic like this is
+    if (filterLine.empty() && _scan->precursorMz > 0) {
+        _scan->filterLine = _scan->scanType + ":"
+                            + float2string(_scan->precursorMz, 4) + " ["
+                            + float2string(_scan->productMz, 4) + "]";
+    }
 }
 
-void mzSample::parseMzXMLScan(const xml_node &scan, const int& scannum)
+void mzSample::parseMzXMLScan(const xml_node& scan, const int& scannum)
 {
-
     float rt = 0.0, precursorMz = 0.0f, productMz = 0, collisionEnergy = 0;
-	int scanpolarity = 0, msLevel = 1;
-	string filterLine, scanType;
-	vector<float> mzint;
+    int scanpolarity = 0, msLevel = 1;
+    string filterLine, scanType;
+    vector<float> mzint;
 
-	for (xml_attribute attr = scan.first_attribute(); attr; attr = attr.next_attribute())
-	{
-		if (strncasecmp(attr.name(), "retentionTime", 10) == 0)
-		{
-			rt = parseRTFromMzXML(attr);
-		}
+    for (xml_attribute attr = scan.first_attribute(); attr;
+         attr = attr.next_attribute()) {
+        if (strncasecmp(attr.name(), "retentionTime", 10) == 0) {
+            rt = parseRTFromMzXML(attr);
+        }
 
-		if (strncasecmp(attr.name(), "polarity", 5) == 0)
-		{
-			scanpolarity = parsePolarityFromMzXML(attr);
-		}
+        if (strncasecmp(attr.name(), "polarity", 5) == 0) {
+            scanpolarity = parsePolarityFromMzXML(attr);
+        }
 
-		if (strncasecmp(attr.name(), "filterLine", 9) == 0)
-		{
-			filterLine = attr.value();
-		}
+        if (strncasecmp(attr.name(), "filterLine", 9) == 0) {
+            filterLine = attr.value();
+        }
 
-		if (strncasecmp(attr.name(), "mslevel", 5) == 0)
-		{
-			msLevel = string2integer(attr.value());
-			//If ms Level is less than Zero then its hardcoded
-			//to one
-			if (msLevel <= 0)
-				msLevel = 1;
-		}
+        if (strncasecmp(attr.name(), "mslevel", 5) == 0) {
+            msLevel = string2integer(attr.value());
+            // If ms Level is less than Zero then its hardcoded
+            // to one
+            if (msLevel <= 0)
+                msLevel = 1;
+        }
 
-		if (strncasecmp(attr.name(), "basePeakMz", 9) == 0)
-		{
-			productMz = string2float(attr.value());
-		}
+        if (strncasecmp(attr.name(), "basePeakMz", 9) == 0) {
+            productMz = string2float(attr.value());
+        }
 
-		if (strncasecmp(attr.name(), "collisionEnergy", 12) == 0)
-		{
-			collisionEnergy = string2float(attr.value());
-		}
+        if (strncasecmp(attr.name(), "collisionEnergy", 12) == 0) {
+            collisionEnergy = string2float(attr.value());
+        }
 
-		if (strncasecmp(attr.name(), "scanType", 8) == 0)
-		{
-			scanType = attr.value();
-		}
-	}
+        if (strncasecmp(attr.name(), "scanType", 8) == 0) {
+            scanType = attr.value();
+        }
+    }
 
-	//To get the polarity from filterline if polarity turns out to be neurtal
-	if (scanpolarity == 0)
-	{
-		scanpolarity = getPolarityFromfilterLine(filterLine);
-	}
+    // To get the polarity from filterline if polarity turns out to be neurtal
+    if (scanpolarity == 0) {
+        scanpolarity = getPolarityFromfilterLine(filterLine);
+    }
 
-    //no m/z intensity values
+    // no m/z intensity values
     mzint = parsePeaksFromMzXML(scan);
     if (mzint.empty()) {
         return;
     }
 
-    Scan *_scan = new Scan(this, scannum, msLevel, rt, precursorMz, scanpolarity);
+    Scan* _scan =
+        new Scan(this, scannum, msLevel, rt, precursorMz, scanpolarity);
 
     xml_node precursor = scan.child("precursorMz");
     if (precursor) {
         _scan->precursorMz = string2float(scan.child_value("precursorMz"));
         _scan->isolationWindow = 1.0f;
 
-        for (xml_attribute attr = precursor.first_attribute(); attr; attr = attr.next_attribute()) {
+        for (xml_attribute attr = precursor.first_attribute(); attr;
+             attr = attr.next_attribute()) {
             if (strncasecmp(attr.name(), "precursorIntensity", 15) == 0)
                 _scan->precursorIntensity = string2float(attr.value());
             else if (strncasecmp(attr.name(), "precursorCharge", 15) == 0)
@@ -1009,34 +973,33 @@ void mzSample::parseMzXMLScan(const xml_node &scan, const int& scannum)
                 _scan->precursorScanNum = string2integer(attr.value());
             else if (strncasecmp(attr.name(), "windowWideness", 13) == 0)
                 _scan->isolationWindow = string2float(attr.value());
-         }
+        }
     }
 
-	if (!scanType.empty())
-		_scan->scanType = scanType;
+    if (!scanType.empty())
+        _scan->scanType = scanType;
 
-	_scan->productMz = productMz;
+    _scan->productMz = productMz;
 
-	_scan->collisionEnergy = collisionEnergy;
+    _scan->collisionEnergy = collisionEnergy;
 
-	populateMzAndIntensity(mzint, _scan);
+    populateMzAndIntensity(mzint, _scan);
 
-	populateFilterline(filterLine, _scan);
+    populateFilterline(filterLine, _scan);
 
-	addScan(_scan);
+    addScan(_scan);
 }
 
 void mzSample::summary()
 {
-	// void mzSample::summary() const {
-	cerr << "Num of obs:" << this->scans.size() << endl;
-	cerr << "Rt range:" << this->minRt << " " << this->maxRt << endl;
-	cerr << "Mz range:" << this->minMz << " " << this->maxMz << endl;
+    // void mzSample::summary() const {
+    cerr << "Num of obs:" << this->scans.size() << endl;
+    cerr << "Rt range:" << this->minRt << " " << this->maxRt << endl;
+    cerr << "Mz range:" << this->minMz << " " << this->maxMz << endl;
 }
 
 void mzSample::calculateMzRtRange()
 {
-
     if (scans.size() == 0) {
         cerr << "sample has no data" << endl;
         return;
@@ -1077,330 +1040,305 @@ void mzSample::calculateMzRtRange()
         maxRt = 1e4;
 }
 
-mzSlice mzSample::getMinMaxDimentions(const vector<mzSample *> &samples)
+mzSlice mzSample::getMinMaxDimentions(const vector<mzSample*>& samples)
 {
-	//TODO naman unused function
+    // TODO naman unused function
 
-	mzSlice d;
-	d.rtmin = 0;
-	d.rtmax = 0;
-	d.mzmin = 0;
-	d.mzmax = 0;
+    mzSlice d;
+    d.rtmin = 0;
+    d.rtmax = 0;
+    d.mzmin = 0;
+    d.mzmax = 0;
 
-	if (samples.size() > 0)
-	{
+    if (samples.size() > 0) {
+        d.rtmin = samples[0]->minRt;
+        d.rtmax = samples[0]->maxRt;
+        d.mzmin = samples[0]->minMz;
+        d.mzmax = samples[0]->maxMz;
 
-		d.rtmin = samples[0]->minRt;
-		d.rtmax = samples[0]->maxRt;
-		d.mzmin = samples[0]->minMz;
-		d.mzmax = samples[0]->maxMz;
+        for (unsigned int i = 1; i < samples.size(); i++) {
+            if (samples[i]->minRt < d.rtmin)
+                d.rtmin = samples[i]->minRt;
+            if (samples[i]->maxRt > d.rtmax)
+                d.rtmax = samples[i]->maxRt;
+            if (samples[i]->minMz < d.mzmin)
+                d.mzmin = samples[i]->minMz;
+            if (samples[i]->maxMz > d.mzmax)
+                d.mzmax = samples[i]->maxMz;
+        }
+    }
 
-		for (unsigned int i = 1; i < samples.size(); i++)
-		{
-			if (samples[i]->minRt < d.rtmin)
-				d.rtmin = samples[i]->minRt;
-			if (samples[i]->maxRt > d.rtmax)
-				d.rtmax = samples[i]->maxRt;
-			if (samples[i]->minMz < d.mzmin)
-				d.mzmin = samples[i]->minMz;
-			if (samples[i]->maxMz > d.mzmax)
-				d.mzmax = samples[i]->maxMz;
-		}
-	}
+    cerr << "getMinMaxDimentions() " << d.rtmin << " " << d.rtmax << " "
+         << d.mzmin << " " << d.mzmax << endl;
 
-	cerr << "getMinMaxDimentions() " << d.rtmin << " " << d.rtmax << " " << d.mzmin << " " << d.mzmax << endl;
-
-	return d;
+    return d;
 }
 
-float mzSample::getMaxRt(const vector<mzSample *> &samples)
+float mzSample::getMaxRt(const vector<mzSample*>& samples)
 {
-	//TODO naman unused function
-	float maxRt = 0;
-	for (unsigned int i = 0; i < samples.size(); i++)
-		if (samples[i]->maxRt > maxRt)
-			maxRt = samples[i]->maxRt;
+    // TODO naman unused function
+    float maxRt = 0;
+    for (unsigned int i = 0; i < samples.size(); i++)
+        if (samples[i]->maxRt > maxRt)
+            maxRt = samples[i]->maxRt;
 
-	return maxRt;
+    return maxRt;
 }
 
 float mzSample::getAverageFullScanTime()
 {
-	// float mzSample::getAverageFullScanTime() const {
-	float s = 0;
-	int n = 0;
-	Scan *lscan = NULL;
-	Scan *tscan = NULL;
-	if (scans.size() == 0)
-		return 0;
+    // float mzSample::getAverageFullScanTime() const {
+    float s = 0;
+    int n = 0;
+    Scan* lscan = NULL;
+    Scan* tscan = NULL;
+    if (scans.size() == 0)
+        return 0;
 
-	for (unsigned int i = 1; i < scans.size(); i++)
-	{
-		if (scans[i]->mslevel == 1)
-		{
-			tscan = scans[i];
-			if (lscan)
-			{
-				s += tscan->rt - lscan->rt;
-				n++;
-			}
-			lscan = tscan;
-		}
-	}
-	if (n > 0)
-		return s / n;
-	return 0;
+    for (unsigned int i = 1; i < scans.size(); i++) {
+        if (scans[i]->mslevel == 1) {
+            tscan = scans[i];
+            if (lscan) {
+                s += tscan->rt - lscan->rt;
+                n++;
+            }
+            lscan = tscan;
+        }
+    }
+    if (n > 0)
+        return s / n;
+    return 0;
 }
 
 void mzSample::enumerateSRMScans()
 {
-	srmScans.clear();
-	for (unsigned int i = 0; i < scans.size(); i++)
-	{
-		if (scans[i]->filterLine.length() > 0)
-		{
-			srmScans[scans[i]->filterLine].push_back(i);
-		}
-	}
+    srmScans.clear();
+    for (unsigned int i = 0; i < scans.size(); i++) {
+        if (scans[i]->filterLine.length() > 0) {
+            srmScans[scans[i]->filterLine].push_back(i);
+        }
+    }
 }
 
-Scan *mzSample::getScan(unsigned int scanNum)
+Scan* mzSample::getScan(unsigned int scanNum)
 {
-	if (scanNum >= scans.size())
-		scanNum = scans.size() - 1;
-	if (scanNum < scans.size())
-	{
-		return (scans[scanNum]);
-	}
-	else
-	{
-		cerr << "Warning bad scan number " << scanNum << endl;
-		return NULL;
-	}
+    if (scanNum >= scans.size())
+        scanNum = scans.size() - 1;
+    if (scanNum < scans.size()) {
+        return (scans[scanNum]);
+    } else {
+        cerr << "Warning bad scan number " << scanNum << endl;
+        return NULL;
+    }
 }
 
-EIC *mzSample::getEIC(float precursorMz, float collisionEnergy, float productMz, int eicType, string filterline, float amuQ1 = 0.5, float amuQ3 = 0.5)
+EIC* mzSample::getEIC(float precursorMz,
+                      float collisionEnergy,
+                      float productMz,
+                      int eicType,
+                      string filterline,
+                      float amuQ1 = 0.5,
+                      float amuQ3 = 0.5)
 {
-	EIC *e = new EIC();
-	e->sampleName = sampleName;
-	e->sample = this;
-	e->totalIntensity = 0;
-	e->maxIntensity = 0;
-	e->mzmin = 0;
-	e->mzmax = 0;
+    EIC* e = new EIC();
+    e->sampleName = sampleName;
+    e->sample = this;
+    e->totalIntensity = 0;
+    e->maxIntensity = 0;
+    e->mzmin = 0;
+    e->mzmax = 0;
 
-	for (unsigned int i = 0; i < scans.size(); i++)
-	{
-		Scan *scan = scans[i];
-		if (!(scan->filterLine == filterline || filterline == ""))
-			continue;
-		if (scan->mslevel != 2)
-			continue;
-		if (precursorMz && abs(scan->precursorMz - precursorMz) > amuQ1)
-			continue;
-		//if (productMz && abs(scan->productMz - productMz) > amuQ3)
-		//	continue;
-		//if (collisionEnergy && abs(scan->collisionEnergy-collisionEnergy) > 0.5) continue;
+    for (unsigned int i = 0; i < scans.size(); i++) {
+        Scan* scan = scans[i];
+        if (!(scan->filterLine == filterline || filterline == ""))
+            continue;
+        if (scan->mslevel != 2)
+            continue;
+        if (precursorMz && abs(scan->precursorMz - precursorMz) > amuQ1)
+            continue;
+        // if (productMz && abs(scan->productMz - productMz) > amuQ3)
+        //	continue;
+        // if (collisionEnergy && abs(scan->collisionEnergy-collisionEnergy) >
+        // 0.5) continue;
 
-		float eicMz = 0;
-		float eicIntensity = 0;
+        float eicMz = 0;
+        float eicIntensity = 0;
 
-		switch ((EIC::EicType)eicType)
-		{
+        switch ((EIC::EicType)eicType) {
+        case EIC::MAX: {
+            for (unsigned int k = 0; k < scan->nobs(); k++) {
+                if (abs(productMz - scan->mz[k]) > amuQ3)
+                    continue;
+                if (scan->intensity[k] > eicIntensity) {
+                    eicIntensity = scan->intensity[k];
+                    eicMz = scan->mz[k];
+                }
+            }
+            break;
+        }
 
-		case EIC::MAX:
-		{
-			for (unsigned int k = 0; k < scan->nobs(); k++)
-			{
-				if (abs(productMz - scan->mz[k]) > amuQ3) continue;
-				if (scan->intensity[k] > eicIntensity)
-				{
-					eicIntensity = scan->intensity[k];
-					eicMz = scan->mz[k];
-				}
-			}
-			break;
-		}
+        // calculate the weighted average(with intensities as weights)
+        // while finding the eicMz for the whole EIC.
+        case EIC::SUM: {
+            float n = 0;
+            for (unsigned int k = 0; k < scan->nobs(); k++) {
+                if (abs(productMz - scan->mz[k]) > amuQ3)
+                    continue;
+                eicIntensity += scan->intensity[k];
+                eicMz += (scan->mz[k]) * (scan->intensity[k]);
+                n += scan->intensity[k];
+            }
 
-		//calculate the weighted average(with intensities as weights)
-		//while finding the eicMz for the whole EIC.
-		case EIC::SUM:
-		{
-			float n = 0;
-			for (unsigned int k = 0; k < scan->nobs(); k++)
-			{
-				if (abs(productMz - scan->mz[k]) > amuQ3) continue;
-				eicIntensity += scan->intensity[k];
-				eicMz += (scan->mz[k]) * (scan->intensity[k]);
-				n += scan->intensity[k];
-			}
+            eicMz /= n;
+            break;
+        }
 
-			eicMz /= n;
-			break;
-		}
+        default: {
+            for (unsigned int k = 0; k < scan->nobs(); k++) {
+                if (abs(productMz - scan->mz[k]) > amuQ3)
+                    continue;
+                if (scan->intensity[k] > eicIntensity) {
+                    eicIntensity = scan->intensity[k];
+                    eicMz = scan->mz[k];
+                }
+            }
+            break;
+        }
+        }
 
-		default:
-		{
-			for (unsigned int k = 0; k < scan->nobs(); k++)
-			{
-				if (abs(productMz - scan->mz[k]) > amuQ3) continue;
-				if (scan->intensity[k] > eicIntensity)
-				{
-					eicIntensity = scan->intensity[k];
-					eicMz = scan->mz[k];
-				}
-			}
-			break;
-		}
-		}
+        // if rt is already present save the higher intensity for that rt
+        // this can happen when there are multiple product m/z for the same
+        // precursor
+        if (!e->rt.empty() && e->rt.back() == scan->rt) {
+            if (eicIntensity <= e->intensity.back())
+                continue;
+            else {
+                // replace old values for the rt
+                e->scannum.back() = scan->scannum;
+                e->intensity.back() = eicIntensity;
+                e->mz.back() = eicMz;
+            }
+        }
+        // save values for new rt
+        else {
+            e->scannum.push_back(scan->scannum);
+            e->rt.push_back(scan->rt);
+            e->intensity.push_back(eicIntensity);
+            e->mz.push_back(eicMz);
+        }
+        e->totalIntensity += eicIntensity;
+        if (eicIntensity > e->maxIntensity)
+            e->maxIntensity = eicIntensity;
+    }
 
-		//if rt is already present save the higher intensity for that rt
-		//this can happen when there are multiple product m/z for the same precursor
-		if (!e->rt.empty() && e->rt.back() == scan->rt) {
-			if (eicIntensity <= e->intensity.back()) 
-				continue;
-			else {
-				//replace old values for the rt
-				e->scannum.back() = scan->scannum;
-				e->intensity.back() = eicIntensity;
-				e->mz.back() = eicMz;
-			}
-		}
-		//save values for new rt
-		else {
-			e->scannum.push_back(scan->scannum);
-			e->rt.push_back(scan->rt);
-			e->intensity.push_back(eicIntensity);
-			e->mz.push_back(eicMz);
-		}
-		e->totalIntensity += eicIntensity;
-		if (eicIntensity > e->maxIntensity)
-			e->maxIntensity = eicIntensity;
-	}
+    if (e->rt.size() > 0) {
+        e->rtmin = e->rt[0];
+        e->rtmax = e->rt[e->size() - 1];
+    }
 
-	if (e->rt.size() > 0)
-	{
-		e->rtmin = e->rt[0];
-		e->rtmax = e->rt[e->size() - 1];
-	}
+    float scale = getNormalizationConstant();
+    if (scale != 1.0)
+        for (unsigned int j = 0; j < e->size(); j++) {
+            e->intensity[j] *= scale;
+        }
 
-	float scale = getNormalizationConstant();
-	if (scale != 1.0)
-		for (unsigned int j = 0; j < e->size(); j++)
-		{
-			e->intensity[j] *= scale;
-		}
-
-	//if (e->size() == 0)
-	//	cerr << "getEIC(Q1,CE,Q3): is empty" << precursorMz << " " << collisionEnergy << " " << productMz << endl;
-	//std::cerr << "getEIC(Q1,CE,Q3): srm" << precursorMz << " " << e->intensity.size() << endl;
-	return e;
+    // if (e->size() == 0)
+    //     cerr << "getEIC(Q1,CE,Q3): is empty" << precursorMz << " "
+    //          << collisionEnergy << " " << productMz << endl;
+    // std::cerr << "getEIC(Q1,CE,Q3): srm" << precursorMz << " "
+    //           << e->intensity.size() << endl;
+    return e;
 }
 
-EIC *mzSample::getEIC(string srm, int eicType)
+EIC* mzSample::getEIC(string srm, int eicType)
 {
+    EIC* e = new EIC();
+    e->sampleName = sampleName;
+    e->sample = this;
+    e->totalIntensity = 0;
+    e->maxIntensity = 0;
+    e->mzmin = 0;
+    e->mzmax = 0;
 
-	EIC *e = new EIC();
-	e->sampleName = sampleName;
-	e->sample = this;
-	e->totalIntensity = 0;
-	e->maxIntensity = 0;
-	e->mzmin = 0;
-	e->mzmax = 0;
+    // if (srmScans.size() == 0 )
 
-	// if (srmScans.size() == 0 )
+    // naman Checking for ‘List’ emptiness might be inefficient. Using
+    // List.empty() instead of List.size() can be faster. List.size() can take
+    // linear time but List.empty() is guaranteed to take constant time. src:
+    // https://kmdarshan.wordpress.com/2011/08/15/static-analysis-of-cc-code-using-cppcheck/
+    if (srmScans.empty()) {
+        enumerateSRMScans();
+    }
 
-	// naman Checking for ‘List’ emptiness might be inefficient. Using List.empty() instead of List.size()
-	// can be faster. List.size() can take linear time but List.empty() is guaranteed to take constant time.
-	// src: https://kmdarshan.wordpress.com/2011/08/15/static-analysis-of-cc-code-using-cppcheck/
-	if (srmScans.empty())
-	{
-		enumerateSRMScans();
-	}
+    if (srmScans.count(srm) > 0) {
+        vector<int> srmscans = srmScans[srm];
+        for (unsigned int i = 0; i < srmscans.size(); i++) {
+            Scan* scan = scans[srmscans[i]];
+            float eicMz = 0;
+            float eicIntensity = 0;
 
-	if (srmScans.count(srm) > 0)
-	{
-		vector<int> srmscans = srmScans[srm];
-		for (unsigned int i = 0; i < srmscans.size(); i++)
-		{
-			Scan *scan = scans[srmscans[i]];
-			float eicMz = 0;
-			float eicIntensity = 0;
+            switch ((EIC::EicType)eicType) {
+            case EIC::MAX: {
+                for (unsigned int k = 0; k < scan->nobs(); k++) {
+                    if (scan->intensity[k] > eicIntensity) {
+                        eicIntensity = scan->intensity[k];
+                        eicMz = scan->mz[k];
+                    }
+                }
+                break;
+            }
 
-			switch ((EIC::EicType)eicType)
-			{
+            // calculate the weighted average(with intensities as weights)
+            // while finding the eicMz for the whole EIC.
+            case EIC::SUM: {
+                float n = 0;
+                for (unsigned int k = 0; k < scan->nobs(); k++) {
+                    eicIntensity += scan->intensity[k];
+                    eicMz += (scan->mz[k]) * (scan->intensity[k]);
+                    n += scan->intensity[k];
+                }
 
-			case EIC::MAX:
-			{
-				for (unsigned int k = 0; k < scan->nobs(); k++)
-				{
-					if (scan->intensity[k] > eicIntensity)
-					{
-						eicIntensity = scan->intensity[k];
-						eicMz = scan->mz[k];
-					}
-				}
-				break;
-			}
+                eicMz /= n;
+                break;
+            }
 
-			//calculate the weighted average(with intensities as weights)
-			//while finding the eicMz for the whole EIC.
-			case EIC::SUM:
-			{
-				float n = 0;
-				for (unsigned int k = 0; k < scan->nobs(); k++)
-				{
-					eicIntensity += scan->intensity[k];
-					eicMz += (scan->mz[k]) * (scan->intensity[k]);
-					n += scan->intensity[k];
-				}
+            default: {
+                for (unsigned int k = 0; k < scan->nobs(); k++) {
+                    if (scan->intensity[k] > eicIntensity) {
+                        eicIntensity = scan->intensity[k];
+                        eicMz = scan->mz[k];
+                    }
+                }
+                break;
+            }
+            }
 
-				eicMz /= n;
-				break;
-			}
+            e->scannum.push_back(scan->scannum);
+            e->rt.push_back(scan->rt);
+            e->intensity.push_back(eicIntensity);
+            e->mz.push_back(eicMz);
+            e->totalIntensity += eicIntensity;
 
-			default:
-			{
-				for (unsigned int k = 0; k < scan->nobs(); k++)
-				{
-					if (scan->intensity[k] > eicIntensity)
-					{
-						eicIntensity = scan->intensity[k];
-						eicMz = scan->mz[k];
-					}
-				}
-				break;
-			}
-			}
+            if (eicIntensity > e->maxIntensity)
+                e->maxIntensity = eicIntensity;
+        }
+    }
 
-			e->scannum.push_back(scan->scannum);
-			e->rt.push_back(scan->rt);
-			e->intensity.push_back(eicIntensity);
-			e->mz.push_back(eicMz);
-			e->totalIntensity += eicIntensity;
+    if (e->rt.size() > 0) {
+        e->rtmin = e->rt[0];
+        e->rtmax = e->rt[e->size() - 1];
+    }
 
-			if (eicIntensity > e->maxIntensity)
-				e->maxIntensity = eicIntensity;
-		}
-	}
+    float scale = getNormalizationConstant();
+    if (scale != 1.0)
+        for (unsigned int j = 0; j < e->size(); j++) {
+            e->intensity[j] *= scale;
+        }
+    // if (e->size() == 0)
+    //     cerr << "getEIC(SRM STRING): is empty" << srm << endl;
+    // std::cerr << "getEIC: srm" << srm << " " << e->intensity.size() << endl;
 
-	if (e->rt.size() > 0)
-	{
-		e->rtmin = e->rt[0];
-		e->rtmax = e->rt[e->size() - 1];
-	}
-
-	float scale = getNormalizationConstant();
-	if (scale != 1.0)
-		for (unsigned int j = 0; j < e->size(); j++)
-		{
-			e->intensity[j] *= scale;
-		}
-	//if (e->size() == 0)
-	//	cerr << "getEIC(SRM STRING): is empty" << srm << endl;
-	//std::cerr << "getEIC: srm" << srm << " " << e->intensity.size() << endl;
-
-	return e;
+    return e;
 }
 
 /**
@@ -1413,463 +1351,483 @@ EIC *mzSample::getEIC(string srm, int eicType)
  * MS/MS
  * @return         [description]
  */
-EIC *mzSample::getEIC(float mzmin, float mzmax, float rtmin, float rtmax, int mslevel, int eicType, string filterline)
+EIC* mzSample::getEIC(float mzmin,
+                      float mzmax,
+                      float rtmin,
+                      float rtmax,
+                      int mslevel,
+                      int eicType,
+                      string filterline)
 {
+    // Adjusting the Retension Time so that it matches with the sample
+    // retension time
+    if (rtmin < this->minRt)
+        rtmin = this->minRt;
+    if (rtmax > this->maxRt && this->maxRt > rtmin)
+        rtmax = this->maxRt;
+    if (mzmin < this->minMz)
+        mzmin = this->minMz;
+    if (mzmax > this->maxMz && this->maxMz > mzmin)
+        mzmax = this->maxMz;
 
-	//Adjusting the Retension Time so that it matches with the sample
-	//retension time
-	if (rtmin < this->minRt)
-		rtmin = this->minRt;
-	if (rtmax > this->maxRt && this->maxRt > rtmin)
-		rtmax = this->maxRt;
-	if (mzmin < this->minMz)
-		mzmin = this->minMz;
-	if (mzmax > this->maxMz && this->maxMz > mzmin)
-		mzmax = this->maxMz;
+    EIC* e = new EIC();
+    e->sampleName = sampleName;
+    e->sample = this;
+    e->mzmin = mzmin;
+    e->mzmax = mzmax;
+    e->totalIntensity = 0;
+    e->maxIntensity = 0;
 
-	EIC *e = new EIC();
-	e->sampleName = sampleName;
-	e->sample = this;
-	e->mzmin = mzmin;
-	e->mzmax = mzmax;
-	e->totalIntensity = 0;
-	e->maxIntensity = 0;
+    int scanCount = scans.size();
+    if (scanCount == 0)
+        return e;
 
-	int scanCount = scans.size();
-	if (scanCount == 0)
-		return e;
+    if (mzmin < minMz && mzmax < maxMz) {
+        cerr << "getEIC(): mzmin and mzmax are out of range" << endl;
+        return e;
+    }
 
-	if (mzmin < minMz && mzmax < maxMz)
-	{
-		cerr << "getEIC(): mzmin and mzmax are out of range" << endl;
-		return e;
-	}
+    bool success = e->makeEICSlice(
+        this, mzmin, mzmax, rtmin, rtmax, mslevel, eicType, filterline);
 
-	bool success = e->makeEICSlice(this, mzmin, mzmax, rtmin, rtmax, mslevel, eicType, filterline);
+    if (!success) {
+        return e;
+    }
 
-	if (!success)
-	{
-		return e;
-	}
+    e->getRTMinMaxPerScan();
 
-	e->getRTMinMaxPerScan();
+    // scale EIC by normalization constant
+    float scale = getNormalizationConstant();
+    e->normalizeIntensityPerScan(scale);
 
-	//scale EIC by normalization constant
-	float scale = getNormalizationConstant();
-	e->normalizeIntensityPerScan(scale);
+    // if (e->size() == 0)
+    //     cerr << "getEIC(mzrange,rtrange,mslevel): is empty" << mzmin << " "
+    //          << mzmax << " " << rtmin << " " << rtmax << endl;
 
-	//if (e->size() == 0)
-	//	cerr << "getEIC(mzrange,rtrange,mslevel): is empty" << mzmin << " " << mzmax << " " << rtmin << " " << rtmax << endl;
-
-	return (e);
+    return (e);
 }
 
-EIC *mzSample::getTIC(float rtmin, float rtmax, int mslevel)
+EIC* mzSample::getTIC(float rtmin, float rtmax, int mslevel)
 {
-	//TODO naman unused function
+    // TODO naman unused function
 
-	//ajust EIC retention time window to match sample retentention times
-	if (rtmin < this->minRt)
-		rtmin = this->minRt;
-	if (rtmax > this->maxRt)
-		rtmax = this->maxRt;
+    // ajust EIC retention time window to match sample retentention times
+    if (rtmin < this->minRt)
+        rtmin = this->minRt;
+    if (rtmax > this->maxRt)
+        rtmax = this->maxRt;
 
-	//cerr << "getEIC()" << setprecision(7) << mzmin << " " << mzmax << " " << rtmin << " " << rtmax << endl;
+    // cerr << "getEIC()" << setprecision(7) << mzmin << " " << mzmax << " " <<
+    // rtmin << " " << rtmax << endl;
 
-	EIC *e = new EIC();
-	e->sampleName = sampleName;
-	e->sample = this;
-	e->mzmin = 0;
-	e->mzmax = 0;
-	e->totalIntensity = 0;
-	e->maxIntensity = 0;
+    EIC* e = new EIC();
+    e->sampleName = sampleName;
+    e->sample = this;
+    e->mzmin = 0;
+    e->mzmax = 0;
+    e->totalIntensity = 0;
+    e->maxIntensity = 0;
 
-	int scanCount = scans.size();
-	if (scanCount == 0)
-		return e;
+    int scanCount = scans.size();
+    if (scanCount == 0)
+        return e;
 
-	for (int i = 0; i < scanCount; i++)
-	{
-		if (scans[i]->mslevel == mslevel)
-		{
-			Scan *scan = scans[i];
-			float y = scan->totalIntensity();
-			e->mz.push_back(0);
-			e->scannum.push_back(i);
-			e->rt.push_back(scan->rt);
-			e->intensity.push_back(y);
-			e->totalIntensity += y;
-			if (y > e->maxIntensity)
-				e->maxIntensity = y;
-		}
-	}
-	if (e->rt.size() > 0)
-	{
-		e->rtmin = e->rt[0];
-		e->rtmax = e->rt[e->size() - 1];
-	}
-	return (e);
+    for (int i = 0; i < scanCount; i++) {
+        if (scans[i]->mslevel == mslevel) {
+            Scan* scan = scans[i];
+            float y = scan->totalIntensity();
+            e->mz.push_back(0);
+            e->scannum.push_back(i);
+            e->rt.push_back(scan->rt);
+            e->intensity.push_back(y);
+            e->totalIntensity += y;
+            if (y > e->maxIntensity)
+                e->maxIntensity = y;
+        }
+    }
+    if (e->rt.size() > 0) {
+        e->rtmin = e->rt[0];
+        e->rtmax = e->rt[e->size() - 1];
+    }
+    return (e);
 }
 
 // TODO: Sahil Added this function because of merging of eicwidget
-EIC *mzSample::getBIC(float rtmin, float rtmax, int mslevel)
+EIC* mzSample::getBIC(float rtmin, float rtmax, int mslevel)
 {
+    // ajust EIC retention time window to match sample retentention times
+    if (rtmin < this->minRt)
+        rtmin = this->minRt;
+    if (rtmax > this->maxRt)
+        rtmax = this->maxRt;
 
-	//ajust EIC retention time window to match sample retentention times
-	if (rtmin < this->minRt)
-		rtmin = this->minRt;
-	if (rtmax > this->maxRt)
-		rtmax = this->maxRt;
+    // cerr << "getEIC()" << setprecision(7) << mzmin << " " << mzmax << " " <<
+    // rtmin << " " << rtmax << endl;
 
-	//cerr << "getEIC()" << setprecision(7) << mzmin << " " << mzmax << " " << rtmin << " " << rtmax << endl;
+    EIC* e = new EIC();
+    e->sampleName = sampleName;
+    e->sample = this;
+    e->mzmin = 0;
+    e->mzmax = 0;
+    e->totalIntensity = 0;
+    e->maxIntensity = 0;
 
-	EIC *e = new EIC();
-	e->sampleName = sampleName;
-	e->sample = this;
-	e->mzmin = 0;
-	e->mzmax = 0;
-	e->totalIntensity = 0;
-	e->maxIntensity = 0;
+    int scanCount = scans.size();
+    if (scanCount == 0)
+        return e;
 
-	int scanCount = scans.size();
-	if (scanCount == 0)
-		return e;
-
-	for (int i = 0; i < scanCount; i++)
-	{
-		if (scans[i]->mslevel == mslevel)
-		{
-			Scan *scan = scans[i];
-			float maxMz = 0;
-			float maxIntensity = 0;
-			for (unsigned int i = 0; i < scan->intensity.size(); i++)
-			{
-				if (scan->intensity[i] > maxIntensity)
-				{
-					maxIntensity = scan->intensity[i];
-					maxMz = scan->mz[i];
-				}
-			}
-			e->mz.push_back(maxMz);
-			e->scannum.push_back(i);
-			e->rt.push_back(scan->rt);
-			e->intensity.push_back(maxIntensity);
-			e->totalIntensity += maxIntensity;
-			if (maxIntensity > e->maxIntensity)
-				e->maxIntensity = maxIntensity;
-		}
-	}
-	if (e->rt.size() > 0)
-	{
-		e->rtmin = e->rt[0];
-		e->rtmax = e->rt[e->size() - 1];
-	}
-	return (e);
+    for (int i = 0; i < scanCount; i++) {
+        if (scans[i]->mslevel == mslevel) {
+            Scan* scan = scans[i];
+            float maxMz = 0;
+            float maxIntensity = 0;
+            for (unsigned int i = 0; i < scan->intensity.size(); i++) {
+                if (scan->intensity[i] > maxIntensity) {
+                    maxIntensity = scan->intensity[i];
+                    maxMz = scan->mz[i];
+                }
+            }
+            e->mz.push_back(maxMz);
+            e->scannum.push_back(i);
+            e->rt.push_back(scan->rt);
+            e->intensity.push_back(maxIntensity);
+            e->totalIntensity += maxIntensity;
+            if (maxIntensity > e->maxIntensity)
+                e->maxIntensity = maxIntensity;
+        }
+    }
+    if (e->rt.size() > 0) {
+        e->rtmin = e->rt[0];
+        e->rtmax = e->rt[e->size() - 1];
+    }
+    return (e);
 }
 
-//compute correlation between two mzs within some retention time window
-float mzSample::correlation(float mz1, float mz2, MassCutoff *massCutoff, float rt1, float rt2, int eicType, string filterline)
+// compute correlation between two mzs within some retention time window
+float mzSample::correlation(float mz1,
+                            float mz2,
+                            MassCutoff* massCutoff,
+                            float rt1,
+                            float rt2,
+                            int eicType,
+                            string filterline)
 {
-
-	float ppm1 = massCutoff->massCutoffValue(mz1);
-	float ppm2 = massCutoff->massCutoffValue(mz2);
-	int mslevel = 1;
-	EIC *e1 = mzSample::getEIC(mz1 - ppm1, mz1 + ppm1, rt1, rt2, mslevel, eicType, filterline);
-	EIC *e2 = mzSample::getEIC(mz2 - ppm2, mz2 + ppm1, rt1, rt2, mslevel, eicType, filterline);
-	float correlation = mzUtils::correlation(e1->intensity, e2->intensity);
-	delete (e1);
-	delete (e2);
-	return correlation;
+    float ppm1 = massCutoff->massCutoffValue(mz1);
+    float ppm2 = massCutoff->massCutoffValue(mz2);
+    int mslevel = 1;
+    EIC* e1 = mzSample::getEIC(
+        mz1 - ppm1, mz1 + ppm1, rt1, rt2, mslevel, eicType, filterline);
+    EIC* e2 = mzSample::getEIC(
+        mz2 - ppm2, mz2 + ppm1, rt1, rt2, mslevel, eicType, filterline);
+    float correlation = mzUtils::correlation(e1->intensity, e2->intensity);
+    delete (e1);
+    delete (e2);
+    return correlation;
 }
 
-//TODO: is_verbose not being used
-int mzSample::parseCDF(const char *filename, int is_verbose)
+// TODO: is_verbose not being used
+int mzSample::parseCDF(const char* filename, int is_verbose)
 {
 #ifdef CDFPARSER
-	int cdf = 0;
-	int errflag = 0;
-	long nscans = 0;
-	long ninst = 0;
+    int cdf = 0;
+    int errflag = 0;
+    long nscans = 0;
+    long ninst = 0;
 
-	extern int ncopts; /* from "netcdf.h" */
-	ncopts = 0;
+    extern int ncopts; /* from "netcdf.h" */
+    ncopts = 0;
 
-	static MS_Admin_Data admin_data;
-	static MS_Sample_Data sample_data;
-	static MS_Test_Data test_data;
-	// static MS_Instrument_Data inst_data; //naman unused
-	static MS_Raw_Data_Global raw_global_data;
-	static MS_Raw_Per_Scan raw_data;
-	// double mass_pt=0;
-	// double inty_pt=0;
-	// double inty=0;
+    static MS_Admin_Data admin_data;
+    static MS_Sample_Data sample_data;
+    static MS_Test_Data test_data;
+    // static MS_Instrument_Data inst_data; //naman unused
+    static MS_Raw_Data_Global raw_global_data;
+    static MS_Raw_Per_Scan raw_data;
+    // double mass_pt=0;
+    // double inty_pt=0;
+    // double inty=0;
 
-	cdf = ms_open_read(const_cast<char *>(filename));
-	if (-1 == cdf)
-	{
-		fprintf(stderr, "\nopen_cdf_ms: ms_open_read failed!");
-		return 0;
-	}
+    cdf = ms_open_read(const_cast<char*>(filename));
+    if (-1 == cdf) {
+        fprintf(stderr, "\nopen_cdf_ms: ms_open_read failed!");
+        return 0;
+    }
 
-	/* Initialize attribute data structures */
+    /* Initialize attribute data structures */
 
-	ms_init_global(FALSE, &admin_data, &sample_data, &test_data, &raw_global_data);
+    ms_init_global(
+        FALSE, &admin_data, &sample_data, &test_data, &raw_global_data);
 
-	/* Read global information */
+    /* Read global information */
 
-	if (MS_ERROR == ms_read_global(cdf, &admin_data, &sample_data, &test_data, &raw_global_data))
-	{
-		fprintf(stderr, "\nopen_cdf_ms: ms_read_global failed!");
-		ms_init_global(TRUE, &admin_data, &sample_data, &test_data, &raw_global_data);
-		ms_close(cdf);
-		return 0;
-	}
+    if (MS_ERROR
+        == ms_read_global(
+               cdf, &admin_data, &sample_data, &test_data, &raw_global_data)) {
+        fprintf(stderr, "\nopen_cdf_ms: ms_read_global failed!");
+        ms_init_global(
+            TRUE, &admin_data, &sample_data, &test_data, &raw_global_data);
+        ms_close(cdf);
+        return 0;
+    }
 
-	nscans = raw_global_data.nscans;
+    nscans = raw_global_data.nscans;
 
-	switch (admin_data.experiment_type)
-	{
-	case 0:
-		printf("Centroid");
-		break;
-	case 1:
-		printf("Continuum");
-		break;
-	case 2:
-		printf("Library");
-		break;
-	default:
-		printf("Unknown: '%d'", admin_data.experiment_type);
-		break;
-	}
+    switch (admin_data.experiment_type) {
+    case 0:
+        printf("Centroid");
+        break;
+    case 1:
+        printf("Continuum");
+        break;
+    case 2:
+        printf("Library");
+        break;
+    default:
+        printf("Unknown: '%d'", admin_data.experiment_type);
+        break;
+    }
 
-	printf("\n\n-- Instrument Information --");
-	ninst = admin_data.number_instrument_components;
-	printf("\nNumber_inst_comp\t%ld", ninst);
+    printf("\n\n-- Instrument Information --");
+    ninst = admin_data.number_instrument_components;
+    printf("\nNumber_inst_comp\t%ld", ninst);
 
-	printf("\n\n-- Raw Data Information --");
-	printf("\nNumber of scans\t\t%ld", nscans);
+    printf("\n\n-- Raw Data Information --");
+    printf("\nNumber of scans\t\t%ld", nscans);
 
-	printf("\nMass Range\t\t%.2f > %.2f",
-		   raw_global_data.mass_axis_global_min,
-		   raw_global_data.mass_axis_global_max);
+    printf("\nMass Range\t\t%.2f > %.2f",
+           raw_global_data.mass_axis_global_min,
+           raw_global_data.mass_axis_global_max);
 
-	printf("\nInty Range\t\t%.2f > %.2f",
-		   raw_global_data.intensity_axis_global_min,
-		   raw_global_data.intensity_axis_global_max);
+    printf("\nInty Range\t\t%.2f > %.2f",
+           raw_global_data.intensity_axis_global_min,
+           raw_global_data.intensity_axis_global_max);
 
-	printf("\nTime Range\t\t%.2f > %.2f",
-		   raw_global_data.time_axis_global_min,
-		   raw_global_data.time_axis_global_max);
+    printf("\nTime Range\t\t%.2f > %.2f",
+           raw_global_data.time_axis_global_min,
+           raw_global_data.time_axis_global_max);
 
-	printf("\nActual Run Time\t\t%.2f (%.2f min)",
-		   raw_global_data.run_time, raw_global_data.run_time / 60.0);
-	printf("\nComments \t\t%s", raw_global_data.comments);
+    printf("\nActual Run Time\t\t%.2f (%.2f min)",
+           raw_global_data.run_time,
+           raw_global_data.run_time / 60.0);
+    printf("\nComments \t\t%s", raw_global_data.comments);
 
-	if (errflag) /* if error occurred, clean up and leave */
-	{
-		ms_init_global(TRUE, &admin_data, &sample_data, &test_data, &raw_global_data);
-		ms_close(cdf);
-		return 0;
-	}
+    if (errflag) /* if error occurred, clean up and leave */
+    {
+        ms_init_global(
+            TRUE, &admin_data, &sample_data, &test_data, &raw_global_data);
+        ms_close(cdf);
+        return 0;
+    }
 
-	/* Check to see if scale factors and offsets are set to "NULL"
-            values; if so, correct them for use below */
+    /* Check to see if scale factors and offsets are set to "NULL"
+        values; if so, correct them for use below */
 
-	if ((int)MS_NULL_FLT == (int)raw_global_data.mass_factor)
-		raw_global_data.mass_factor = 1.0;
+    if ((int)MS_NULL_FLT == (int)raw_global_data.mass_factor)
+        raw_global_data.mass_factor = 1.0;
 
-	if ((int)MS_NULL_FLT == (int)raw_global_data.time_factor)
-		raw_global_data.time_factor = 1.0;
+    if ((int)MS_NULL_FLT == (int)raw_global_data.time_factor)
+        raw_global_data.time_factor = 1.0;
 
-	if ((int)MS_NULL_FLT == (int)raw_global_data.intensity_factor)
-		raw_global_data.intensity_factor = 1.0;
+    if ((int)MS_NULL_FLT == (int)raw_global_data.intensity_factor)
+        raw_global_data.intensity_factor = 1.0;
 
-	if ((int)MS_NULL_FLT == (int)raw_global_data.intensity_offset)
-		raw_global_data.intensity_offset = 0.0;
+    if ((int)MS_NULL_FLT == (int)raw_global_data.intensity_offset)
+        raw_global_data.intensity_offset = 0.0;
 
-	if ((raw_global_data.mass_axis_global_min < 0) || (raw_global_data.mass_axis_global_max < 0))
-	{
-		/* this bug is frequently observed with files from HP/Agilent ChemStation */
-		fprintf(stderr, "\n*** WARNING: Negative mass reported! Use '-v' for details.\n\n");
-	}
+    if ((raw_global_data.mass_axis_global_min < 0)
+        || (raw_global_data.mass_axis_global_max < 0)) {
+        /* this bug is frequently observed with files from HP/Agilent
+         * ChemStation */
+        fprintf(
+            stderr,
+            "\n*** WARNING: Negative mass reported! Use '-v' for details.\n\n");
+    }
 
-	for (int scan = 0; scan < nscans; scan++)
-	{
-		ms_init_per_scan(FALSE, &raw_data, NULL);
-		raw_data.scan_no = (long)scan;
-		double mass_pt, inty_pt = 0.0; /* init */ //naman The scope can be reduced.
+    for (int scan = 0; scan < nscans; scan++) {
+        ms_init_per_scan(FALSE, &raw_data, NULL);
+        raw_data.scan_no = (long)scan;
+        double mass_pt, inty_pt = 0.0;
+            /* init */  // naman The scope can be reduced.
 
-		if (MS_ERROR == ms_read_per_scan(cdf, &raw_data, NULL))
-		{ /* free allocated memory before leaving */
-			fprintf(stderr, "\nreadchro: ms_read_per_scan failed (scan %d)!", scan);
-			ms_init_per_scan(TRUE, &raw_data, NULL);
-			return 0;
-		}
+        if (MS_ERROR
+            == ms_read_per_scan(
+                   cdf,
+                   &raw_data,
+                   NULL)) { /* free allocated memory before leaving */
+            fprintf(
+                stderr, "\nreadchro: ms_read_per_scan failed (scan %d)!", scan);
+            ms_init_per_scan(TRUE, &raw_data, NULL);
+            return 0;
+        }
 
-		if (!raw_data.points)
-		{ /* empty scan? */
-			break;
-		}
-		else
-		{ /* there are data points */
+        if (!raw_data.points) { /* empty scan? */
+            break;
+        } else { /* there are data points */
 
-			int polarity = 0;
-			if (test_data.ionization_mode == polarity_plus)
-				polarity = +1;
-			else
-				polarity = -1;
+            int polarity = 0;
+            if (test_data.ionization_mode == polarity_plus)
+                polarity = +1;
+            else
+                polarity = -1;
 
-			Scan *myscan = new Scan(this, raw_data.actual_scan_no,
-									test_data.scan_function - (int)resolution_proportional,
-									raw_data.scan_acq_time / 60,
-									0,
-									polarity);
+            Scan* myscan =
+                new Scan(this,
+                         raw_data.actual_scan_no,
+                         test_data.scan_function - (int)resolution_proportional,
+                         raw_data.scan_acq_time / 60,
+                         0,
+                         polarity);
 
-			myscan->intensity.resize(raw_data.points);
-			myscan->mz.resize(raw_data.points);
+            myscan->intensity.resize(raw_data.points);
+            myscan->mz.resize(raw_data.points);
 
-			if (admin_data.experiment_type == 0)
-				myscan->centroided = true;
-			else
-				myscan->centroided = false;
+            if (admin_data.experiment_type == 0)
+                myscan->centroided = true;
+            else
+                myscan->centroided = false;
 
-			for (int i = 0; i < raw_data.points; i++)
-			{
-				switch (raw_global_data.mass_format)
-				{
-				case data_short:
-					mass_pt = (double)((short *)raw_data.masses)[i];
-					break;
+            for (int i = 0; i < raw_data.points; i++) {
+                switch (raw_global_data.mass_format) {
+                case data_short:
+                    mass_pt = (double)((short*)raw_data.masses)[i];
+                    break;
 
-				case data_long:
-					mass_pt = (double)((long *)raw_data.masses)[i];
-					break;
+                case data_long:
+                    mass_pt = (double)((long*)raw_data.masses)[i];
+                    break;
 
-				case data_float:
-					mass_pt = (double)((float *)raw_data.masses)[i];
-					break;
+                case data_float:
+                    mass_pt = (double)((float*)raw_data.masses)[i];
+                    break;
 
-				case data_double:
-					mass_pt = ((double *)raw_data.masses)[i];
-					break;
-				}
+                case data_double:
+                    mass_pt = ((double*)raw_data.masses)[i];
+                    break;
+                }
 
-				mass_pt *= raw_global_data.mass_factor;
+                mass_pt *= raw_global_data.mass_factor;
 
-				switch (raw_global_data.intensity_format)
-				{
-				case data_short:
-					inty_pt = (double)((short *)raw_data.intensities)[i];
-					break;
+                switch (raw_global_data.intensity_format) {
+                case data_short:
+                    inty_pt = (double)((short*)raw_data.intensities)[i];
+                    break;
 
-				case data_long:
-					inty_pt = (double)((long *)raw_data.intensities)[i];
-					break;
+                case data_long:
+                    inty_pt = (double)((long*)raw_data.intensities)[i];
+                    break;
 
-				case data_float:
-					inty_pt = (double)((float *)raw_data.intensities)[i];
-					break;
+                case data_float:
+                    inty_pt = (double)((float*)raw_data.intensities)[i];
+                    break;
 
-				case data_double:
-					inty_pt = (double)((double *)raw_data.intensities)[i];
-					break;
-				}
+                case data_double:
+                    inty_pt = (double)((double*)raw_data.intensities)[i];
+                    break;
+                }
 
-				inty_pt = inty_pt * raw_global_data.intensity_factor + raw_global_data.intensity_offset;
-				//cerr << "mz/int" << mass_pt << " " << inty_pt << endl;
-				myscan->intensity[i] = inty_pt;
-				myscan->mz[i] = mass_pt;
+                inty_pt = inty_pt * raw_global_data.intensity_factor
+                          + raw_global_data.intensity_offset;
+                // cerr << "mz/int" << mass_pt << " " << inty_pt << endl;
+                myscan->intensity[i] = inty_pt;
+                myscan->mz[i] = mass_pt;
 
-				if (raw_data.flags > 0)
-					printf("\nWarning: There are flags in scan %ld (ignored).", scan);
-			} /* i loop */
+                if (raw_data.flags > 0)
+                    printf("\nWarning: There are flags in scan %ld (ignored).",
+                           scan);
+            } /* i loop */
 
-			addScan(myscan);
-		}
+            addScan(myscan);
+        }
 
-		ms_init_per_scan(TRUE, &raw_data, NULL);
+        ms_init_per_scan(TRUE, &raw_data, NULL);
 
-	} /* scan loop */
+    } /* scan loop */
 #endif
-	return 1;
+    return 1;
 }
 
-Scan *mzSample::getAverageScan(float rtmin, float rtmax, int mslevel, int polarity, float sd)
+Scan* mzSample::getAverageScan(float rtmin,
+                               float rtmax,
+                               int mslevel,
+                               int polarity,
+                               float sd)
 {
-	//TODO naman unused function
+    // TODO naman unused function
 
-	float rt = rtmin + (rtmax - rtmin) / 2;
-	int scanCount = 0;
-	int scannum = 0;
+    float rt = rtmin + (rtmax - rtmin) / 2;
+    int scanCount = 0;
+    int scannum = 0;
 
-	map<float, double> mz_intensity_map;
-	map<float, double> mz_bin_map;
-	map<float, int> mz_count;
+    map<float, double> mz_intensity_map;
+    map<float, double> mz_bin_map;
+    map<float, int> mz_count;
 
-	for (unsigned int s = 0; s < scans.size(); s++)
-	{
-		if (scans[s]->getPolarity() != polarity || scans[s]->mslevel != mslevel || scans[s]->rt < rtmin || scans[s]->rt > rtmax)
-			continue;
+    for (unsigned int s = 0; s < scans.size(); s++) {
+        if (scans[s]->getPolarity() != polarity || scans[s]->mslevel != mslevel
+            || scans[s]->rt < rtmin || scans[s]->rt > rtmax)
+            continue;
 
-		Scan *scan = scans[s];
-		scanCount++;
-		for (unsigned int i = 0; i < scan->mz.size(); i++)
-		{
-			float bin = FLOATROUND(scan->mz[i], sd);
-			mz_intensity_map[bin] += ((double)scan->intensity[i]);
-			mz_bin_map[bin] += ((double)(scan->intensity[i]) * (scan->mz[i]));
-			mz_count[bin]++;
-		}
-	}
+        Scan* scan = scans[s];
+        scanCount++;
+        for (unsigned int i = 0; i < scan->mz.size(); i++) {
+            float bin = FLOATROUND(scan->mz[i], sd);
+            mz_intensity_map[bin] += ((double)scan->intensity[i]);
+            mz_bin_map[bin] += ((double)(scan->intensity[i]) * (scan->mz[i]));
+            mz_count[bin]++;
+        }
+    }
 
-	Scan *avgScan = new Scan(this, scannum, mslevel, rt / scanCount, 0, polarity);
+    Scan* avgScan =
+        new Scan(this, scannum, mslevel, rt / scanCount, 0, polarity);
 
-	map<float, double>::iterator itr;
-	for (itr = mz_intensity_map.begin(); itr != mz_intensity_map.end(); ++itr)
-	{
-		float bin = (*itr).first;
-		double totalIntensity = (*itr).second;
-		double avgMz = mz_bin_map[bin] / totalIntensity;
-		avgScan->mz.push_back((float)avgMz);
-		avgScan->intensity.push_back((float)totalIntensity / mz_count[bin]);
-	}
-	//cout << "getAverageScan() from:" << from << " to:" << to << " scanCount:" << scanCount << "scans. mzs=" << avgScan->nobs() << endl;
-	return avgScan;
+    map<float, double>::iterator itr;
+    for (itr = mz_intensity_map.begin(); itr != mz_intensity_map.end(); ++itr) {
+        float bin = (*itr).first;
+        double totalIntensity = (*itr).second;
+        double avgMz = mz_bin_map[bin] / totalIntensity;
+        avgScan->mz.push_back((float)avgMz);
+        avgScan->intensity.push_back((float)totalIntensity / mz_count[bin]);
+    }
+    // cout << "getAverageScan() from:" << from << " to:" << to << " scanCount:"
+    // << scanCount << "scans. mzs=" << avgScan->nobs() << endl;
+    return avgScan;
 }
 
 void mzSample::saveCurrentRetentionTimes()
 {
-	lastSavedRTs.resize(scans.size());
-	
-	for (unsigned int ii = 0; ii < scans.size(); ii++)
-	{
-		lastSavedRTs[ii] = scans[ii]->rt;
-	}
+    lastSavedRTs.resize(scans.size());
+
+    for (unsigned int ii = 0; ii < scans.size(); ii++) {
+        lastSavedRTs[ii] = scans[ii]->rt;
+    }
 }
 
 void mzSample::restorePreviousRetentionTimes()
 {
-	if (lastSavedRTs.size() == 0) {
-		//restore original RTs if no alignment has been performed
-		for (auto scan : scans) {
-			scan->rt = scan->originalRt;
-		}
-	} else {
-		for (unsigned int ii = 0; ii < scans.size(); ii++) {
-			scans[ii]->rt = lastSavedRTs[ii];
-		}
-	}
+    if (lastSavedRTs.size() == 0) {
+        // restore original RTs if no alignment has been performed
+        for (auto scan : scans) {
+            scan->rt = scan->originalRt;
+        }
+    } else {
+        for (unsigned int ii = 0; ii < scans.size(); ii++) {
+            scans[ii]->rt = lastSavedRTs[ii];
+        }
+    }
 }
 
 vector<Scan*> mzSample::getFragmentationEvents(mzSlice* slice)
 {
     vector<Scan*> matchedScans;
     for (auto scan : scans) {
-        if (scan->mslevel != 2) continue; //ms2 scans only
-        if (scan->rt < slice->rtmin) continue;
-        if (scan->rt > slice->rtmax) break;
-        if( scan->precursorMz >= slice->mzmin && scan->precursorMz <= slice->mzmax) {
+        if (scan->mslevel != 2)
+            continue;  // ms2 + scans only
+        if (scan->rt < slice->rtmin)
+            continue;
+        if (scan->rt > slice->rtmax)
+            break;
+        if (scan->precursorMz >= slice->mzmin
+            && scan->precursorMz <= slice->mzmax) {
             matchedScans.push_back(scan);
         }
     }
@@ -1878,62 +1836,58 @@ vector<Scan*> mzSample::getFragmentationEvents(mzSlice* slice)
 
 vector<float> mzSample::getIntensityDistribution(int mslevel)
 {
+    vector<float> allintensities;
+    for (unsigned int s = 0; s < this->scans.size(); s++) {
+        Scan* scan = this->scans[s];
+        if (scan->mslevel != mslevel)
+            continue;
 
-	vector<float> allintensities;
-	for (unsigned int s = 0; s < this->scans.size(); s++)
-	{
-		Scan *scan = this->scans[s];
-		if (scan->mslevel != mslevel)
-			continue;
+        for (unsigned int i = 0; i < scan->mz.size(); i++) {
+            allintensities.push_back(scan->intensity[i]);
+        }
+    }
 
-		for (unsigned int i = 0; i < scan->mz.size(); i++)
-		{
-			allintensities.push_back(scan->intensity[i]);
-		}
-	}
-
-	return (quantileDistribution(allintensities));
+    return (quantileDistribution(allintensities));
 }
 
 /*
 @author: Sahil
 */
-//TODO: Sahil, Added while merging projectdockwidget
+// TODO: Sahil, Added while merging projectdockwidget
 void mzSample::applyPolynomialTransform()
 {
-	int poly_align_degree = polynomialAlignmentTransformation.size() - 1;
-	if (poly_align_degree <= 0)
-		return;
+    int poly_align_degree = polynomialAlignmentTransformation.size() - 1;
+    if (poly_align_degree <= 0)
+        return;
 
-	double *transform = &polynomialAlignmentTransformation.front();
-	for (unsigned int i = 0; i < scans.size(); i++)
-	{
-		float newrt = leasev(transform, poly_align_degree, scans[i]->rt);
-		//cerr << "applyPolynomialTransform() " << scans[i]->rt << "\t" << newrt << endl;
-		scans[i]->rt = newrt;
-	}
+    double* transform = &polynomialAlignmentTransformation.front();
+    for (unsigned int i = 0; i < scans.size(); i++) {
+        float newrt = leasev(transform, poly_align_degree, scans[i]->rt);
+        // cerr << "applyPolynomialTransform() " << scans[i]->rt << "\t" <<
+        // newrt << endl;
+        scans[i]->rt = newrt;
+    }
 }
 
 mzLink::mzLink()
 {
-	mz1 = mz2 = 0.0;
-	value1 = value2 = 0.0;
-	data1 = data2 = NULL;
-	correlation = 0;
+    mz1 = mz2 = 0.0;
+    value1 = value2 = 0.0;
+    data1 = data2 = NULL;
+    correlation = 0;
 }
 
 mzLink::mzLink(int a, int b, string n) : value1(a), value2(b), note(n)
 {
-	mz1 = mz2 = 0.0;
-	value1 = value2 = 0.0;
-	data1 = data2 = NULL;
-	correlation = 0;
+    mz1 = mz2 = 0.0;
+    value1 = value2 = 0.0;
+    data1 = data2 = NULL;
+    correlation = 0;
 }
 mzLink::mzLink(float a, float b, string n) : mz1(a), mz2(b), note(n)
 {
-	mz1 = mz2 = 0.0;
-	value1 = value2 = 0.0;
-	data1 = data2 = NULL;
-	correlation = 0;
+    mz1 = mz2 = 0.0;
+    value1 = value2 = 0.0;
+    data1 = data2 = NULL;
+    correlation = 0;
 }
-

--- a/src/core/libmaven/mzUtils.cpp
+++ b/src/core/libmaven/mzUtils.cpp
@@ -941,8 +941,6 @@ Series:  Prentice-Hall Series in Automatic Computation
 
         } while (ret == Z_OK);
 
-        cerr << "B..." << "ret=" << ret;
-
         inflateEnd(&zs);
 
         if (ret != Z_STREAM_END) {          // an error occurred that was not EOF
@@ -952,7 +950,6 @@ Series:  Prentice-Hall Series in Automatic Computation
             // throw(std::runtime_error(oss.str()));
         }
 
-        cerr << "C...";
 #endif
         return outstring;
     }

--- a/src/core/libmaven/mzUtils.cpp
+++ b/src/core/libmaven/mzUtils.cpp
@@ -909,8 +909,6 @@ Series:  Prentice-Hall Series in Automatic Computation
         return ( t );
     }
 
-
-    /** Decompress an STL string using zlib and return the original data. */
     std::string decompressString(const std::string& str)
     {
         string outstring;

--- a/src/core/libmaven/mzUtils.cpp
+++ b/src/core/libmaven/mzUtils.cpp
@@ -2,6 +2,9 @@
 #include "SavGolSmoother.h"
 #include "csvparser.h"
 #include "masscutofftype.h"
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
 
 /**
  * random collection of useful functions 
@@ -908,48 +911,17 @@ Series:  Prentice-Hall Series in Automatic Computation
 
 
     /** Decompress an STL string using zlib and return the original data. */
-    std::string decompress_string(const std::string& str)
+    std::string decompressString(const std::string& str)
     {
-        std::string outstring;
-
+        string outstring;
 #ifdef ZLIB
-        z_stream zs;                        // z_stream is zlib's control structure
-        memset(&zs, 0, sizeof(zs));
-
-
-
-        if (inflateInit(&zs) != Z_OK)
-            throw(std::runtime_error("inflateInit failed while decompressing."));
-
-        zs.next_in = (Bytef*)str.data();
-        zs.avail_in = str.size();
-
-        int ret;
-        char outbuffer[32768];
-
-        // get the decompressed bytes blockwise using repeated calls to inflate
-        do {
-            zs.next_out = reinterpret_cast<Bytef*>(outbuffer);
-            zs.avail_out = sizeof(outbuffer);
-
-            ret = inflate(&zs, Z_NO_FLUSH);
-
-            if (outstring.size() < zs.total_out) {
-                outstring.append(outbuffer,
-                        zs.total_out - outstring.size());
-            }
-
-        } while (ret == Z_OK);
-
-        inflateEnd(&zs);
-
-        if (ret != Z_STREAM_END) {          // an error occurred that was not EOF
-            std::ostringstream oss;
-            oss << "Exception during zlib decompression: (" << ret << ") "
-                << zs.msg;
-            // throw(std::runtime_error(oss.str()));
-        }
-
+        stringstream compressed(str);
+        stringstream decompressed;
+        boost::iostreams::filtering_streambuf<boost::iostreams::input> in;
+        in.push(boost::iostreams::zlib_decompressor());
+        in.push(compressed);
+        boost::iostreams::copy(in, decompressed);
+        outstring = decompressed.str();
 #endif
         return outstring;
     }

--- a/src/core/libmaven/mzUtils.h
+++ b/src/core/libmaven/mzUtils.h
@@ -377,7 +377,7 @@ namespace mzUtils {
      * @param  str               []
      * @return []
      */
-    std::string decompress_string(const std::string& str);
+    std::string decompressString(const std::string& str);
 
     /* rounding and ppm functions */
     /**

--- a/src/core/libmaven/mzUtils.h
+++ b/src/core/libmaven/mzUtils.h
@@ -372,10 +372,10 @@ namespace mzUtils {
             std::string& uncompressedBytes);
 
     /**
-     * [decompress_string ]
-     * @method decompress_string
-     * @param  str               []
-     * @return []
+     * @method Decompress an STL string using zlib (deflate) filter of Boost
+     * Iostream library and return uncompressed data.
+     * @param str A STL string containing compressed zlib binary data.
+     * @return An STL string containing uncompressed data.
      */
     std::string decompressString(const std::string& str);
 

--- a/src/core/libmaven/zlib.cpp
+++ b/src/core/libmaven/zlib.cpp
@@ -1,0 +1,200 @@
+// (C) Copyright 2008 CodeRage, LLC (turkanis at coderage dot com)
+// (C) Copyright 2003-2007 Jonathan Turkanis
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt.)
+
+// See http://www.boost.org/libs/iostreams for documentation.
+
+// To configure Boost to work with zlib, see the
+// installation instructions here:
+// http://boost.org/libs/iostreams/doc/index.html?path=7
+
+// Define BOOST_IOSTREAMS_SOURCE so that <boost/iostreams/detail/config.hpp>
+// knows that we are building the library (possibly exporting code), rather
+// than using it (possibly importing code).
+#define BOOST_IOSTREAMS_SOURCE
+
+#include <boost/throw_exception.hpp>
+#include <boost/iostreams/detail/config/dyn_link.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+#include "zlib.h"   // Jean-loup Gailly's and Mark Adler's "zlib.h" header.
+                    // To configure Boost to work with zlib, see the
+                    // installation instructions here:
+                    // http://boost.org/libs/iostreams/doc/index.html?path=7
+
+namespace boost
+{
+namespace iostreams
+{
+namespace zlib
+{
+    // Compression levels
+
+    const int no_compression = Z_NO_COMPRESSION;
+    const int best_speed = Z_BEST_SPEED;
+    const int best_compression = Z_BEST_COMPRESSION;
+    const int default_compression = Z_DEFAULT_COMPRESSION;
+
+    // Compression methods
+
+    const int deflated = Z_DEFLATED;
+
+    // Compression strategies
+
+    const int default_strategy = Z_DEFAULT_STRATEGY;
+    const int filtered = Z_FILTERED;
+    const int huffman_only = Z_HUFFMAN_ONLY;
+
+    // Status codes
+
+    const int okay = Z_OK;
+    const int stream_end = Z_STREAM_END;
+    const int stream_error = Z_STREAM_ERROR;
+    const int version_error = Z_VERSION_ERROR;
+    const int data_error = Z_DATA_ERROR;
+    const int mem_error = Z_MEM_ERROR;
+    const int buf_error = Z_BUF_ERROR;
+
+    // Flush codes
+
+    const int finish = Z_FINISH;
+    const int no_flush = Z_NO_FLUSH;
+    const int sync_flush = Z_SYNC_FLUSH;
+
+    // Code for current OS
+
+    // const int os_code              = OS_CODE;
+
+} // End namespace zlib.
+
+//------------------Implementation of zlib_error------------------------------//
+
+zlib_error::zlib_error(int error)
+    : BOOST_IOSTREAMS_FAILURE("zlib error"), error_(error)
+{
+}
+
+void zlib_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(int error)
+{
+    switch (error) {
+    case Z_OK:
+    case Z_STREAM_END:
+        // case Z_BUF_ERROR:
+        return;
+    case Z_MEM_ERROR:
+        boost::throw_exception(std::bad_alloc());
+    default:
+        boost::throw_exception(zlib_error(error));
+        ;
+    }
+}
+
+//------------------Implementation of zlib_base-------------------------------//
+
+namespace detail
+{
+    zlib_base::zlib_base()
+        : stream_(new z_stream),
+          calculate_crc_(false),
+          crc_(0),
+          crc_imp_(0),
+          total_in_(0),
+          total_out_(0)
+    {
+    }
+
+    zlib_base::~zlib_base() { delete static_cast<z_stream*>(stream_); }
+
+    void zlib_base::before(const char*& src_begin,
+                           const char* src_end,
+                           char*& dest_begin,
+                           char* dest_end)
+    {
+        z_stream* s = static_cast<z_stream*>(stream_);
+        s->next_in =
+            reinterpret_cast<zlib::byte*>(const_cast<char*>(src_begin));
+        s->avail_in = static_cast<zlib::uint>(src_end - src_begin);
+        s->next_out = reinterpret_cast<zlib::byte*>(dest_begin);
+        s->avail_out = static_cast<zlib::uint>(dest_end - dest_begin);
+    }
+
+    void zlib_base::after(const char*& src_begin,
+                          char*& dest_begin,
+                          bool compress)
+    {
+        z_stream* s = static_cast<z_stream*>(stream_);
+        const char* next_in = reinterpret_cast<const char*>(s->next_in);
+        char* next_out = reinterpret_cast<char*>(s->next_out);
+        if (calculate_crc_) {
+            const zlib::byte* buf =
+                compress
+                    ? reinterpret_cast<const zlib::byte*>(src_begin)
+                    : reinterpret_cast<const zlib::byte*>(
+                          const_cast<const char*>(dest_begin));
+            zlib::uint length =
+                compress
+                    ? static_cast<zlib::uint>(next_in - src_begin)
+                    : static_cast<zlib::uint>(next_out - dest_begin);
+            crc_ = crc_imp_ = crc32(crc_imp_, buf, length);
+        }
+        total_in_ = s->total_in;
+        total_out_ = s->total_out;
+        src_begin = next_in;
+        dest_begin = next_out;
+    }
+
+    int zlib_base::xdeflate(int flush)
+    {
+        return ::deflate(static_cast<z_stream*>(stream_), flush);
+    }
+
+    int zlib_base::xinflate(int flush)
+    {
+        return ::inflate(static_cast<z_stream*>(stream_), flush);
+    }
+
+    void zlib_base::reset(bool compress, bool realloc)
+    {
+        z_stream* s = static_cast<z_stream*>(stream_);
+        // Undiagnosed bug:
+        // deflateReset(), etc., return Z_DATA_ERROR
+        // zlib_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
+        realloc ? (compress ? deflateReset(s) : inflateReset(s))
+                : (compress ? deflateEnd(s) : inflateEnd(s));
+        //);
+        crc_imp_ = 0;
+    }
+
+    void zlib_base::do_init(const zlib_params& p,
+                            bool compress,
+                            zlib::xalloc_func /* alloc */,
+                            zlib::xfree_func /* free*/,
+                            void* derived)
+    {
+        calculate_crc_ = p.calculate_crc;
+        z_stream* s = static_cast<z_stream*>(stream_);
+
+        // Current interface for customizing memory management
+        // is non-conforming and has been disabled:
+        //    s->zalloc = alloc;
+        //    s->zfree = free;
+        s->zalloc = 0;
+        s->zfree = 0;
+        s->opaque = derived;
+        int window_bits = p.noheader ? -p.window_bits : p.window_bits;
+        zlib_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
+            compress ? deflateInit2(s,
+                                    p.level,
+                                    p.method,
+                                    window_bits,
+                                    p.mem_level,
+                                    p.strategy)
+                     : inflateInit2(s, window_bits));
+    }
+
+}  // End namespace detail.
+
+//----------------------------------------------------------------------------//
+
+}  // namespace iostreams
+}  // namespace boost

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -378,12 +378,12 @@ mzSample* mzFileIO::parseMzData(QString fileName) {
 
                      if (taglist.at(taglist.size()-2) == "mzArrayBinary") {
                       currentScan->mz=
-                               base64::decode_base64(xml.readElementText().toStdString(),precision/8,false,false);
+                               base64::decodeBase64(xml.readElementText().toStdString(),precision/8,false,false);
                      }
 
                      if (taglist.at(taglist.size()-2) == "intenArrayBinary") {
                         currentScan->intensity =
-                                base64::decode_base64(xml.readElementText().toStdString(),precision/8,false,false);
+                                base64::decodeBase64(xml.readElementText().toStdString(),precision/8,false,false);
                      }
                 }
 

--- a/tests/MavenTests/testbase64.cpp
+++ b/tests/MavenTests/testbase64.cpp
@@ -25,11 +25,10 @@ void Testbase64::cleanup() {
     // This function is executed after each test
 }
 
-void Testbase64::testdecode_base64() {
-
+void Testbase64::testdecodeBase64()
+{
     string b64String="Qowh+kUQcBVCjCYG";
-    vector<float> decodedArray =
-        base64::decode_base64(b64String, 4, true, false);
+    vector<float> decodedArray = base64::decodeBase64(b64String, 4, true, false);
 
     QVERIFY(decodedArray.size()==3);
     QVERIFY(TestUtils::floatCompare(decodedArray[0],70.0663604736328));
@@ -37,39 +36,11 @@ void Testbase64::testdecode_base64() {
     QVERIFY(TestUtils::floatCompare(decodedArray[2],70.0742645263672));
 }
 
-void Testbase64::testencode_base64() {
-
-    vector<float> decodedArray(3);
-    decodedArray[0]=70.0663604736328;
-    decodedArray[1]=2311.00512695312;
-    decodedArray[2]=70.0742645263672;
-
-    unsigned char* out=base64::encode_base64(decodedArray);
-
-    QVERIFY(out[0]=='+');
-    QVERIFY(out[1]=='i');
-    QVERIFY(out[2]=='G');
-    QVERIFY(out[3]=='M');
-    QVERIFY(out[4]=='Q');
-    QVERIFY(out[5]=='h');
-    QVERIFY(out[6]=='V');
-    QVERIFY(out[7]=='w');
-    QVERIFY(out[8]=='E');
-    QVERIFY(out[9]=='E');
-    QVERIFY(out[10]=='U');
-    QVERIFY(out[11]=='G');
-    QVERIFY(out[12]=='J');
-    QVERIFY(out[13]=='o');
-    QVERIFY(out[14]=='x');
-    QVERIFY(out[15]=='C');
-
-}
-
-void Testbase64::testdecodeString() {
-
+void Testbase64::testdecodeString()
+{
     string b64String="bWF2ZW4gaXMgYXdlc29tZQ==";
 
-    char *dest = base64::decodeString(b64String);
+    string dest = base64::decodeString(b64String.c_str(), b64String.size());
 
     QVERIFY((unsigned char)dest[0]=='m');
     QVERIFY((unsigned char)dest[1]=='a');
@@ -87,37 +58,5 @@ void Testbase64::testdecodeString() {
     QVERIFY((unsigned char)dest[13]=='o');
     QVERIFY((unsigned char)dest[14]=='m');
     QVERIFY((unsigned char)dest[15]=='e');
-
-}
-
-void Testbase64::testencodeString() {
-
-    unsigned char arr[17]={'m','a','v','e','n',' ','i','s',' ','a','w','e','s','o','m','e'};
-    unsigned char *src=arr;
-
-    unsigned char *dest=base64::encodeString(src,16);
-
-    QVERIFY((unsigned char)dest[0]=='b');
-    QVERIFY((unsigned char)dest[1]=='W');
-    QVERIFY((unsigned char)dest[2]=='F');
-    QVERIFY((unsigned char)dest[3]=='2');
-    QVERIFY((unsigned char)dest[4]=='Z');
-    QVERIFY((unsigned char)dest[5]=='W');
-    QVERIFY((unsigned char)dest[6]=='4');
-    QVERIFY((unsigned char)dest[7]=='g');
-    QVERIFY((unsigned char)dest[8]=='a');
-    QVERIFY((unsigned char)dest[9]=='X');
-    QVERIFY((unsigned char)dest[10]=='M');
-    QVERIFY((unsigned char)dest[11]=='g');
-    QVERIFY((unsigned char)dest[12]=='Y');
-    QVERIFY((unsigned char)dest[13]=='X');
-    QVERIFY((unsigned char)dest[14]=='d');
-    QVERIFY((unsigned char)dest[15]=='l');
-    QVERIFY((unsigned char)dest[16]=='c');
-    QVERIFY((unsigned char)dest[17]=='2');
-    QVERIFY((unsigned char)dest[18]=='9');
-    QVERIFY((unsigned char)dest[19]=='t');
-    QVERIFY((unsigned char)dest[20]=='Z');
-    QVERIFY((unsigned char)dest[21]=='Q');
 
 }

--- a/tests/MavenTests/testbase64.h
+++ b/tests/MavenTests/testbase64.h
@@ -26,11 +26,8 @@ class Testbase64 : public QObject {
 
         // test functions - all functions prefixed with "test" will be ran as tests
         // this is automatically detected thanks to Qt's meta-information about QObjects
-        void testdecode_base64();
+        void testdecodeBase64();
         void testdecodeString();
-        void testencode_base64();
-        void testencodeString();
-
 };
 
 #endif // TESTBASE64_H


### PR DESCRIPTION
Decompression of zlib encoded data strings from sample files has not been possible for a long time. This issue has already been fixed in the upstream MAVEN project, by using a new base64 decoding
function that returns a string and then simply passing this string to the decompression function in mzUtils (if decompression is needed at all). This bypasses the original implementation where a
lot of raw buffer manipulation was being done before sending the string to the decompression function. The same mechanism will not be used in El-MAVEN.

Also part of this PR are the following related changes:
 - Remove unrequired methods from the base64 namespace.
 - Add checks for compression status in MzML files.
 -  Add ZLIB macro definitions to all platforms.
 - Use a Boost (iostreams) library for safe decompression of binary data.
