### PR TITLE
Synchronize mass resolution windows

### DIFF
--- a/src/gui/mzroll/forms/peakdetectiondialog.ui
+++ b/src/gui/mzroll/forms/peakdetectiondialog.ui
@@ -94,6 +94,9 @@
           </item>
           <item row="0" column="1">
            <widget class="QDoubleSpinBox" name="ppmStep">
+            <property name="suffix">
+             <string> ppm</string>
+            </property>
             <property name="decimals">
              <number>3</number>
             </property>
@@ -101,7 +104,7 @@
              <double>1000000000.000000000000000</double>
             </property>
             <property name="singleStep">
-             <double>1.000000000000000</double>
+             <double>0.500000000000000</double>
             </property>
             <property name="value">
              <double>20.000000000000000</double>
@@ -172,7 +175,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>Time Domain Resolution (scans)</string>
+             <string>Time Domain Resolution</string>
             </property>
            </widget>
           </item>
@@ -209,7 +212,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_7">
             <property name="text">
-             <string>Mass Domain Resolution (ppm)</string>
+             <string>Mass Domain Resolution</string>
             </property>
            </widget>
           </item>
@@ -264,6 +267,9 @@
             <property name="maximum">
              <double>1000000.000000000000000</double>
             </property>
+            <property name="singleStep">
+             <double>0.500000000000000</double>
+            </property>
             <property name="value">
              <double>20.000000000000000</double>
             </property>
@@ -288,7 +294,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="label_11">
             <property name="text">
-             <string>EIC Extraction Window  +/- PPM </string>
+             <string>EIC Extraction Window (+/-)</string>
             </property>
            </widget>
           </item>

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2980,6 +2980,21 @@ void MainWindow::createToolBars() {
             SIGNAL(valueChanged(double)),
             this,
             SLOT(setUserMassCutoff(double)));
+    void (QDoubleSpinBox::* doubleChanged)(double) = &QDoubleSpinBox::valueChanged;
+    connect(massCutoffWindowBox,
+            doubleChanged,
+            [=] (double value) {
+                if (!peakDetectionDialog->isVisible())
+                    peakDetectionDialog->compoundPPMWindow->setValue(value);
+            });
+    connect(peakDetectionDialog->ppmStep,
+            doubleChanged,
+            massCutoffWindowBox,
+            &QDoubleSpinBox::setValue);
+    connect(peakDetectionDialog->compoundPPMWindow,
+            doubleChanged,
+            massCutoffWindowBox,
+            &QDoubleSpinBox::setValue);
     massCutoffWindowBox->setValue(settings->value("massCutoffWindowBox").toDouble());
 
     searchText = new QLineEdit(hBox);

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -193,13 +193,8 @@ void PeakDetectionDialog::onReset()
 
 void PeakDetectionDialog::setMassCutoffType(QString type)
 {
-    /* we are changing in peaks dialog from an event that occurs outside of peaks dialog
-     * (@see in MainWindow masscutoffCombox::currentIndexChanged)
-     */
-    massCutoffType = type;
-    label_7->setText(QString("Mass Domain Resolution (%1)").arg(type));
-    string EICExtractionWindow="EIC Extraction Window  +/- "+type.toStdString();
-    label_11->setText(QApplication::translate("PeakDetectionDialog", &EICExtractionWindow[0], 0));
+    massCutoffType = QString(" %1").arg(type);
+    ppmStep->setSuffix(type);
     compoundPPMWindow->setSuffix(type);
     emit updateSettings(peakSettings);
 }


### PR DESCRIPTION
The mass resolution settings in peak detection dialog, when changed were not updating main window's mass cutoff setting and was causing some confusions among users. This has been fixed. And at the same time changing main window's mass cutoff value will, now, also change the targeted compound extraction window setting, as this is also somewhat desirable.