### PR TITLE
Fix some UX issues on peak detection dialog

### DIFF
--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -168,9 +168,9 @@ PeakDetectionDialog::PeakDetectionDialog(QWidget *parent) :
         chargeMin->setVisible(false);
         chargeMax->setVisible(false);
         
-        connect(dbOptions, SIGNAL(clicked(bool)), SLOT(dbOptionsClicked()));
+        connect(dbOptions, SIGNAL(toggled(bool)), SLOT(dbOptionsClicked()));
         featureOptions->setChecked(false);
-        connect(featureOptions, SIGNAL(clicked(bool)), SLOT(featureOptionsClicked()));
+        connect(featureOptions, SIGNAL(toggled(bool)), SLOT(featureOptionsClicked()));
 
         compoundRTWindow->setEnabled(false); //TODO: Sahil - Kiran, Added while merging mainwindow
         reportIsotopesOptions->setEnabled(true); //TODO: Sahil - Kiran, Added while merging mainwindow


### PR DESCRIPTION
This patch fixes the following issues with peak detection dialog:
 1. "Report Isotopic Peaks" gets disabled even though "Compound database search" is on, after re-setting options.
 2. "Automated Feature Detection" and "Report Isotopic Peaks" being on at the same time after a session restart.

Issue: #1041