### PR TITLE
Fix logout not resetting username label

### DIFF
--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -748,6 +748,7 @@ QStringList PollyElmavenInterfaceDialog::_prepareFilesToUpload(QDir qdir,
 
 void PollyElmavenInterfaceDialog::_logout()
 {
+    usernameLabel->setText("");
     _pollyIntegration->logout();
     _projectNameIdMap = QVariantMap();
     close();


### PR DESCRIPTION
The username label on EPI dialog is used for sending email to the user. This label was not reset after logging out, resulting in all emails from a switched session to be sent to the previously logged in user. This has been fixed.