### PR TITLE
[Fix] Reduce build-time for Linux

### DIFF
--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -8,7 +8,7 @@ DESTDIR = $$top_srcdir/bin/
 
 QT += multimedia multimediawidgets
 
-CONFIG += qt thread warn_off sql svg console precompile_header
+CONFIG += qt thread warn_off sql svg console precompile_header resources_big
 
 #Faster build + C++11 ++ OpenMP
 


### PR DESCRIPTION
Since the addition of ML videos in the qrc file,
compilation on ubuntu consumes a lot of memory (upto 5GB for a ~30MB resource) often leading to the system freezing.

Developers on multiple online forums recommend using
'resources_big' to fix this issue. There is no official documentation to be found although there are mentions on the qt bug reporting platform: https://bugreports.qt.io/browse/QTBUG-50468