### PR TITLE
Hide isoPlot and srmList widgets by default

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -417,6 +417,8 @@ using namespace mzUtils;
 	// rconsoleDockWidget->setVisible(false);
 	spectralHitsDockWidget->setVisible(false);
     peptideFragmentation->setVisible(false);
+	srmDockWidget->setVisible(false);
+	isotopePlotDockWidget->setVisible(false);
 	
 	//treemap->setVisible(false);
 	//peaksPanel->setVisible(false);


### PR DESCRIPTION
Isotope plot and SRM widget are open by default in El-MAVEN. This was not intentional. This PR will keep both widgets hidden till a user interacts with these.