### PR TITLE
Manage PRM features with MRM data

### DIFF
--- a/src/core/libmaven/Fragment.cpp
+++ b/src/core/libmaven/Fragment.cpp
@@ -188,6 +188,11 @@ void Fragment::buildConsensus(float productPpmTolr)
         consensusFrag->sortByMz();
     }
 
+    if (!consensusFrag->intensityValues.size() || 
+        !consensusFrag->mzValues.size() ||
+        !consensusFrag->obscount.size()) {
+            return;
+    }
     consensusFrag->rt = consensusRt();
     consensusFrag->purity = consensusPurity();
 

--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -181,6 +181,20 @@ void PeakGroup::clear() {
     groupRank=INT_MAX;
 }
 
+bool PeakGroup::isMS1()
+{
+    if (peaks.size() == 0) return false;
+
+    Peak peak = peaks[0];
+    if (peak.getSample()) {
+        Scan* scan = peak.getSample()->getScan(peak.scan);
+        if (scan && scan->mslevel == 1)
+            return true;
+    }
+
+    return false;
+}
+
 void PeakGroup::addPeak(const Peak &peak)
 {
 	peaks.push_back(peak);
@@ -708,6 +722,8 @@ vector<Scan*> PeakGroup::getRepresentativeFullScans() {
 vector<Scan*> PeakGroup::getFragmentationEvents()
 {
     vector<Scan*> matchedScans;
+    if (!this->isMS1()) return matchedScans;
+    
     for(auto peak : peaks) {
         mzSample* sample = peak.getSample();
         if (sample == NULL) continue;

--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -156,6 +156,8 @@ class PeakGroup{
         float changeFoldRatio;
         float changePValue;
 
+        bool isMS1();
+
         /**
          * [hasSrmId ]
          * @method hasSrmId

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1272,9 +1272,9 @@ EIC *mzSample::getEIC(float precursorMz, float collisionEnergy, float productMz,
 			e->intensity[j] *= scale;
 		}
 
-	if (e->size() == 0)
-		cerr << "getEIC(Q1,CE,Q3): is empty" << precursorMz << " " << collisionEnergy << " " << productMz << endl;
-	std::cerr << "getEIC(Q1,CE,Q3): srm" << precursorMz << " " << e->intensity.size() << endl;
+	//if (e->size() == 0)
+	//	cerr << "getEIC(Q1,CE,Q3): is empty" << precursorMz << " " << collisionEnergy << " " << productMz << endl;
+	//std::cerr << "getEIC(Q1,CE,Q3): srm" << precursorMz << " " << e->intensity.size() << endl;
 	return e;
 }
 
@@ -1377,9 +1377,9 @@ EIC *mzSample::getEIC(string srm, int eicType)
 		{
 			e->intensity[j] *= scale;
 		}
-	if (e->size() == 0)
-		cerr << "getEIC(SRM STRING): is empty" << srm << endl;
-	std::cerr << "getEIC: srm" << srm << " " << e->intensity.size() << endl;
+	//if (e->size() == 0)
+	//	cerr << "getEIC(SRM STRING): is empty" << srm << endl;
+	//std::cerr << "getEIC: srm" << srm << " " << e->intensity.size() << endl;
 
 	return e;
 }
@@ -1439,8 +1439,8 @@ EIC *mzSample::getEIC(float mzmin, float mzmax, float rtmin, float rtmax, int ms
 	float scale = getNormalizationConstant();
 	e->normalizeIntensityPerScan(scale);
 
-	if (e->size() == 0)
-		cerr << "getEIC(mzrange,rtrange,mslevel): is empty" << mzmin << " " << mzmax << " " << rtmin << " " << rtmax << endl;
+	//if (e->size() == 0)
+	//	cerr << "getEIC(mzrange,rtrange,mslevel): is empty" << mzmin << " " << mzmax << " " << rtmin << " " << rtmax << endl;
 
 	return (e);
 }

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -2007,6 +2007,7 @@ void EicWidget::addMS2Events(float mzmin, float mzmax)
     
 	int count = 0;
     for (auto const& sample : samples) {
+		if (sample->ms1ScanCount() == 0) continue;
         for (auto const& scan : sample->scans) {
             if (scan->mslevel > 1 &&
 				scan->precursorMz >= mzmin &&

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3616,6 +3616,9 @@ void MainWindow::showFragmentationScans(float pmz)
         return;
     fragPanel->clearTree();
     for (auto sample : samples) {
+        if (sample->ms1ScanCount() == 0)
+            continue;
+
         for (auto scan : sample->scans) {
 	        if (scan->mslevel < 2) continue;
 	        if (massCutoffDist(scan->precursorMz,


### PR DESCRIPTION
This PR makes the following changes:
- Prevent crash on loading MRM data
- No MS2 markers should be added to EIC if the sample does not have MS1 scans
- Fragmentation pattern and other MS2 statistics should not be calculated for MRM data