### PR TITLE
Improvements to sample ordering

### DIFF
--- a/src/core/libmaven/Fragment.cpp
+++ b/src/core/libmaven/Fragment.cpp
@@ -59,6 +59,22 @@ Fragment::Fragment(Fragment* other)
     this->rt = other->rt;
 }
 
+Fragment& Fragment::operator=(const Fragment& f)  {
+    this->precursorMz = f.precursorMz;
+    this->polarity = f.polarity;
+    this->mzValues = f.mzValues;
+    this->intensityValues = f.intensityValues;
+    this->obscount = f.obscount;
+    this->consensus = f.consensus;
+    this->scanNum = f.scanNum;
+    this->sampleName = f.sampleName;
+    this->collisionEnergy = f.collisionEnergy;
+    this->precursorCharge= f.precursorCharge;
+    this->purity = f.purity;
+    this->rt = f.rt;
+    return *this;
+}
+
 Fragment::~Fragment()
 {
     mzUtils::delete_all(brothers);

--- a/src/core/libmaven/Fragment.h
+++ b/src/core/libmaven/Fragment.h
@@ -97,6 +97,8 @@ class Fragment {
 
         Fragment(Fragment* other);
 
+        Fragment& operator=(const Fragment& f);
+
         ~Fragment();
 
         double precursorMz;				//parent

--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -165,7 +165,10 @@ PeakGroup::~PeakGroup() {
 
 void PeakGroup::copyChildren(const PeakGroup& o) {
     children = o.children;
+    childrenBarPlot = o.childrenBarPlot;
     for(unsigned int i=0; i < children.size(); i++ ) children[i].parent = this;
+    for(unsigned int i=0; i < childrenBarPlot.size(); i++ )
+        childrenBarPlot[i].parent = this;
 }
 
 bool PeakGroup::isPrimaryGroup() {

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -25,7 +25,7 @@ mzSample::mzSample()
 	totalIntensity = 0;
 	_normalizationConstant = 1; //TODO: Sahil Not being used anywhere
 	injectionTime = 0;
-	_sampleOrder = 0;
+        _sampleOrder = -1;
 	sampleNumber = -1;
 	_C13Labeled = false;
 	_N15Labeled = false;

--- a/src/gui/mzroll/grouprtwidget.cpp
+++ b/src/gui/mzroll/grouprtwidget.cpp
@@ -15,12 +15,21 @@ GroupRtWidget::GroupRtWidget(MainWindow* mw, QDockWidget* dockWidget):
 void GroupRtWidget::plotGraph(PeakGroup*  group) {
 
     if (!_mw->groupRtDockWidget->isVisible()) return;
-    currentDisplayedGroup=group;
+    if (currentDisplayedGroup)
+        delete currentDisplayedGroup;
+    currentDisplayedGroup = new PeakGroup;
+    currentDisplayedGroup->copyObj(*group);
     intialSetup();
-    if (group == nullptr)
+    if (currentDisplayedGroup == nullptr)
+        return;
+    updateGraph();
+}
+void GroupRtWidget::updateGraph(){
+    if(currentDisplayedGroup == nullptr)
         return;
 
-    PeakGroup groupUnalignedShadowed = *group;
+    intialSetup();
+    PeakGroup groupUnalignedShadowed = *currentDisplayedGroup;
 
     refRtLine(groupUnalignedShadowed);
 
@@ -38,10 +47,7 @@ void GroupRtWidget::plotGraph(PeakGroup*  group) {
     _mw->groupRtVizPlot->yAxis->setRange(0, samples.size() + 1);
     _mw->groupRtVizPlot->xAxis->setRange(rtRange-1, rtRange+1);
     _mw->groupRtVizPlot->replot();
-}
-void GroupRtWidget::updateGraph(){
-    if(currentDisplayedGroup != nullptr)
-        plotGraph(currentDisplayedGroup);
+
 }
 void GroupRtWidget::intialSetup() {
     _mw->groupRtVizPlot->clearPlottables();
@@ -261,7 +267,8 @@ vector<mzSample*> GroupRtWidget::getSamplesFromGroup(PeakGroup group) {
     vector<mzSample*> samples;
     for(unsigned int i=0; i < peaks.size(); i++ ) {
         mzSample* s = peaks[i].getSample();
-        samples.push_back(s);
+        if (s->isSelected)
+            samples.push_back(s);
     }
     sort (samples.begin(), samples.end(),mzSample::compSampleOrder);
     reverse(samples.begin(),samples.end());

--- a/src/gui/mzroll/grouprtwidget.cpp
+++ b/src/gui/mzroll/grouprtwidget.cpp
@@ -17,11 +17,11 @@ void GroupRtWidget::plotGraph(PeakGroup*  group) {
     if (!_mw->groupRtDockWidget->isVisible()) return;
     if (currentDisplayedGroup)
         delete currentDisplayedGroup;
+    if (group == nullptr)
+        return;
     currentDisplayedGroup = new PeakGroup;
     currentDisplayedGroup->copyObj(*group);
     intialSetup();
-    if (currentDisplayedGroup == nullptr)
-        return;
     updateGraph();
 }
 void GroupRtWidget::updateGraph(){

--- a/src/gui/mzroll/grouprtwidget.cpp
+++ b/src/gui/mzroll/grouprtwidget.cpp
@@ -7,6 +7,7 @@ GroupRtWidget::GroupRtWidget(MainWindow* mw, QDockWidget* dockWidget):
     _mw(mw),
     _dockWidget(dockWidget)
 {
+    currentDisplayedGroup = nullptr;
     setXAxis();
     setYAxis();
 }
@@ -16,6 +17,9 @@ void GroupRtWidget::plotGraph(PeakGroup*  group) {
     if (!_mw->groupRtDockWidget->isVisible()) return;
     currentDisplayedGroup=group;
     intialSetup();
+    if (group == nullptr)
+        return;
+
     PeakGroup groupUnalignedShadowed = *group;
 
     refRtLine(groupUnalignedShadowed);
@@ -36,7 +40,8 @@ void GroupRtWidget::plotGraph(PeakGroup*  group) {
     _mw->groupRtVizPlot->replot();
 }
 void GroupRtWidget::updateGraph(){
-    if(currentDisplayedGroup) plotGraph(currentDisplayedGroup);
+    if(currentDisplayedGroup != nullptr)
+        plotGraph(currentDisplayedGroup);
 }
 void GroupRtWidget::intialSetup() {
     _mw->groupRtVizPlot->clearPlottables();

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -43,6 +43,11 @@ void IsotopePlot::clear() {
     }
 }
 
+void IsotopePlot::replot()
+{
+    setPeakGroup(_group);
+}
+
 void IsotopePlot::setPeakGroup(PeakGroup* group) {
     //cerr << "IsotopePlot::setPeakGroup()" << group << endl;
     if ( group == NULL ) return;

--- a/src/gui/mzroll/isotopeplot.cpp
+++ b/src/gui/mzroll/isotopeplot.cpp
@@ -45,7 +45,13 @@ void IsotopePlot::clear() {
 
 void IsotopePlot::replot()
 {
-    setPeakGroup(_group);
+    clear();
+    _samples.clear();
+    _samples = _mw->getVisibleSamples();
+    if (_samples.size() == 0)
+        return;
+    sort(_samples.begin(), _samples.end(), mzSample::compRevSampleOrder);
+    showBars();
 }
 
 void IsotopePlot::setPeakGroup(PeakGroup* group) {
@@ -55,11 +61,15 @@ void IsotopePlot::setPeakGroup(PeakGroup* group) {
 
     if (group->isIsotope() && group->getParent() ) {
         setPeakGroup(group->getParent());
+        return;
     }
 
     clear();
 
-    _group = group;
+    if (_group)
+        delete _group;
+    _group = new PeakGroup;
+    _group->copyObj(*group);
 
 	_samples.clear();
 	_samples = _mw->getVisibleSamples();
@@ -67,9 +77,9 @@ void IsotopePlot::setPeakGroup(PeakGroup* group) {
 	    sort(_samples.begin(), _samples.end(), mzSample::compRevSampleOrder);
 
     _isotopes.clear();
-    for(int i=0; i < group->childCountBarPlot(); i++ ) {
-        if (group->childrenBarPlot[i].isIsotope() ) {
-            PeakGroup isotope = group->childrenBarPlot[i];
+    for(int i=0; i < _group->childCountBarPlot(); i++ ) {
+        if (_group->childrenBarPlot[i].isIsotope() ) {
+            PeakGroup isotope = _group->childrenBarPlot[i];
             _isotopes.push_back(isotope);
         }
     }

--- a/src/gui/mzroll/isotopeplot.h
+++ b/src/gui/mzroll/isotopeplot.h
@@ -30,6 +30,9 @@ public:
     void showBars();
     void setPoolThreshold(double poolThreshold) { _poolThreshold = poolThreshold;}
 
+public Q_SLOTS:
+    void replot();
+
 private Q_SLOTS:
     void showPointToolTip(QMouseEvent *event);
 	

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1419,7 +1419,8 @@ vector<mzSample*> MainWindow::getVisibleSamples() {
 		if (samples[i] && samples[i]->isSelected) {
 			vsamples.push_back(samples[i]);
 		}
-	}
+    }
+    sort(begin(vsamples), end(vsamples), mzSample::compSampleOrder);
 	return vsamples;
 }
 

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -141,9 +141,8 @@ void EicPoint::mousePressEvent (QGraphicsSceneMouseEvent* event) {
 
     if (_group) Q_EMIT peakGroupSelected(_group);
     if (_peak)  Q_EMIT peakSelected(_peak);
-
-    _mw->groupRtWidget->plotGraph(_group);
-
+    if (_group)
+        _mw->groupRtWidget->plotGraph(_group);
     if ( _group && _group->isIsotope() == false ) {
         _mw->isotopeWidget->updateIsotopicBarplot(_group);
     }

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -226,11 +226,11 @@ void ProjectDockWidget::changeSampleOrder() {
     }
 
     if (changed) {
-
         _mainwindow->alignmentVizAllGroupsWidget->replotGraph();
         _mainwindow->sampleRtWidget->plotGraph();
         _mainwindow->groupRtWidget->updateGraph();
         _mainwindow->getEicWidget()->replot();
+        _mainwindow->isotopeWidget->updateSampleList();
     }
 }
 

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -231,6 +231,7 @@ void ProjectDockWidget::changeSampleOrder() {
         _mainwindow->groupRtWidget->updateGraph();
         _mainwindow->getEicWidget()->replot();
         _mainwindow->isotopeWidget->updateSampleList();
+        _mainwindow->isotopePlot->replot();
     }
 }
 

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -232,6 +232,7 @@ void ProjectDockWidget::changeSampleOrder() {
         _mainwindow->getEicWidget()->replot();
         _mainwindow->isotopeWidget->updateSampleList();
         _mainwindow->isotopePlot->replot();
+        _mainwindow->fragPanel->sortScansBySample();
     }
 }
 

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -176,6 +176,21 @@ void ProjectDockWidget::updateSampleList() {
     vector<mzSample*>samples = _mainwindow->getSamples();
     std::sort(samples.begin(), samples.end(),mzSample::compSampleSort);
 
+    // obtain current maximum sample order
+    auto maxOrdSample = max_element(begin(samples),
+                                    end(samples),
+                                    [] (mzSample* s1, mzSample* s2) {
+                                        return s1->getSampleOrder()
+                                               < s2->getSampleOrder();
+                                    });
+    int maxOrder = (*maxOrdSample)->getSampleOrder();
+
+    // assign sample order to any newly added samples
+    for (const auto sample : samples) {
+        if (sample->getSampleOrder() == -1)
+            sample->setSampleOrder(++maxOrder);
+    }
+
     if ( samples.size() > 0 ) setInfo(samples);
 
     if ( _mainwindow->getEicWidget() ) {
@@ -480,7 +495,6 @@ void ProjectDockWidget::setInfo(vector<mzSample*>&samples) {
 
     float N = samples.size();
     sort(samples.begin(), samples.end(), mzSample::compSampleOrder);
-    reverse(samples.begin(),samples.end());
     for(int i=0; i < samples.size(); i++ ) {
 
         mzSample* sample = samples[i];
@@ -547,7 +561,6 @@ void ProjectDockWidget::setInfo(vector<mzSample*>&samples) {
     connect(_treeWidget,
             SIGNAL(itemDropped(QTreeWidgetItem*)),
             SLOT(changeSampleOrder()));
-    _treeWidget->sortItems(0, Qt::SortOrder::AscendingOrder);
     changeSampleOrder();
 }
 

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -545,7 +545,8 @@ void ProjectDockWidget::setInfo(vector<mzSample*>&samples) {
     connect(_treeWidget,SIGNAL(itemChanged(QTreeWidgetItem*, int)), SLOT(changeSampleSet(QTreeWidgetItem*,int)));
     connect(_treeWidget,SIGNAL(itemChanged(QTreeWidgetItem*, int)), SLOT(changeNormalizationConstant(QTreeWidgetItem*,int)));
     connect(_treeWidget,SIGNAL(itemChanged(QTreeWidgetItem*, int)), SLOT(showSample(QTreeWidgetItem*,int)));
-
+    _treeWidget->sortItems(0, Qt::SortOrder::AscendingOrder);
+    changeSampleOrder();
 }
 
 void ProjectDockWidget::showSample(QTreeWidgetItem* item, int col) {

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -566,6 +566,9 @@ void ProjectDockWidget::showSample(QTreeWidgetItem* item, int col) {
 
             if(changed) {
                 cerr << "ProjectDockWidget::showSample() changed! " << checked << endl;
+                _mainwindow->alignmentVizAllGroupsWidget->replotGraph();
+                _mainwindow->sampleRtWidget->plotGraph();
+                _mainwindow->groupRtWidget->updateGraph();
                 _mainwindow->getEicWidget()->replotForced();
                 _mainwindow->isotopeWidget->updateSampleList();
                 _mainwindow->isotopePlot->replot();

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -568,6 +568,7 @@ void ProjectDockWidget::showSample(QTreeWidgetItem* item, int col) {
                 cerr << "ProjectDockWidget::showSample() changed! " << checked << endl;
                 _mainwindow->getEicWidget()->replotForced();
                 _mainwindow->isotopeWidget->updateSampleList();
+                _mainwindow->isotopePlot->replot();
             }
         }
     }

--- a/src/gui/mzroll/projectdockwidget.h
+++ b/src/gui/mzroll/projectdockwidget.h
@@ -113,7 +113,6 @@ private Q_SLOTS:
     void changeColors();
     void checkUncheck(); //TODO: Sahil, Added while merging projectdockwidget
     void setSampleColor(QTreeWidgetItem* item, QColor color);
-    void dropEvent (QDropEvent*event);
     // void unloadSample(); //TODO: Sahil, Removed while merging projectdockwidget
     void unloadSample(mzSample* sample); //TODO: Sahil, Added while merging projectdockwidget
     void filterTreeItems(QString filterString);
@@ -134,6 +133,29 @@ private:
     QString _lastSavedProject;
     std::chrono::time_point<std::chrono::system_clock> _lastSave;
     std::chrono::time_point<std::chrono::system_clock> _lastLoad;
+};
+
+/**
+ * @brief The ProjectTreeWidget class is meant to provide drag and drop
+ * functionality to the regular tree widget used for storing samples in a
+ * ProjectDockWidget class.
+ */
+class ProjectTreeWidget : public QTreeWidget
+{
+    Q_OBJECT
+
+public:
+    ProjectTreeWidget(QWidget* parent=nullptr);
+
+Q_SIGNALS:
+    void itemDropped(QTreeWidgetItem* item);
+
+protected:
+    void dragEnterEvent(QDragEnterEvent* event);
+    void dropEvent(QDropEvent* event);
+
+private:
+    QTreeWidgetItem* _draggedItem;
 };
 
 #endif // PROJECTDOCKWIDGET_H

--- a/src/gui/mzroll/treedockwidget.cpp
+++ b/src/gui/mzroll/treedockwidget.cpp
@@ -39,8 +39,9 @@ QTreeWidgetItem* TreeDockWidget::addItem(QTreeWidgetItem* parentItem, string key
 	return item;
 }
 
-void TreeDockWidget::clearTree() { 
-		treeWidget->clear();
+void TreeDockWidget::clearTree() {
+    treeWidget->clear();
+    _scansList.clear();
 }
 
 
@@ -285,6 +286,7 @@ void TreeDockWidget::setupScanListHeader()
 }
 
 void TreeDockWidget::addScanItem(Scan* scan) {
+        _scansList.append(scan);
         if (scan == NULL) return;
 
         QIcon icon = _mainWindow->projectDockWidget->getSampleIcon(scan->sample);
@@ -299,6 +301,17 @@ void TreeDockWidget::addScanItem(Scan* scan) {
         item->setText(5,QString::number(scan->nobs()));
 }
 
+void TreeDockWidget::sortScansBySample()
+{
+    treeWidget->clear();
+    auto samples = _mainWindow->getVisibleSamples();
+    for (auto sample : samples) {
+        for (auto scan : sample->scans) {
+            if (_scansList.contains(scan))
+                addScanItem(scan);
+        }
+    }
+}
 
 void TreeDockWidget::setInfo(vector<Compound*>&compounds) {
     clearTree();

--- a/src/gui/mzroll/treedockwidget.cpp
+++ b/src/gui/mzroll/treedockwidget.cpp
@@ -286,8 +286,8 @@ void TreeDockWidget::setupScanListHeader()
 }
 
 void TreeDockWidget::addScanItem(Scan* scan) {
-        _scansList.append(scan);
         if (scan == NULL) return;
+        _scansList.append(scan);
 
         QIcon icon = _mainWindow->projectDockWidget->getSampleIcon(scan->sample);
 

--- a/src/gui/mzroll/treedockwidget.h
+++ b/src/gui/mzroll/treedockwidget.h
@@ -37,8 +37,9 @@ public Q_SLOTS:
 	  void setInfo(vector<mzSlice*>&slices);
 	  void setInfo(deque<Pathway*>&pathways);
     void setupScanListHeader();
-	  void addScanItem(Scan* scan);
-	  void clearTree();
+    void addScanItem(Scan* scan);
+    void sortScansBySample();
+          void clearTree();
 	  void filterTree(QString needle);
       void copyToClipbard();
 
@@ -83,7 +84,7 @@ public Q_SLOTS:
       QDoubleSpinBox* amuQ3;
       QToolButton* associateCompounds;
       QMenu* matchCompoundMenu;
-
+      QList<Scan*> _scansList;
 };
 
 #endif


### PR DESCRIPTION
This patch contains the following changes and patches to sample ordering UX:
  * Add hooks for updating some widgets (where samples are information is present) as soon as order of samples in project (samples) widget changes or when any of the widgets is deselected/selected.
  * Fix some crashes due to volatile PeakGroup reference being held by isotope plot and group alignment viz widget.
  * Enable drag-and-drop for project (samples) widget. This change, however, will remove the ability to sort samples according to any of the columns in samples widget. We can discuss whether we should keep this change.