### PR TITLE
Show EPI error when any API breaks

### DIFF
--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -48,7 +48,7 @@ PollyElmavenInterfaceDialog::PollyElmavenInterfaceDialog(MainWindow* mw)
     groupSetCombo->addItem("Exclude Bad Groups");
     groupSetCombo->setCurrentIndex(0);
 
-    connect(_pollyIntegration, SIGNAL(sendEPIError(QString)), SLOT(showEPIError(QString)));
+    connect(_pollyIntegration, SIGNAL(receivedEPIError(QString)), SLOT(showEPIError(QString)));
 
     connect(logoutButton, SIGNAL(clicked(bool)), SLOT(_logout()));
     connect(workflowMenu,

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -48,6 +48,8 @@ PollyElmavenInterfaceDialog::PollyElmavenInterfaceDialog(MainWindow* mw)
     groupSetCombo->addItem("Exclude Bad Groups");
     groupSetCombo->setCurrentIndex(0);
 
+    connect(_pollyIntegration, SIGNAL(sendEPIError(QString)), SLOT(showEPIError(QString)));
+
     connect(logoutButton, SIGNAL(clicked(bool)), SLOT(_logout()));
     connect(workflowMenu,
             SIGNAL(currentItemChanged(QListWidgetItem*, QListWidgetItem*)),
@@ -271,6 +273,16 @@ void PollyElmavenInterfaceDialog::initialSetup()
         }
         return;
     }
+}
+
+void PollyElmavenInterfaceDialog::showEPIError(QString errorMessage)
+{
+    _resetUiElements();
+    QMessageBox errorDialog(this);
+    errorDialog.setWindowModality(Qt::WindowModal);
+    errorDialog.setWindowTitle("Polly Error");
+    errorDialog.setText(errorMessage);
+    errorDialog.exec();
 }
 
 void PollyElmavenInterfaceDialog::_callLoginForm()

--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -91,6 +91,8 @@ public Q_SLOTS:
      */
     void setSelectedTable(TableDockWidget* table);
 
+    void showEPIError(QString errorMessage);
+
 Q_SIGNALS:
 
     /**

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -242,7 +242,7 @@ QString PollyIntegration::obtainComponentId(PollyApp app)
     for (auto elem : array) {
         auto jsonObject = elem.toObject();
         auto name = jsonObject.value("component").toString();
-        if (name == componentName)
+        if (name == _stringForApp(app))
             return QString::number(jsonObject.value("id").toInt());
     }
     return QString::number(-1);

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -330,7 +330,7 @@ bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
             QString errorMessage = message + "\n" +
                                    "Type: " + type + "\n" +
                                    supportMessage;
-            emit sendEPIError(errorMessage);
+            emit receivedEPIError(errorMessage);
             return true;
         }
 
@@ -339,12 +339,12 @@ bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
         QString errorString = QString::fromStdString(errorResponse.toStdString());
         errorString.replace("\n", "");
         if (!errorString.isEmpty()) {
-            emit sendEPIError(errorString);
+            emit receivedEPIError(errorString);
             return true;
         }
     } else if (resultAndError.size() == 0) {
         //no response or error
-        emit sendEPIError("Qt Process failed " + supportMessage);
+        emit receivedEPIError("Qt Process failed " + supportMessage);
         return true;
     }
 

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -337,9 +337,7 @@ bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
         //if proper error message is not available
         //send full error response from js process
         QString errorString = QString::fromStdString(errorResponse.toStdString());
-        qDebug() << "**************";
-        qDebug() << errorString;
-        //errorString.replace("\n", "");
+        errorString.replace("\n", "");
         if (!errorString.isEmpty()) {
             emit sendEPIError(errorString);
             return true;
@@ -400,37 +398,6 @@ int PollyIntegration::checkLoginStatus(){
     }
     return status;
 }
-
-// void PollyIntegration::checkLicense() {
-//     qDebug() << "checking license";
-//     QString command = "getLicense";
-//     QString status;
-
-//     QList<QByteArray> resultAndError = runQtProcess(command, QStringList() << credFile);
-//     QByteArray result = resultAndError.at(0);
-
-//     // split based on newlines, JSON is second last string after split
-//     QList<QByteArray> resultList = result.split('\n');
-//     result = resultList[resultList.size() - 1];
-
-//     // remove extra quotation around JSON array
-//     result = result.right(result.size() - 1);
-//     //result = result.left(result.size() - 1);
-//     // replace doubly escaped quotes
-//     result = result.replace("\\\"", "\"");
-
-
-//     qDebug() << result;
-
-//     QJsonDocument doc(QJsonDocument::fromJson(result));
-//     QJsonObject jsonObj = doc.object()["licenses"].toObject();
-//     auto licenses = jsonObj.keys();
-//     auto component = jsonObj["components"].toArray();
-//     if (component.size())
-//         qDebug() << component;
-
-//     qDebug() << "json error" << QString::number(-1);
-// }
 
 // name OF FUNCTION: authenticateLogin
 // PURPOSE:

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -29,7 +29,7 @@ PollyIntegration::PollyIntegration(DownloadManager* dlManager):
         nodePath = binDir + "node_bin" + QDir::separator() + "node";
     #endif
 
-    indexFileURL = "https://raw.githubusercontent.com/ElucidataInc/polly-cli/proper_console_error/test/index.js";
+    indexFileURL = "https://raw.githubusercontent.com/ElucidataInc/polly-cli/master/prod/index.js";
     _dlManager->setRequest(indexFileURL, this);
 }
 
@@ -141,6 +141,9 @@ QMap<QString, QStringList> PollyIntegration::_fetchAppLicense() {
                                                     QStringList() << credFile);
 
     QMap <QString, QStringList> appLicenses;
+    if (_hasError(resultAndError))
+        return appLicenses;
+
     QByteArray result = resultAndError.at(0);
     QStringList resultList = QString::fromStdString(result.toStdString()).split('\n');
     for (int i = 0; i < resultList.length(); i++) {
@@ -209,12 +212,16 @@ QString PollyIntegration::stringForApp(PollyApp app)
 QString PollyIntegration::obtainComponentName(PollyApp app)
 {
     QString command = "getComponentName";
+    QString componentName = "";
     QList<QByteArray> resultAndError = runQtProcess(command,
                                                     QStringList() << stringForApp(app)
                                                                   << credFile);
+   if (_hasError(resultAndError))
+        return componentName;
+
     QByteArray result = resultAndError.at(0);
     QList<QByteArray> resultList = result.split('\n');
-    QString componentName = QString(resultList.at(0).split(' ').at(1));
+    componentName = QString(resultList.at(0).split(' ').at(1));
     return componentName;
 }
 
@@ -223,6 +230,9 @@ QString PollyIntegration::obtainComponentId(PollyApp app)
     QString command = "getComponentId";
     QList<QByteArray> resultAndError = runQtProcess(command,
                                                     QStringList() << credFile);
+    if (_hasError(resultAndError))
+        return QString::number(-1);
+
     QByteArray result = resultAndError.at(0);
 
     // replace doubly escaped quotes
@@ -253,6 +263,9 @@ QString PollyIntegration::obtainWorkflowId(PollyApp app)
     QString command = "getWorkflowId";
     QList<QByteArray> resultAndError = runQtProcess(command,
                                                     QStringList() << credFile);
+    if (_hasError(resultAndError))
+        return QString::number(-1);
+
     QByteArray result = resultAndError.at(0);
 
     // split based on newlines, JSON is second last string after split
@@ -282,22 +295,75 @@ QStringList PollyIntegration::get_project_upload_url_commands(QString url_with_w
         QString copy_url_with_wildcard = url_with_wildcard;
         QString url_map_json = copy_url_with_wildcard.replace("*", new_filename) ;
         QString upload_command = "upload_project_data";
-        QList<QByteArray> patch_id_result_and_error = runQtProcess(upload_command, QStringList() << url_map_json << filename);
-        patchId.append(patch_id_result_and_error.at(0));
+        QList<QByteArray> resultAndError = runQtProcess(upload_command, QStringList() << url_map_json << filename);
+        
+        if (_hasError(resultAndError))
+            return patchId;
+
+        patchId.append(resultAndError.at(0));
     }
     return patchId;
+}
+
+bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
+{
+    QString supportMessage = "Contact tech support at elmaven@elucidata.io if the problem persists";
+    if (resultAndError.size() > 1) {
+        //if there is standard error look for error message
+        QByteArray errorResponse = resultAndError.at(1);
+        errorResponse.replace(QByteArray("\n"), QByteArray(""));
+
+        QJsonDocument doc(QJsonDocument::fromJson(errorResponse));
+        QJsonObject jsonObj = doc.object();
+        QString message;
+        QString type;
+        for (auto key : jsonObj.keys()) {
+            if (key == "message") {
+                message = jsonObj[key].toString();
+            }
+            if (key == "type") {
+                type = jsonObj[key].toString();
+            }
+        }
+
+        if (!message.isEmpty() || !type.isEmpty()) {
+            QString errorMessage = message + "\n" +
+                                   "Type: " + type + "\n" +
+                                   supportMessage;
+            emit sendEPIError(errorMessage);
+            return true;
+        }
+
+        //if proper error message is not available
+        //send full error response from js process
+        QString errorString = QString::fromStdString(errorResponse.toStdString());
+        qDebug() << "**************";
+        qDebug() << errorString;
+        //errorString.replace("\n", "");
+        if (!errorString.isEmpty()) {
+            emit sendEPIError(errorString);
+            return true;
+        }
+    } else if (resultAndError.size() == 0) {
+        //no response or error
+        emit sendEPIError("Qt Process failed " + supportMessage);
+        return true;
+    }
+
+    return false;
 }
 
 bool PollyIntegration::activeInternet()
 {
     QString command = QString("check_internet_connection");
-    QList<QByteArray> results = runQtProcess(command, QStringList());
-    if(!results.isEmpty()) {
-        results = results.at(0).split('\n');
-        QString status = results[1];
-        if (status == "Connected") {
-            return true;
-        }
+    QList<QByteArray> resultAndError = runQtProcess(command, QStringList());
+    if (_hasError(resultAndError))
+        return false;
+
+    QList<QByteArray> results = resultAndError.at(0).split('\n');
+    QString status = results[1];
+    if (status == "Connected") {
+        return true;
     }
     return false; 
 }
@@ -315,6 +381,10 @@ int PollyIntegration::checkLoginStatus(){
     int status;
     QString command = QString("authenticate");
     QList<QByteArray> resultAndError = runQtProcess(command, QStringList() << credFile);
+
+    if (_hasError(resultAndError))
+        return status;
+
     QList<QByteArray> testList = resultAndError.at(0).split('\n');
     QByteArray statusLine = testList[0];
     if (statusLine == "already logged in") {
@@ -379,16 +449,16 @@ QString PollyIntegration::authenticateLogin(QString username, QString password) 
     QString status;
     
     QList<QByteArray> resultAndError = runQtProcess(command, QStringList() << credFile << username << password);
+    if (_hasError(resultAndError))
+        return "error";
+
     int statusInside = checkLoginStatus();
     if (statusInside == 1) {
         status = "ok";
-    }
-    else if (resultAndError.at(1) != "") {
-        status = "error";
-    }
-    else {
+    } else {
         status = "incorrect credentials";
     }
+    
     return status;
 }
 
@@ -469,9 +539,13 @@ QVariantMap PollyIntegration::getUserProjectsMap(QByteArray result2) {
 
 
 QVariantMap PollyIntegration::getUserProjects() {
+    QVariantMap userProjects;
     QString getProjectsCommand = "get_Project_names";
     QList<QByteArray> resultAndError = runQtProcess(getProjectsCommand, QStringList() << credFile);
-    QVariantMap userProjects = getUserProjectsMap(resultAndError.at(0));
+    if (_hasError(resultAndError))
+        return userProjects;
+
+    userProjects = getUserProjectsMap(resultAndError.at(0));
     return userProjects;
 }
 
@@ -515,6 +589,9 @@ QVariantMap PollyIntegration::getUserProjectFiles(QStringList projectIds) {
         QString projectId = projectIds.at(i);
         QString getProjectsCommand = "get_Project_files";
         QList<QByteArray> resultAndError = runQtProcess(getProjectsCommand, QStringList() << credFile << projectId);
+        if (_hasError(resultAndError))
+            return userProjectfilesmap;
+
         QStringList userProjectfiles = getUserProjectFilesMap(resultAndError.at(0));
         userProjectfilesmap[projectId] = userProjectfiles;
     }
@@ -531,42 +608,57 @@ QVariantMap PollyIntegration::getUserProjectFiles(QStringList projectIds) {
 
 
 QString PollyIntegration::createProjectOnPolly(QString projectname) {
+    QString runId;
     QString command2 = "createProject";
     QList<QByteArray> resultAndError = runQtProcess(command2, QStringList() << credFile << projectname);
-    QString runId = parseId(resultAndError.at(0));
+    if (_hasError(resultAndError))
+        return runId;
+
+    runId = parseId(resultAndError.at(0));
     return runId;
 }
 
 QString PollyIntegration::createWorkflowRequest(QString projectId,
                                                 QString workflowName,
                                                 QString workflowId) {
+    QString workflowRequestId;
     QString command2 = "createWorkflowRequest";
     QList<QByteArray> resultAndError = runQtProcess(command2, QStringList() << credFile 
                                                                             << projectId
                                                                             << workflowName
                                                                             << workflowId);
-    QString workflowRequestId = parseId(resultAndError.at(0));
+    if (_hasError(resultAndError))
+        return workflowRequestId;
+
+    workflowRequestId = parseId(resultAndError.at(0));
     return workflowRequestId;
 }
 
 QString PollyIntegration::createRunRequest(QString componentId,
                                            QString projectId)
 {
+    QString runId;
     QString command = "createRunRequest";
     QStringList arguments = QStringList() << credFile
                                           << componentId
                                           << projectId;
     QList<QByteArray> resultAndError = runQtProcess(command, arguments);
-    QString runId = parseId(resultAndError.at(0));
+    if (_hasError(resultAndError))
+        return runId;
+
+    runId = parseId(resultAndError.at(0));
     return runId;
 }
 
 QByteArray PollyIntegration::redirectionUiEndpoint()
 {
+    QByteArray result;
     QString command = "getEndpointForRuns";
     QList<QByteArray> resultAndError = runQtProcess(command, QStringList(credFile));
+    if (_hasError(resultAndError))
+        return result;
 
-    QByteArray result = resultAndError.at(0);
+    result = resultAndError.at(0);
 
     // split based on newlines, JSON is second last string after split
     QList<QByteArray> resultList = result.split('\n');
@@ -633,6 +725,9 @@ bool PollyIntegration::sendEmail(QString userEmail,
                                                                   << emailMessage
                                                                   << emailContent
                                                                   << appName);
+    if (_hasError(resultAndError))
+        return false;
+
     QList<QByteArray> testList = resultAndError.at(0).split('\n');
     int size = testList.size();
     if (size > 2) {
@@ -657,12 +752,17 @@ bool PollyIntegration::sendEmail(QString userEmail,
 
 QStringList PollyIntegration::exportData(QStringList filenames, QString projectId) {
     qDebug() << "files to be uploaded " << filenames;
+    QStringList patchId;
+
     QElapsedTimer timer;
     timer.start();
     QString get_upload_Project_urls = "get_upload_Project_urls";
-    QList<QByteArray> result_and_error = runQtProcess(get_upload_Project_urls, QStringList() << credFile << projectId);
-    QString url_with_wildcard = getFileUploadURLs(result_and_error.at(0));    
-    QStringList patchId = get_project_upload_url_commands(url_with_wildcard, filenames);
+    QList<QByteArray> resultAndError = runQtProcess(get_upload_Project_urls, QStringList() << credFile << projectId);
+    if (_hasError(resultAndError))
+        return patchId;
+
+    QString url_with_wildcard = getFileUploadURLs(resultAndError.at(0));    
+    patchId = get_project_upload_url_commands(url_with_wildcard, filenames);
     qDebug() << "time taken in uploading json file, by polly cli is - " << timer.elapsed();
     
     return patchId;
@@ -681,20 +781,29 @@ QString PollyIntegration::getFileUploadURLs(QByteArray result2) {
     return url_with_wildcard;
 }
 
-QString PollyIntegration::UploadToCloud(QString uploadUrl, QString filePath){
+QString PollyIntegration::UploadToCloud(QString uploadUrl, QString filePath)
+{
+    QString status;
     QString upload_command = "uploadCuratedPeakDataToCloud";
-    QList<QByteArray> patch_id_result_and_error = runQtProcess(upload_command, QStringList() << uploadUrl << filePath);
-    QString status = "success";
+    QList<QByteArray> resultAndError = runQtProcess(upload_command, QStringList() << uploadUrl << filePath);
+    if (_hasError(resultAndError))
+        return status;
+
+    status = "success";
     return status;
 }
 
 QString PollyIntegration::UploadPeaksToCloud(QString session_indentifier, QString fileName, QString filePath){
+    QString status;
     QElapsedTimer timer;
     timer.start();
     QString command = "getPeakUploadUrls";
-    QList<QByteArray> result_and_error = runQtProcess(command, QStringList() << session_indentifier << fileName);
-    QString uploadUrl = getFileUploadURLs(result_and_error.at(0));
-    QString status = UploadToCloud(uploadUrl, filePath);
+    QList<QByteArray> resultAndError = runQtProcess(command, QStringList() << session_indentifier << fileName);
+    if (_hasError(resultAndError))
+        return status;
+
+    QString uploadUrl = getFileUploadURLs(resultAndError.at(0));
+    status = UploadToCloud(uploadUrl, filePath);
     qDebug() << "time taken in uploading json file, by polly cli is - " << timer.elapsed();
     return status;
 }

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -389,7 +389,6 @@ QString PollyIntegration::authenticateLogin(QString username, QString password) 
     else {
         status = "incorrect credentials";
     }
-    QMap<QString, QStringList> _fetchAppLicense();
     return status;
 }
 

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -331,6 +331,37 @@ int PollyIntegration::checkLoginStatus(){
     return status;
 }
 
+// void PollyIntegration::checkLicense() {
+//     qDebug() << "checking license";
+//     QString command = "getLicense";
+//     QString status;
+
+//     QList<QByteArray> resultAndError = runQtProcess(command, QStringList() << credFile);
+//     QByteArray result = resultAndError.at(0);
+
+//     // split based on newlines, JSON is second last string after split
+//     QList<QByteArray> resultList = result.split('\n');
+//     result = resultList[resultList.size() - 1];
+
+//     // remove extra quotation around JSON array
+//     result = result.right(result.size() - 1);
+//     //result = result.left(result.size() - 1);
+//     // replace doubly escaped quotes
+//     result = result.replace("\\\"", "\"");
+
+
+//     qDebug() << result;
+
+//     QJsonDocument doc(QJsonDocument::fromJson(result));
+//     QJsonObject jsonObj = doc.object()["licenses"].toObject();
+//     auto licenses = jsonObj.keys();
+//     auto component = jsonObj["components"].toArray();
+//     if (component.size())
+//         qDebug() << component;
+
+//     qDebug() << "json error" << QString::number(-1);
+// }
+
 // name OF FUNCTION: authenticateLogin
 // PURPOSE:
 //    This function is responsible for authenticating the user.
@@ -358,6 +389,7 @@ QString PollyIntegration::authenticateLogin(QString username, QString password) 
     else {
         status = "incorrect credentials";
     }
+    QMap<QString, QStringList> _fetchAppLicense();
     return status;
 }
 

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -242,7 +242,7 @@ QString PollyIntegration::obtainComponentId(PollyApp app)
     for (auto elem : array) {
         auto jsonObject = elem.toObject();
         auto name = jsonObject.value("component").toString();
-        if (name == _stringForApp(app))
+        if (name == componentName)
             return QString::number(jsonObject.value("id").toInt());
     }
     return QString::number(-1);

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -141,6 +141,13 @@ public:
     QString obtainComponentId(PollyApp app);
 
     /**
+     * @brief Get the status of current user's application licenses on Polly.
+     * @return A map of PollyApp and a boolean value indicating whether the user
+     * should have access to that application.
+     */
+    QMap<PollyApp, bool> getAppLicenseStatus();
+
+    /**
      * @brief Extract out a workflow ID from a JSON response obtained by
      * requesting to api/wf-fe-info endpoint.
      * @param workflowName The Polly application for which ID is needed.
@@ -179,6 +186,7 @@ private:
     QMap<QString, QStringList> _fetchAppLicense();
     void checkForIndexFile();
     bool validCohorts(QStringList cohorts);
+    QString _stringForApp(PollyApp app);
 };
 
 #endif // POLLYINTEGRATION_H

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -167,7 +167,7 @@ public slots:
     void requestFailed();
 
 Q_SIGNALS:
-    void sendEPIError(QString);
+    void receivedEPIError(QString);
 
 private:
     QString _username;

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -184,6 +184,9 @@ public slots:
     void requestSuccess();
     void requestFailed();
 
+Q_SIGNALS:
+    void sendEPIError(QString);
+
 private:
     QString _username;
     QString credFile;
@@ -197,6 +200,7 @@ private:
     void checkForIndexFile();
     bool validCohorts(QStringList cohorts);
     QString _stringForApp(PollyApp app);
+    bool _hasError(QList<QByteArray>);
 };
 
 #endif // POLLYINTEGRATION_H

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -92,7 +92,6 @@ public:
                            QStringList loadedSamples = QStringList());
     QString getCredFile();
     QString getCurrentUsername();
-    //void checkLicense();
 
     /**
      * @brief check for active internet connection

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -141,6 +141,16 @@ public:
     QString obtainComponentId(PollyApp app);
 
     /**
+     * @brief Extract out a workflow ID from a JSON response obtained by
+     * requesting to api/wf-fe-info endpoint.
+     * @param workflowName The Polly application for which ID is needed.
+     * @return The workflow ID as a QString.
+     */
+    QString obtainWorkflowId(PollyApp app);
+
+    QString obtainComponentName(PollyApp app);
+
+    /**
      * @brief Get the status of current user's application licenses on Polly.
      * @return A map of PollyApp and a boolean value indicating whether the user
      * should have access to that application.

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -139,14 +139,6 @@ public:
      */
     QString obtainComponentId(PollyApp app);
 
-    /**
-     * @brief Extract out a workflow ID from a JSON response obtained by
-     * requesting to api/wf-fe-info endpoint.
-     * @param workflowName The Polly application for which ID is needed.
-     * @return The workflow ID as a QString.
-     */
-    QString obtainWorkflowId(PollyApp app);
-
     QString obtainComponentName(PollyApp app);
 
     /**
@@ -163,15 +155,6 @@ public:
      * @return The workflow ID as a QString.
      */
     QString obtainWorkflowId(PollyApp app);
-
-    QString obtainComponentName(PollyApp app);
-
-    /**
-     * @brief Get the status of current user's application licenses on Polly.
-     * @return A map of PollyApp and a boolean value indicating whether the user
-     * should have access to that application.
-     */
-    QMap<PollyApp, bool> getAppLicenseStatus();
 
     /**
      * @brief Get the string name of a PollyApp enum identifier.

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -92,6 +92,7 @@ public:
                            QStringList loadedSamples = QStringList());
     QString getCredFile();
     QString getCurrentUsername();
+    //void checkLicense();
 
     /**
      * @brief check for active internet connection

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -181,7 +181,6 @@ private:
     QMap<QString, QStringList> _fetchAppLicense();
     void checkForIndexFile();
     bool validCohorts(QStringList cohorts);
-    QString _stringForApp(PollyApp app);
     bool _hasError(QList<QByteArray>);
 };
 


### PR DESCRIPTION
- If API returns an error message, display it in the format:
error Message
Type: errorCode
Contact details for support

- If API does not return a proper error message that can be read by El-MAVEN, the complete standard error will be displayed
- If there is any other error in EPI that leads to a failure, a general message is displayed with contact details for support