### PR TITLE
Fix peak classification

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -529,6 +529,8 @@ void PeakGroup::groupStatistics() {
     //@Kailash: Added for Avg Peak Quality and Intensity Weighted Peak Quality
     float peakQualitySum=0;
     float highestIntensity=0;
+    float weightedSum = 0;
+    float sumWeights = 0;
 
     for(unsigned int i=0; i< peaks.size(); i++) {
         if(peaks[i].pos != 0 && peaks[i].baseMz != 0) { rtSum += peaks[i].rt; mzSum += peaks[i].baseMz; nonZeroCount++; }
@@ -579,11 +581,14 @@ void PeakGroup::groupStatistics() {
             sampleCount++;
             if(peaks[i].peakIntensity > sampleMax) sampleMax = peaks[i].peakIntensity;
         }
-        
+
+        weightedSum += peaks[i].quality * peaks[i].peakIntensity;
+        sumWeights += peaks[i].peakIntensity;
         peakQualitySum += peaks[i].quality;
         if (peaks[i].peakIntensity > highestIntensity) highestIntensity = peaks[i].peakIntensity;
     }
     avgPeakQuality = peakQualitySum / peaks.size();
+    weightedAvgPeakQuality = weightedSum/sumWeights;
 
     if (sampleCount>0) sampleMean = sampleMean/sampleCount;
     if ( nonZeroCount ) {

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -266,7 +266,7 @@ void CSVReports::writeDataForPolly(const std::string& file, std::list<PeakGroup>
         for(auto grp: groups) {
             for(auto child: grp.children) {
 
-                int mlLabel =  (child.markedGoodByCloudModel) ? 1 : (child.markedBadByCloudModel) ? -1 : 0;
+                int mlLabel =  (child.markedGoodByCloudModel) ? 1 : (child.markedBadByCloudModel) ? 0 : -1;
                 groupReport << mlLabel;
                 groupReport << ",";
 


### PR DESCRIPTION
There are two changes in this PR:
1. Parent and C12 parent groups were being classified differently by the new ML model due to a missing quality statistic in C12 parent.
2. El-MAVEN and PollyPhi were using different values to denote 'bad' and 'ambiguous' groups. This has been fixed on El-MAVEN's end