### PR TITLE
Fix login errors

### DIFF
--- a/src/cli/peakdetector/peakdetectorcli.cpp
+++ b/src/cli/peakdetector/peakdetectorcli.cpp
@@ -1020,6 +1020,11 @@ QString PeakDetectorCLI::uploadToPolly(QString jsPath,
     if (loginResponse == ErrorStatus::Failure) {
         cerr << "Incorrect credentials. Please check." << endl;
         return uploadProjectId;
+    } else if (loginResponse == ErrorStatus::Error) {
+        cerr << "A server error was encountered. Please contact tech support "
+                "at elmaven@elucidata.io if the problem persists."
+             << endl;
+        return uploadProjectId;
     }
 
     // User is logged in, now proceeding to upload…

--- a/src/gui/mzroll/forms/loginform.ui
+++ b/src/gui/mzroll/forms/loginform.ui
@@ -178,7 +178,7 @@
      <item>
       <widget class="QLabel" name="registerLabel">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New to Polly? &lt;a href=&quot;https://polly.elucidata.io/#/signup&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Request a demo now&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New to Polly? &lt;a href=&quot;https://calendly.com/elucidata/polly-demo&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Request a demo now&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
       </widget>
      </item>

--- a/src/gui/mzroll/forms/pollywaitdialog.ui
+++ b/src/gui/mzroll/forms/pollywaitdialog.ui
@@ -13,9 +13,6 @@
     <height>341</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Dialog</string>
-  </property>
   <widget class="QLabel" name="label">
    <property name="geometry">
     <rect>

--- a/src/gui/mzroll/loginform.cpp
+++ b/src/gui/mzroll/loginform.cpp
@@ -47,6 +47,7 @@ void LoginForm::login(QString username, QString password)
         ui->login_label->setText("Fetching user data…");
         QCoreApplication::processEvents();
         _pollyelmaveninterfacedialog->startupDataLoad();
+        _pollyelmaveninterfacedialog->usernameLabel->setText(username);
         hide();
         _pollyelmaveninterfacedialog->show();
     } else if (response == ErrorStatus::Failure) {

--- a/src/gui/mzroll/loginform.cpp
+++ b/src/gui/mzroll/loginform.cpp
@@ -51,8 +51,14 @@ void LoginForm::login(QString username, QString password)
         hide();
         _pollyelmaveninterfacedialog->show();
     } else if (response == ErrorStatus::Failure) {
+        QCoreApplication::processEvents();
         ui->login_label->setStyleSheet("QLabel {color : red; }");
         ui->login_label->setText("Incorrect credentials");
+        ui->pushButton->setEnabled(true);
+    } else {
+        QCoreApplication::processEvents();
+        ui->login_label->setStyleSheet("Qlabel {color : green; }");
+        ui->login_label->clear();
         ui->pushButton->setEnabled(true);
     }
 }

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -713,16 +713,6 @@ void PollyElmavenInterfaceDialog::_performPostFilesUploadTasks(QStringList patch
         _worker->start();
     } else {
         _performPostUploadTasks(false);
-        statusUpdate->setStyleSheet("QLabel {color : red;}");
-        QString errorTitle = "An unexpected error occured";
-        QString errorMessage = patchId.isEmpty() ? "Sorry. We were unable to "
-                                                   "send data."
-                                                 : "There seems to be a server "
-                                                   "issue. Please try again "
-                                                   "later.";
-        statusUpdate->setText(errorTitle);
-        _showErrorMessage(errorTitle,
-                          errorMessage);
     }
 }
 
@@ -914,6 +904,9 @@ void PollyElmavenInterfaceDialog::_performPostUploadTasks(bool uploadSuccessful)
     groupSetCombo->setEnabled(true);
     projectOptions->setEnabled(true);
     workflowMenu->setEnabled(true);
+    statusUpdate->setEnabled(true);
+    statusUpdate->setStyleSheet("QLabel { color : green;}");
+    statusUpdate->clear();
 }
 
 MainWindow* PollyElmavenInterfaceDialog::getMainWindow()

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -348,6 +348,10 @@ void PollyElmavenInterfaceDialog::showEPIError(QString errorMessage)
 {
     _resetUiElements();
     _showErrorMessage("Polly Error", errorMessage, QMessageBox::NoIcon);
+    _populateProjects();
+    _populateTables();
+    _hideFormIfNotLicensed();
+    QCoreApplication::processEvents();
 }
 
 void PollyElmavenInterfaceDialog::_callLoginForm()
@@ -458,11 +462,24 @@ void PollyElmavenInterfaceDialog::startupDataLoad()
         return;
     }
 
+    _populateProjects();
+    _populateTables();
+
+    _loadingDialog->close();
+    _hideFormIfNotLicensed();
+    QCoreApplication::processEvents();
+}
+
+void PollyElmavenInterfaceDialog::_populateProjects()
+{
     QStringList keys = _projectNameIdMap.keys();
     for (auto key : keys) {
         existingProjectCombo->addItem(_projectNameIdMap[key].toString());
     }
+}
 
+void PollyElmavenInterfaceDialog::_populateTables()
+{
     _bookmarkTable = _mainwindow->getBookmarkedPeaks();
     _addTableIfPossible(_bookmarkTable, "Bookmark Table ");
 
@@ -486,10 +503,6 @@ void PollyElmavenInterfaceDialog::startupDataLoad()
         // reset active table
         _activeTable = nullptr;
     }
-
-    _loadingDialog->close();
-    _hideFormIfNotLicensed();
-    QCoreApplication::processEvents();
 }
 
 void PollyElmavenInterfaceDialog::_hideFormIfNotLicensed()

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -77,6 +77,17 @@ PollyElmavenInterfaceDialog::PollyElmavenInterfaceDialog(MainWindow* mw)
                                                       "ViewTutorial",
                                                       appName);
             });
+    connect(demoButton,
+            &QPushButton::clicked,
+            [=] {
+                QDesktopServices::openUrl(
+                    QUrl("https://calendly.com/elucidata/polly-demo"));
+                auto appName = PollyIntegration::stringForApp(_selectedApp);
+                _mainwindow->getAnalytics()->hitEvent("PollyDialog",
+                                                      "DemoButton",
+                                                      appName);
+            });
+
     connect(_worker,
             SIGNAL(projectsReady(QVariantMap)),
             this,

--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -328,7 +328,9 @@ private:
      * @param title Title of the message box to be shown.
      * @param message Message to be shown.
      */
-    void _showErrorMessage(QString title, QString message);
+    void _showErrorMessage(QString title,
+                           QString message,
+                           QMessageBox::Icon icon);
 
     /**
      * @brief Reset and clear UI elements of the dialog to their fresh state.

--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -347,6 +347,10 @@ private:
 
     void _showPollyButtonIfUrlExists();
 
+    void _populateProjects();
+
+    void _populateTables();
+
 private Q_SLOTS:
 
     /**

--- a/src/gui/mzroll/pollywaitdialog.cpp
+++ b/src/gui/mzroll/pollywaitdialog.cpp
@@ -15,3 +15,9 @@ PollyWaitDialog::~PollyWaitDialog()
 {
     delete ui;
 }
+
+void PollyWaitDialog::keyPressEvent(QKeyEvent* e)
+{
+    if(e->key() != Qt::Key_Escape)
+        QDialog::keyPressEvent(e);
+}

--- a/src/gui/mzroll/pollywaitdialog.cpp
+++ b/src/gui/mzroll/pollywaitdialog.cpp
@@ -21,3 +21,8 @@ void PollyWaitDialog::keyPressEvent(QKeyEvent* e)
     if(e->key() != Qt::Key_Escape)
         QDialog::keyPressEvent(e);
 }
+
+void PollyWaitDialog::closeEvent(QCloseEvent* e)
+{
+    return;
+}

--- a/src/gui/mzroll/pollywaitdialog.cpp
+++ b/src/gui/mzroll/pollywaitdialog.cpp
@@ -24,5 +24,5 @@ void PollyWaitDialog::keyPressEvent(QKeyEvent* e)
 
 void PollyWaitDialog::closeEvent(QCloseEvent* e)
 {
-    return;
+    e->ignore();
 }

--- a/src/gui/mzroll/pollywaitdialog.cpp
+++ b/src/gui/mzroll/pollywaitdialog.cpp
@@ -8,7 +8,8 @@ PollyWaitDialog::PollyWaitDialog(QWidget *parent) : QDialog(parent), ui(new Ui::
     movie = new QMovie(":/images/loading.gif");
     movie->start();
 
-    setWindowTitle("Please Wait..");
+    //setWindowTitle("Please Wait..");
+    setWindowFlags(Qt::Window | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
 }
 
 PollyWaitDialog::~PollyWaitDialog()
@@ -20,9 +21,4 @@ void PollyWaitDialog::keyPressEvent(QKeyEvent* e)
 {
     if(e->key() != Qt::Key_Escape)
         QDialog::keyPressEvent(e);
-}
-
-void PollyWaitDialog::closeEvent(QCloseEvent* e)
-{
-    e->ignore();
 }

--- a/src/gui/mzroll/pollywaitdialog.h
+++ b/src/gui/mzroll/pollywaitdialog.h
@@ -17,6 +17,8 @@ public:
     ~PollyWaitDialog();
     QMovie* movie;
 
+    void keyPressEvent(QKeyEvent* e);
+
 private:
     Ui::PollyWaitDialog *ui;
 };

--- a/src/gui/mzroll/pollywaitdialog.h
+++ b/src/gui/mzroll/pollywaitdialog.h
@@ -18,6 +18,7 @@ public:
     QMovie* movie;
 
     void keyPressEvent(QKeyEvent* e);
+    void closeEvent(QCloseEvent* e);
 
 private:
     Ui::PollyWaitDialog *ui;

--- a/src/gui/mzroll/pollywaitdialog.h
+++ b/src/gui/mzroll/pollywaitdialog.h
@@ -18,7 +18,6 @@ public:
     QMovie* movie;
 
     void keyPressEvent(QKeyEvent* e);
-    void closeEvent(QCloseEvent* e);
 
 private:
     Ui::PollyWaitDialog *ui;

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -328,7 +328,6 @@ bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
     if (resultAndError.size() > 1) {
         //if there is standard error look for error message
         QByteArray errorResponse = resultAndError.at(1);
-        errorResponse.replace(QByteArray("\n"), QByteArray(""));
 
         QJsonDocument doc(QJsonDocument::fromJson(errorResponse));
         QJsonObject jsonObj = doc.object();
@@ -356,7 +355,7 @@ bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
         QString errorString = QString::fromStdString(errorResponse.toStdString());
         errorString.replace("\n", "");
         if (!errorString.isEmpty()) {
-            QString errorMessage = "Unknown error:\n" +
+            QString errorMessage = "Unknown error: " + errorString + "\n" +
                                    supportMessage;
             emit receivedEPIError(errorMessage);
             return true;

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -184,6 +184,11 @@ QMap<PollyApp, bool> PollyIntegration::getAppLicenseStatus()
 
     if (error == ErrorStatus::Error ||
         error == ErrorStatus::Failure) {
+        appLicenseStatus = {
+            {PollyApp::FirstView, false},
+            {PollyApp::PollyPhi, false},
+            {PollyApp::QuantFit, false}
+        };
         return appLicenseStatus;
     }
 

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -344,7 +344,7 @@ bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
 
         if (!message.isEmpty() || !type.isEmpty()) {
             QString errorMessage = message + "\n" +
-                                   "Type: " + type + "\n" +
+                                   type + "\n" +
                                    supportMessage;
             emit receivedEPIError(errorMessage);
             return true;


### PR DESCRIPTION
Some final polish to the recent EPI refactoring:
1. Remove two different error dialogs for network/server errors.
2. Display username even for the first EPI login.
3. Handle error in license fetching and prevent an indefinite mutual recursion.
4. Handle error state for auth in CLI.
5. Add new URL for booking a Polly demo.
6. Handle EPI errors more cleanly and prevent dismissal of "Loading" banner.