### PR TITLE
Remove underscore from program's main window title

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -994,7 +994,7 @@ void MainWindow::threadSave(QString filename)
 
     QFileInfo fileInfo(filename);
     setWindowTitle(programName
-                   + "_"
+                   + " "
                    + STR(EL_MAVEN_VERSION)
                    + " "
                    + fileInfo.fileName());
@@ -1094,7 +1094,7 @@ void MainWindow::saveProject(bool explicitSave)
             _latestUserProjectName = _currentProjectName;
             QFileInfo fileInfo(_latestUserProjectName);
             setWindowTitle(programName
-                           + "_"
+                           + " "
                            + STR(EL_MAVEN_VERSION)
                            + " "
                            + fileInfo.fileName());
@@ -1741,7 +1741,7 @@ void MainWindow::open()
 
     // Changing the title of the main window after selecting the samples
     setWindowTitle(programName
-                   + "_"
+                   + " "
                    + STR(EL_MAVEN_VERSION)
                    + " "
                    + fileInfo.fileName());
@@ -1770,7 +1770,7 @@ void MainWindow::open()
         // SQLite project
         QFileInfo fileInfo(_latestUserProjectName);
         setWindowTitle(programName
-                       + "_"
+                       + " "
                        + STR(EL_MAVEN_VERSION)
                        + " "
                        + fileInfo.fileName());


### PR DESCRIPTION
We are completely removing underscores from application name and title bar in this release. This commit removes underscore separated `APPNAME` and `APPVERSION` strings that are set after loading files in-to the app.