### PR TITLE
Use correct path for loading model files

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -230,7 +230,7 @@ using namespace mzUtils;
     QString appDir;
 
     #if defined(Q_OS_WIN) || defined(Q_OS_LINUX)
-        appDir =  QDir::cleanPath(QApplication::applicationDirPath() + QDir::separator());
+        appDir =  QDir::cleanPath(QApplication::applicationDirPath()) + QDir::separator();
     #endif
 
     #if defined(Q_OS_MAC)


### PR DESCRIPTION
El-MAVEN could not load the model files on Windows/Linux systems because of a missing separator in the file paths. This has been fixed in this PR.