### PR TITLE
Support for mzrollDB format

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1107,7 +1107,7 @@ void MainWindow::saveProjectForFilename(bool tablesOnly)
 {
     if (fileLoader->isMzRollProject(_currentProjectName)) {
         _saveAllTablesAsMzRoll();
-    } else if (fileLoader->isSQLiteProject(_currentProjectName)) {
+    } else if (fileLoader->isEmdbProject(_currentProjectName)) {
         if (tablesOnly) {
             auto allTables = getPeakTableList();
             allTables.append(bookmarkedPeaks);
@@ -1707,8 +1707,8 @@ void MainWindow::open()
         this,
         "Select projects, peaks, samples to open:",
         dir,
-        tr("All Known Formats(*.mzroll *.emDB *.mzPeaks *.mzXML *.mzxml "
-           "*.mzdata *.mzData *.mzData.xml *.cdf *.nc *.mzML);;")
+        tr("All Known Formats(*.mzroll *.emDB *mzrollDB *.mzPeaks *.mzXML "
+           "*.mzxml *.mzdata *.mzData *.mzData.xml *.cdf *.nc *.mzML);;")
             + tr("mzXML Format(*.mzXML *.mzxml);;")
             + tr("mzData Format(*.mzdata *.mzData *.mzData.xml);;")
             + tr("mzML Format(*.mzml *.mzML);;")
@@ -1740,11 +1740,13 @@ void MainWindow::open()
                    + " "
                    + fileInfo.fileName());
 
-    QString sqliteProjectBeingLoaded = "";
+    QString emdbProjectBeingLoaded = "";
     Q_FOREACH (QString filename, filelist) {
-        if (fileLoader->isSQLiteProject(filename)) {
-            sqliteProjectBeingLoaded = filename;
+        if (fileLoader->isEmdbProject(filename)) {
+            emdbProjectBeingLoaded = filename;
             analytics->hitEvent("Project Load", "emDB");
+        } else if (fileLoader->isMzrollDbProject(filename)) {
+            analytics->hitEvent("Project Load", "mzrollDB");
         } else if (fileLoader->isMzRollProject(filename)) {
             analytics->hitEvent("Project Load", "mzroll");
         }
@@ -1752,9 +1754,9 @@ void MainWindow::open()
         fileLoader->addFileToQueue(filename);
     }
 
-    if (!sqliteProjectBeingLoaded.isEmpty()) {
+    if (!emdbProjectBeingLoaded.isEmpty()) {
         projectDockWidget->saveAndCloseCurrentSQLiteProject();
-        _latestUserProjectName = sqliteProjectBeingLoaded;
+        _latestUserProjectName = emdbProjectBeingLoaded;
 
         // reset filename in the title to overwrite any saves while closing last
         // SQLite project

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1746,6 +1746,8 @@ void MainWindow::open()
             emdbProjectBeingLoaded = filename;
             analytics->hitEvent("Project Load", "emDB");
         } else if (fileLoader->isMzrollDbProject(filename)) {
+            emdbProjectBeingLoaded = fileLoader->swapFilenameExtension(filename,
+                                                                       "emDB");
             analytics->hitEvent("Project Load", "mzrollDB");
         } else if (fileLoader->isMzRollProject(filename)) {
             analytics->hitEvent("Project Load", "mzroll");

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1707,7 +1707,7 @@ void MainWindow::open()
         this,
         "Select projects, peaks, samples to open:",
         dir,
-        tr("All Known Formats(*.mzroll *.emDB *mzrollDB *.mzPeaks *.mzXML "
+        tr("All Known Formats(*.mzroll *.emDB *.mzrollDB *.mzPeaks *.mzXML "
            "*.mzxml *.mzdata *.mzData *.mzData.xml *.cdf *.nc *.mzML);;")
             + tr("mzXML Format(*.mzXML *.mzxml);;")
             + tr("mzData Format(*.mzdata *.mzData *.mzData.xml);;")

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -1008,8 +1008,19 @@ void mzFileIO::_postSampleLoadOperations()
             if (t->windowTitle() == tableName)
                 table = t;
 
-        if (!table && tableName != _mainwindow->bookmarkedPeaks->windowTitle())
-            _mainwindow->addPeaksTable();
+        if (!table
+            && tableName != _mainwindow->bookmarkedPeaks->windowTitle()) {
+            int customTableId = 0;
+            // attempt to extract out peak table ID from its name, assuming ID
+            // is at the end of the title passed
+            auto stringList = tableName.split(QRegExp("\\s+"),
+                                              QString::SkipEmptyParts);
+            if (stringList.size()) {
+                auto idString = stringList[stringList.size() - 1].toStdString();
+                customTableId = std::stoi(idString);
+            }
+            _mainwindow->addPeaksTable(customTableId);
+        }
     }
 
     _sqliteDBLoadInProgress = true;

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -809,11 +809,7 @@ QString mzFileIO::openSQLiteProject(QString filename)
     // new emDB file and then open that project for use in El-MAVEN.
     QString openedFilename = filename;
     if (isMzrollDbProject(filename)) {
-        QFileInfo fileInfo(filename);
-        QDir parentDir = QDir(fileInfo.path());
-        QString baseName = fileInfo.completeBaseName();
-        openedFilename = parentDir.filePath(baseName + ".emDB");
-        qDebug() << openedFilename;
+        openedFilename = swapFilenameExtension(filename, "emDB");
         MzrollDbConverter::convertLegacyToCurrent(filename.toStdString(),
                                                   openedFilename.toStdString());
     }
@@ -1018,6 +1014,16 @@ void mzFileIO::_postSampleLoadOperations()
 
     _sqliteDBLoadInProgress = true;
     start();
+}
+
+QString mzFileIO::swapFilenameExtension(QString filename, QString ext)
+{
+    QString newFilename = filename;
+    QFileInfo fileInfo(filename);
+    QDir parentDir = QDir(fileInfo.path());
+    QString baseName = fileInfo.completeBaseName();
+    newFilename = parentDir.filePath(baseName + "." + ext);
+    return newFilename;
 }
 
 void mzFileIO::markv_0_1_5mzroll(QString fileName)

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -778,13 +778,13 @@ bool mzFileIO::writeSQLiteProject(QString filename)
         for (const auto& peakTable : allTablesList) {
             for (PeakGroup* group : peakTable->getGroups()) {
                 topLevelGroupCount++;
-                string tableName = peakTable->windowTitle().toStdString();
                 groupVector.push_back(group);
                 if (group->compound)
                     compoundSet.insert(group->compound);
             }
-            _currentProject->saveGroups(groupVector,
-                                        peakTable->windowTitle().toStdString());
+            string tableName = peakTable->titlePeakTable
+                                        ->text().toStdString();
+            _currentProject->saveGroups(groupVector, tableName);
             groupVector.clear();
         }
         _currentProject->saveCompounds(compoundSet);

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -155,6 +155,15 @@ Q_OBJECT
         QString openSQLiteProject(QString filename);
 
         /**
+         * @brief Create a new file name from the given file name, with its
+         * extension changed.
+         * @param filename The name of the file, to be used as a template.
+         * @param ext The new extension to be replaced in the given filename.
+         * @return A new filename with the given extension.
+         */
+        QString swapFilenameExtension(QString filename, QString ext);
+
+        /**
          * @brief For making old mzroll compatible, this will act as a flag
          * whether loaded mzroll file is old or new one. this will be set by
          * class method <markv_0_1_5mzroll>

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -103,7 +103,15 @@ Q_OBJECT
          * @return true if the filename ends with ".emDB" extension, false
          * otherwise
          */
-        bool isSQLiteProject(QString filename);
+        bool isEmdbProject(QString filename);
+
+        /**
+         * @brief Check whether the filename ends with a ".mzrollDB" extension.
+         * @param filename String name of the file to be checked.
+         * @return true if the filename ends with ".mzrollDB" extension, false
+         * otherwise
+         */
+        bool isMzrollDbProject(QString filename);
 
         /**
          * @brief Check if a SQLite project is currently open.
@@ -138,9 +146,13 @@ Q_OBJECT
 
         /**
          * @brief Create a `ProjectDatabase` instance for the given filename.
+         * @details If the filename passed is of the type "mzrollDB", then a
+         * conversion is made into a new emDB file and then this file is set
+         * as the current project.
          * @param filename Name of SQLite project to be set as `currentProject`.
+         * @return Return the filename of the opened project.
          */
-        void openSQLiteProject(QString filename);
+        QString openSQLiteProject(QString filename);
 
         /**
          * @brief For making old mzroll compatible, this will act as a flag

--- a/src/projectDB/mzrolldbconverter.cpp
+++ b/src/projectDB/mzrolldbconverter.cpp
@@ -1,0 +1,508 @@
+#include <boost/filesystem.hpp>
+
+#include "connection.h"
+#include "cursor.h"
+#include "mzrolldbconverter.h"
+#include "schema.h"
+
+using namespace std;
+
+namespace bfs = boost::filesystem;
+
+void MzrollDbConverter::convertLegacyToCurrent(const string& fromPath,
+                                               const string& toPath)
+{
+    bfs::path originalPath(fromPath);
+    bfs::path newPath(toPath);
+    if (!bfs::exists(fromPath))
+        return;
+
+    cerr << "Converting provided mzrollDb to emDb…" << endl;
+
+    Connection mzrollDb(fromPath);
+    Connection emDb(toPath);
+
+    copySamples(mzrollDb, emDb);
+    copyScans(mzrollDb, emDb);
+    copyPeakgroups(mzrollDb, emDb);
+    copyPeaks(mzrollDb, emDb);
+    copyCompounds(mzrollDb, emDb);
+    copyAlignmentData(mzrollDb, emDb);
+    setVersion(emDb, 1);
+}
+
+void MzrollDbConverter::copySamples(Connection &mzrollDb, Connection &emDb)
+{
+    if (!emDb.prepare(CREATE_SAMPLES_TABLE)->execute()) {
+        cerr << "Error: failed to create samples table" << endl;
+        return;
+    }
+
+    auto writeQuery = emDb.prepare(
+        "INSERT INTO samples         \
+              VALUES ( :sample_id    \
+                     , :name         \
+                     , :filename     \
+                     , :set_name     \
+                     , :sample_order \
+                     , :is_blank     \
+                     , :is_selected  \
+                     , :color_red    \
+                     , :color_green  \
+                     , :color_blue   \
+                     , :color_alpha  \
+                     , :norml_const  \
+                     , :transform_a0 \
+                     , :transform_a1 \
+                     , :transform_a2 \
+                     , :transform_a4 \
+                     , :transform_a5 )");
+
+    auto readQuery = mzrollDb.prepare("SELECT *       \
+                                         FROM samples ");
+
+    emDb.begin();
+    while (readQuery->next()) {
+        writeQuery->bind(":sample_id",
+                         readQuery->integerValue("sampleId"));
+        writeQuery->bind(":name",
+                         readQuery->stringValue("name"));
+        writeQuery->bind(":filename",
+                         readQuery->stringValue("filename"));
+        writeQuery->bind(":set_name",
+                         readQuery->stringValue("setName"));
+        writeQuery->bind(":sample_order",
+                         readQuery->integerValue("sampleOrder"));
+        writeQuery->bind(":is_blank",
+                         0);
+        writeQuery->bind(":is_selected",
+                         readQuery->integerValue("isSelected"));
+        writeQuery->bind(":color_red",
+                         readQuery->floatValue("color_red"));
+        writeQuery->bind(":color_green",
+                         readQuery->floatValue("color_green"));
+        writeQuery->bind(":color_blue",
+                         readQuery->floatValue("color_blue"));
+        writeQuery->bind(":color_alpha",
+                         readQuery->floatValue("color_alpha"));
+        writeQuery->bind(":normal_const",
+                         readQuery->floatValue("norml_const"));
+        writeQuery->bind(":transform_a0",
+                         readQuery->floatValue("transform_a0"));
+        writeQuery->bind(":transform_a1",
+                         readQuery->floatValue("transform_a1"));
+        writeQuery->bind(":transform_a2",
+                         readQuery->floatValue("transform_a2"));
+        writeQuery->bind(":transform_a4",
+                         readQuery->floatValue("transform_a4"));
+        writeQuery->bind(":transform_a5",
+                         readQuery->floatValue("transform_a5"));
+
+        if (!writeQuery->execute())
+            cerr << "Error: failed to save sample" << endl;
+    }
+    emDb.commit();
+}
+
+void MzrollDbConverter::copyScans(Connection &mzrollDb, Connection &emDb)
+{
+    if(!emDb.prepare(CREATE_SCANS_TABLE)->execute()) {
+        cerr << "Error: failed to create scans table" << endl;
+        return;
+    }
+
+    auto writeQuery = emDb.prepare(
+        "INSERT INTO scans               \
+              VALUES ( :sample_id        \
+                     , :scan             \
+                     , :file_seek_start  \
+                     , :file_seek_end    \
+                     , :mslevel          \
+                     , :rt               \
+                     , :precursor_mz     \
+                     , :precursor_charge \
+                     , :precursor_ic     \
+                     , :precursor_purity \
+                     , :minmz            \
+                     , :maxmz            \
+                     , :data             )");
+
+    auto readQuery = mzrollDb.prepare("SELECT *     \
+                                         FROM scans ");
+
+    emDb.begin();
+    while (readQuery->next()) {
+        writeQuery->bind(":sample_id",
+                         readQuery->integerValue("sampleId"));
+        writeQuery->bind(":scan",
+                         readQuery->integerValue("scan"));
+        writeQuery->bind(":file_seek_start",
+                         readQuery->integerValue("fileSeekStart"));
+        writeQuery->bind(":file_seek_end",
+                         readQuery->integerValue("fileSeekEnd"));
+        writeQuery->bind(":mslevel",
+                         readQuery->integerValue("mslevel"));
+        writeQuery->bind(":rt",
+                         readQuery->floatValue("rt"));
+        writeQuery->bind(":precursor_mz",
+                         readQuery->floatValue("precursorMz"));
+        writeQuery->bind(":precursor_charge",
+                         readQuery->integerValue("precursorCharge"));
+        writeQuery->bind(":precursor_ic",
+                         readQuery->floatValue("precursorIc"));
+        writeQuery->bind(":precursor_purity",
+                         readQuery->floatValue("precursorPurity"));
+        writeQuery->bind(":minmz",
+                         readQuery->floatValue("minmz"));
+        writeQuery->bind(":maxmz",
+                         readQuery->floatValue("maxmz"));
+        writeQuery->bind(":data",
+                         readQuery->stringValue("data"));
+
+        if (!writeQuery->execute())
+            cerr << "Error: failed to save scan" << endl;
+    }
+    emDb.commit();
+}
+
+void MzrollDbConverter::copyPeakgroups(Connection &mzrollDb, Connection &emDb)
+{
+    if(!emDb.prepare(CREATE_PEAK_GROUPS_TABLE)->execute()) {
+        cerr << "Error: failed to create peakgroups table" << endl;
+        return;
+    }
+
+    auto writeQuery = emDb.prepare(
+        "INSERT INTO peakgroups                            \
+              VALUES ( :group_id                           \
+                     , :parent_group_id                    \
+                     , :meta_group_id                      \
+                     , :tag_string                         \
+                     , :expected_mz                        \
+                     , :expected_abundance                 \
+                     , :expected_rt_diff                   \
+                     , :group_rank                         \
+                     , :label                              \
+                     , :type                               \
+                     , :srm_id                             \
+                     , :ms2_event_count                    \
+                     , :ms2_score                          \
+                     , :adduct_name                        \
+                     , :compound_id                        \
+                     , :compound_name                      \
+                     , :compound_db                        \
+                     , :table_name                         \
+                     , :min_quality                        \
+                     , :fragmentation_fraction_matched     \
+                     , :fragmentation_mz_frag_error        \
+                     , :fragmentation_hypergeom_score      \
+                     , :fragmentation_mvh_score            \
+                     , :fragmentation_dot_product          \
+                     , :fragmentation_weighted_dot_product \
+                     , :fragmentation_spearman_rank_corr   \
+                     , :fragmentation_tic_matched          \
+                     , :fragmentation_num_matches          \
+                     , :sample_ids                         )");
+
+    auto readQuery = mzrollDb.prepare("SELECT *          \
+                                         FROM peakgroups ");
+
+    emDb.begin();
+    while (readQuery->next()) {
+        writeQuery->bind(":group_id",
+                         readQuery->integerValue("groupId"));
+        writeQuery->bind(":parent_group_id",
+                         readQuery->integerValue("parentGroupId"));
+        writeQuery->bind(":meta_group_id",
+                         readQuery->integerValue("metaGroupId"));
+        writeQuery->bind(":tag_string",
+                         readQuery->stringValue("tagString"));
+        writeQuery->bind(":expected_mz",
+                         0.0);
+        writeQuery->bind(":expected_abundance",
+                         0.0);
+        writeQuery->bind(":expected_rt_diff",
+                         readQuery->floatValue("expectedRtDiff"));
+        writeQuery->bind(":group_rank",
+                         readQuery->floatValue("groupRank"));
+        writeQuery->bind(":label",
+                         readQuery->stringValue("label"));
+        writeQuery->bind(":type",
+                         readQuery->integerValue("type"));
+        writeQuery->bind(":srm_id",
+                         readQuery->stringValue("srmId"));
+        writeQuery->bind(":ms2_event_count",
+                         readQuery->integerValue("ms2EventCount"));
+        writeQuery->bind(":ms2_score",
+                         readQuery->floatValue("ms2Score"));
+        writeQuery->bind(":adduct_name",
+                         readQuery->stringValue("adductName"));
+        writeQuery->bind(":compound_id",
+                         readQuery->stringValue("compoundId"));
+        writeQuery->bind(":compound_name",
+                         readQuery->stringValue("compoundName"));
+        writeQuery->bind(":compound_db",
+                         readQuery->stringValue("compoundDB"));
+        writeQuery->bind(":table_name",
+                         readQuery->stringValue("searchTableName"));
+
+        if (!writeQuery->execute())
+            cerr << "Error: failed to save peak group" << endl;
+    }
+    emDb.commit();
+    emDb.prepare(CREATE_PEAKS_GROUP_INDEX)->execute();
+
+    // rename all peak tables to be compatible with El-MAVEN
+    auto tableReadQuery = emDb.prepare("SELECT DISTINCT table_name \
+                                                   FROM peakgroups ");
+    vector<string> tables;
+    while (tableReadQuery->next()) {
+        auto table = tableReadQuery->stringValue("table_name");
+        if (!table.empty())
+            tables.push_back(table);
+    }
+    auto tableWriteQuery = emDb.prepare("UPDATE peakgroups                   \
+                                            SET table_name = :new_table_name \
+                                          WHERE table_name = :old_table_name ");
+    emDb.begin();
+    int peakTableCount = 0;
+    for (auto table : tables) {
+        string newTable = "Peak Table " + to_string(++peakTableCount);
+        tableWriteQuery->bind(":old_table_name", table);
+        tableWriteQuery->bind(":new_table_name", newTable);
+        tableWriteQuery->execute();
+    }
+    emDb.commit();
+}
+
+void MzrollDbConverter::copyPeaks(Connection &mzrollDb, Connection &emDb)
+{
+    if(!emDb.prepare(CREATE_PEAKS_TABLE)->execute()) {
+        cerr << "Error: failed to create peaks table" << endl;
+        return;
+    }
+
+    auto writeQuery = emDb.prepare(
+        "INSERT INTO peaks                      \
+              VALUES ( :peak_id                 \
+                     , :group_id                \
+                     , :sample_id               \
+                     , :pos                     \
+                     , :minpos                  \
+                     , :maxpos                  \
+                     , :rt                      \
+                     , :rtmin                   \
+                     , :rtmax                   \
+                     , :mzmin                   \
+                     , :mzmax                   \
+                     , :scan                    \
+                     , :minscan                 \
+                     , :maxscan                 \
+                     , :peak_area               \
+                     , :peak_area_corrected     \
+                     , :peak_area_top           \
+                     , :peak_area_top_corrected \
+                     , :peak_area_fractional    \
+                     , :peak_rank               \
+                     , :peak_intensity          \
+                     , :peak_baseline_level     \
+                     , :peak_mz                 \
+                     , :median_mz               \
+                     , :base_mz                 \
+                     , :quality                 \
+                     , :width                   \
+                     , :gauss_fit_sigma         \
+                     , :gauss_fit_r2            \
+                     , :no_noise_obs            \
+                     , :no_noise_fraction       \
+                     , :symmetry                \
+                     , :signal_baseline_ratio   \
+                     , :group_overlap           \
+                     , :group_overlap_frac      \
+                     , :local_max_flag          \
+                     , :from_blank_sample       \
+                     , :label                   \
+                     , :peak_spline_area        )");
+
+    auto readQuery = mzrollDb.prepare("SELECT *     \
+                                         FROM peaks ");
+
+    emDb.begin();
+    while (readQuery->next()) {
+        writeQuery->bind(":peak_id",
+                         readQuery->integerValue("peakId"));
+        writeQuery->bind(":group_id",
+                         readQuery->integerValue("groupId"));
+        writeQuery->bind(":sample_id",
+                         readQuery->integerValue("sampleId"));
+        writeQuery->bind(":pos",
+                         readQuery->integerValue("pos"));
+        writeQuery->bind(":minpos",
+                         readQuery->integerValue("minpos"));
+        writeQuery->bind(":maxpos",
+                         readQuery->integerValue("maxpos"));
+        writeQuery->bind(":rt",
+                         readQuery->floatValue("rt"));
+        writeQuery->bind(":rtmin",
+                         readQuery->floatValue("rtmin"));
+        writeQuery->bind(":rtmax",
+                         readQuery->floatValue("rtmax"));
+        writeQuery->bind(":mzmin",
+                         readQuery->floatValue("mzmin"));
+        writeQuery->bind(":mzmax",
+                         readQuery->floatValue("mzmax"));
+        writeQuery->bind(":scan",
+                         readQuery->integerValue("scan"));
+        writeQuery->bind(":minscan",
+                         readQuery->integerValue("minscan"));
+        writeQuery->bind(":maxscan",
+                         readQuery->integerValue("maxscan"));
+        writeQuery->bind(":peak_area",
+                         readQuery->floatValue("peakArea"));
+        writeQuery->bind(":peak_area_corrected",
+                         readQuery->floatValue("peakAreaCorrected"));
+        writeQuery->bind(":peak_area_top",
+                         readQuery->floatValue("peakAreaTop"));
+        writeQuery->bind(":peak_area_top_corrected",
+                         0.0);
+        writeQuery->bind(":peak_area_fractional",
+                         readQuery->floatValue("peakAreaFractional"));
+        writeQuery->bind(":peak_rank",
+                         readQuery->floatValue("peakRank"));
+        writeQuery->bind(":peak_intensity",
+                         readQuery->floatValue("peakIntensity"));
+        writeQuery->bind(":peak_baseline_level",
+                         readQuery->floatValue("peakBaseLineLevel"));
+        writeQuery->bind(":peak_mz",
+                         readQuery->floatValue("peakMz"));
+        writeQuery->bind(":median_mz",
+                         readQuery->floatValue("medianMz"));
+        writeQuery->bind(":base_mz",
+                         readQuery->floatValue("baseMz"));
+        writeQuery->bind(":quality",
+                         readQuery->floatValue("quality"));
+        writeQuery->bind(":width",
+                         readQuery->integerValue("width"));
+        writeQuery->bind(":gauss_fit_sigma",
+                         readQuery->floatValue("gaussFitSigma"));
+        writeQuery->bind(":gauss_fit_r2",
+                         readQuery->floatValue("gaussFitR2"));
+        writeQuery->bind(":no_noise_obs",
+                         readQuery->integerValue("noNoiseObs"));
+        writeQuery->bind(":no_noise_fraction",
+                         readQuery->floatValue("noNoiseFraction"));
+        writeQuery->bind(":symmetry",
+                         readQuery->floatValue("symmetry"));
+        writeQuery->bind(":signal_baseline_ratio",
+                         readQuery->floatValue("signalBaselineRatio"));
+        writeQuery->bind(":group_overlap",
+                         readQuery->floatValue("groupOverlap"));
+        writeQuery->bind(":group_overlap_frac",
+                         readQuery->floatValue("groupOverlapFrac"));
+        writeQuery->bind(":local_max_flag",
+                         readQuery->floatValue("localMaxFlag"));
+        writeQuery->bind(":from_blank_sample",
+                         readQuery->integerValue("fromBlankSample"));
+        writeQuery->bind(":label",
+                         readQuery->integerValue("label"));
+
+        if (!writeQuery->execute())
+            cerr << "Error: failed to save peak" << endl;
+    }
+    emDb.commit();
+}
+
+void MzrollDbConverter::copyCompounds(Connection &mzrollDb, Connection &emDb)
+{
+    if (!emDb.prepare(CREATE_COMPOUNDS_TABLE)->execute()) {
+        cerr << "Error: failed to create compounds table" << endl;
+        return;
+    }
+
+    auto writeQuery = emDb.prepare(
+        "INSERT INTO compounds                 \
+               VALUES ( :compound_id           \
+                      , :db_name               \
+                      , :name                  \
+                      , :formula               \
+                      , :smile_string          \
+                      , :srm_id                \
+                      , :mass                  \
+                      , :charge                \
+                      , :expected_rt           \
+                      , :precursor_mz          \
+                      , :product_mz            \
+                      , :collision_energy      \
+                      , :log_p                 \
+                      , :virtual_fragmentation \
+                      , :ionization_mode       \
+                      , :category              \
+                      , :fragment_mzs          \
+                      , :fragment_intensity    \
+                      , :fragment_ion_types    \
+                      , :note                  )");
+
+    auto readQuery = mzrollDb.prepare("SELECT *         \
+                                         FROM compounds ");
+
+    emDb.begin();
+    while (readQuery->next()) {
+        writeQuery->bind(":compound_id",
+                         readQuery->stringValue("compoundId"));
+        writeQuery->bind(":db_name",
+                         readQuery->stringValue("dbName"));
+        writeQuery->bind(":name",
+                         readQuery->stringValue("name"));
+        writeQuery->bind(":formula",
+                         readQuery->stringValue("formula"));
+        writeQuery->bind(":smile_string",
+                         readQuery->stringValue("smileString"));
+        writeQuery->bind(":srm_id",
+                         readQuery->stringValue("srmId"));
+        writeQuery->bind(":mass",
+                         readQuery->floatValue("mass"));
+        writeQuery->bind(":charge",
+                         readQuery->integerValue("charge"));
+        writeQuery->bind(":expected_rt",
+                         readQuery->floatValue("expectedRt"));
+        writeQuery->bind(":precursor_mz",
+                         readQuery->floatValue("precursorMz"));
+        writeQuery->bind(":product_mz",
+                         readQuery->floatValue("productMz"));
+        writeQuery->bind(":collision_energy",
+                         readQuery->floatValue("collisionEnergy"));
+        writeQuery->bind(":log_p",
+                         readQuery->floatValue("logP"));
+        writeQuery->bind(":virtual_fragmentation",
+                         readQuery->integerValue("virtualFragmentation"));
+        writeQuery->bind(":ionization_mode",
+                         readQuery->integerValue("ionizationMode"));
+        writeQuery->bind(":category",
+                         readQuery->stringValue("category"));
+        writeQuery->bind(":fragment_mzs",
+                         readQuery->stringValue("fragment_mzs"));
+        writeQuery->bind(":fragment_intensity",
+                         readQuery->stringValue("fragment_intensity"));
+
+        if (!writeQuery->execute())
+            cerr << "Error: failed to save compound" << endl;
+    }
+    emDb.commit();
+    emDb.prepare(CREATE_COMPOUNDS_DB_INDEX)->execute();
+}
+
+void MzrollDbConverter::copyAlignmentData(Connection &mzrollDb,
+                                          Connection &emDb)
+{
+    if (!emDb.prepare(CREATE_ALIGNMENT_TABLE)->execute()) {
+        cerr << "Error: failed to create alignment_rts table" << endl;
+        return;
+    }
+    cerr << "Warning: unable to convert alignment data from mzrollDb" << endl;
+}
+
+void MzrollDbConverter::setVersion(Connection &emDb, int version)
+{
+    auto query = emDb.prepare("PRAGMA user_version = " + to_string(version));
+    query->execute();
+}

--- a/src/projectDB/mzrolldbconverter.cpp
+++ b/src/projectDB/mzrolldbconverter.cpp
@@ -3,6 +3,7 @@
 #include "connection.h"
 #include "cursor.h"
 #include "mzrolldbconverter.h"
+#include "mzUtils.h"
 #include "schema.h"
 
 using namespace std;
@@ -66,7 +67,7 @@ void MzrollDbConverter::copySamples(Connection &mzrollDb, Connection &emDb)
         writeQuery->bind(":sample_id",
                          readQuery->integerValue("sampleId"));
         writeQuery->bind(":name",
-                         readQuery->stringValue("name"));
+                         mzUtils::cleanFilename(readQuery->stringValue("name")));
         writeQuery->bind(":filename",
                          readQuery->stringValue("filename"));
         writeQuery->bind(":set_name",

--- a/src/projectDB/mzrolldbconverter.h
+++ b/src/projectDB/mzrolldbconverter.h
@@ -1,0 +1,67 @@
+#ifndef MZROLLDBCONVERTER_H
+#define MZROLLDBCONVERTER_H
+
+namespace MzrollDbConverter
+{
+    /**
+     * @brief This function helps convert an mzrollDB file to an emDB file.
+     * @details The file that is converted will not be modified, instead a new
+     * emDB file is created into which the data is copied.
+     * @param fromPath The path of an mzrollDB file (that has to be converted).
+     * @param toPath The path of an emDB file (in which converted data will be
+     * stored).
+     */
+    void convertLegacyToCurrent(const std::string& fromPath,
+                                const std::string& toPath);
+
+    /**
+     * @brief Copy samples from a given mzrollDB to emDB.
+     * @param mzrollDb Database connection to an mzrollDB file.
+     * @param emDb Database connection to an emDB file.
+     */
+    void copySamples(Connection& mzrollDb, Connection& emDb);
+
+    /**
+     * @brief Copy scans from a given mzrollDB to emDB.
+     * @param mzrollDb Database connection to an mzrollDB file.
+     * @param emDb Database connection to an emDB file.
+     */
+    void copyScans(Connection& mzrollDb, Connection& emDb);
+
+    /**
+     * @brief Copy peak groups from a given mzrollDB to emDB.
+     * @param mzrollDb Database connection to an mzrollDB file.
+     * @param emDb Database connection to an emDB file.
+     */
+    void copyPeakgroups(Connection& mzrollDb, Connection& emDb);
+
+    /**
+     * @brief Copy peaks from a given mzrollDB to emDB.
+     * @param mzrollDb Database connection to an mzrollDB file.
+     * @param emDb Database connection to an emDB file.
+     */
+    void copyPeaks(Connection& mzrollDb, Connection& emDb);
+
+    /**
+     * @brief Copy compounds from a given mzrollDB to emDB.
+     * @param mzrollDb Database connection to an mzrollDB file.
+     * @param emDb Database connection to an emDB file.
+     */
+    void copyCompounds(Connection& mzrollDb, Connection& emDb);
+
+    /**
+     * @brief Copy alignment data from a given mzrollDB to emDB.
+     * @param mzrollDb Database connection to an mzrollDB file.
+     * @param emDb Database connection to an emDB file.
+     */
+    void copyAlignmentData(Connection& mzrollDb, Connection& emDb);
+
+    /**
+     * @brief Set user version of an emDB file.
+     * @param emDb Database connection to an emDB file.
+     * @param version The integer version to set user version to.
+     */
+    void setVersion(Connection& emDb, int version);
+} // namespace MzrollDbConverter
+
+#endif // MZROLLDBCONVERTER_H

--- a/src/projectDB/projectDB.pro
+++ b/src/projectDB/projectDB.pro
@@ -28,10 +28,12 @@ INCLUDEPATH += $$top_srcdir/src/core/libmaven \
 SOURCES	= connection.cpp \
           cursor.cpp \
           projectdatabase.cpp \
-          projectversioning.cpp
+          projectversioning.cpp \
+          mzrolldbconverter.cpp
 
 HEADERS +=  schema.h \
             connection.h \
             cursor.h \
             projectdatabase.h \
-            projectversioning.h
+            projectversioning.h \
+            mzrolldbconverter.h

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -230,14 +230,17 @@ int ProjectDatabase::saveGroupAndPeaks(PeakGroup* group,
     groupsQuery->bind(":table_name", tableName);
     groupsQuery->bind(":min_quality", group->minQuality);
 
-    string sample_ids = accumulate(next(begin(group->samples)),
-                                   end(group->samples),
-                                   to_string(group->samples[0]->getSampleId()),
-                                   [](string current, mzSample* s) {
-                                       return move(current)
-                                              + ';'
-                                              + to_string(s->getSampleId());
-                                   });
+    string sample_ids = "";
+    if (group->samples.size() > 0) {
+        sample_ids = accumulate(next(begin(group->samples)),
+                                end(group->samples),
+                                to_string(group->samples[0]->getSampleId()),
+                                [](string current, mzSample* s) {
+                                    return move(current)
+                                           + ';'
+                                           + to_string(s->getSampleId());
+                                });
+    }
     groupsQuery->bind(":sample_ids", sample_ids);
 
     if (!groupsQuery->execute())

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -941,8 +941,11 @@ vector<PeakGroup*> ProjectDatabase::loadGroups(const vector<mzSample*>& loaded)
 
         vector<string> sample_ids;
         mzUtils::split(groupsQuery->stringValue("sample_ids"), ';', sample_ids);
-        for (auto id_string : sample_ids) {
-            int sampleId = stoi(id_string);
+        for (auto idString : sample_ids) {
+            if (idString.empty())
+                continue;
+
+            int sampleId = stoi(idString);
             auto sampleIter = find_if(begin(loaded),
                                       end(loaded),
                                       [sampleId](mzSample* s) {


### PR DESCRIPTION
MAVEN users have started using a SQLite project format, mzrollDB, from which emDB was itself derived. However, a lot of (mostly naming) changes exist between the two formats. To allow easier transition of MAVEN users to El-MAVEN, mzrollDB format will now be allowed to be read in and a converted emDB file will be generated containing almost all information from the mzrolDB. This emDB file will then be made the session's current project.

Note: alignment data is not being saved at the moment because of difference of save/load algorithm of alignment data between the two applications.