### PR TITLE
Add check for end of sample vector

### DIFF
--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -183,7 +183,9 @@ void ProjectDockWidget::updateSampleList() {
                                         return s1->getSampleOrder()
                                                < s2->getSampleOrder();
                                     });
-    int maxOrder = (*maxOrdSample)->getSampleOrder();
+    int maxOrder = 0;
+    if (maxOrdSample != end(samples))
+        maxOrder = (*maxOrdSample)->getSampleOrder();
 
     // assign sample order to any newly added samples
     for (const auto sample : samples) {


### PR DESCRIPTION
A check was needed when the samples are loaded through emDB and their order is -1 throughout. Their correct orders are later assigned and they are sorted accordingly.