### PR TITLE
Update widgets from EicPoint using static methods

### DIFF
--- a/src/gui/mzroll/point.h
+++ b/src/gui/mzroll/point.h
@@ -57,6 +57,11 @@ private:
     bool _forceFill;
     float _cSize;
 
+    static void _updateWidgetsForPeakGroup(MainWindow* mw,
+                                           PeakGroup* group,
+                                           Peak* peak);
+    static void _updateWidgetsForScan(MainWindow* mw, Scan* scan);
+
 private Q_SLOTS:
 	void bookmark();
 	void linkCompound();


### PR DESCRIPTION
An EicPoint object drawn on an EIC is destroyed whenever that EIC
window scene is cleared. The EIC is cleared everytime it is
resized, so whenever a user clicks on an MS2 marker in the EIC
window, an EicPoint for that MS2 marker will trigger opening of
spectra widget, which in turn changes the size of EIC window
causing the EicPoint itself to be deleted before it could perform
other necessary widget updates. This was causing a crash because
the method in call was trying to use invalidated variables, past
their lifetime.

With this patch, all direct widget updates are now handled by new
static methods of the EicPoint class, that have stable copies of
required pointers.