### PR TITLE
Fix untargeted EPI crash

### DIFF
--- a/src/cli/peakdetector/peakdetectorcli.cpp
+++ b/src/cli/peakdetector/peakdetectorcli.cpp
@@ -1137,17 +1137,19 @@ void PeakDetectorCLI::saveCSV(string setName, bool pollyExport)
 
     csvreports->setUserQuantType(quantitationType);
 
-    auto prmGroupAt =
+    auto ddaGroupAt =
         find_if(begin(mavenParameters->allgroups),
                 end(mavenParameters->allgroups),
                 [](PeakGroup& group) {
+                    if (!group.compound)
+                        return false;
                     return group.compound->type() == Compound::Type::PRM;
                 });
-    bool prmGroupExists = prmGroupAt != end(mavenParameters->allgroups);
+    bool ddaGroupExists = ddaGroupAt != end(mavenParameters->allgroups);
 
     // Added to pass into csvreports file when merged with Maven776 - Kiran
     // CLI exports the default Group Summary Matrix Format (without set Names)
-    csvreports->openGroupReport(fileName, prmGroupExists);
+    csvreports->openGroupReport(fileName, ddaGroupExists);
 
     for (int i = 0; i < mavenParameters->allgroups.size(); i++) {
         PeakGroup& group = mavenParameters->allgroups[i];
@@ -1184,7 +1186,7 @@ void PeakDetectorCLI::saveCSV(string setName, bool pollyExport)
 
     if (fileNeedsCorrection) {
         // rewrite file if needed
-        csvreports->openGroupReport(fileName, prmGroupExists);
+        csvreports->openGroupReport(fileName, ddaGroupExists);
         csvreports->groupId = 0;
 
         sort(groupsWithMissingLabels.begin(), groupsWithMissingLabels.end());

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -840,7 +840,7 @@ void MainWindow::showNotification(TableDockWidget* table) {
     QString message("Make your analyses more insightful with Machine learning."
                     "\nView your fluxomics workflow in PollyPhi.");
 
-    if (table->groupCount() == 0 || table->labeledGroups == 0)
+    if (table->groupCount() == 0 || table->getLabeledGroupCount() == 0)
         return;
 
     Notificator* fluxomicsPrompt = Notificator::showMessage(icon,

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -536,9 +536,9 @@ void PollyElmavenInterfaceDialog::_showPollyButtonIfUrlExists()
 void PollyElmavenInterfaceDialog::_addTableIfPossible(TableDockWidget* table,
                                                       QString tableName)
 {
-    if (!table->getGroups().isEmpty()) {
+    if (!table->getGroups().isEmpty() && table->getTargetedGroupCount() > 0) {
         if (_selectedApp == PollyApp::PollyPhi
-            && table->labeledGroups > 0) {
+            && table->getLabeledGroupCount() > 0) {
             peakTableCombo->addItem(tableName);
         } else if (_selectedApp == PollyApp::FirstView
                    || _selectedApp == PollyApp::QuantFit) {

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -23,6 +23,8 @@ TableDockWidget::TableDockWidget(MainWindow *mw) {
   setAllowedAreas(Qt::AllDockWidgetAreas);
   setFloating(false);
   _mainwindow = mw;
+  _labeledGroups = 0;
+  _targetedGroups = 0;
   pal = palette();
   setAutoFillBackground(true);
   pal.setColor(QPalette::Background, QColor(170, 170, 170, 100));
@@ -407,8 +409,10 @@ void ListView::keyPressEvent(QKeyEvent *event) {
 PeakGroup *TableDockWidget::addPeakGroup(PeakGroup *group) {
   if (group != NULL) {
     allgroups.push_back(*group);
-	if (group->childCount() > 0)
-		labeledGroups++;
+    if (group->childCount() > 0)
+      _labeledGroups++;
+    if (group->compound)
+      _targetedGroups++;
     if (allgroups.size() > 0) {
       PeakGroup &g = allgroups[allgroups.size() - 1];
       for (unsigned int i = 0; i < allgroups.size(); i++) {
@@ -728,9 +732,9 @@ void TableDockWidget::prepareDataForPolly(QString writableTempDir,
   QList<PeakGroup *> selectedGroups = getSelectedGroups();
   csvreports->setSelectionFlag(static_cast<int>(peakTableSelection));
 
-  for (int i = 0; i < allgroups.size(); i++) {
-    if (selectedGroups.contains(&allgroups[i])) {
-      PeakGroup &group = allgroups[i];
+  for (auto& group : allgroups) {
+    // we do not set untargeted groups to Polly yet, remove this when we can.
+    if (selectedGroups.contains(&group) && group.compound != nullptr) {
       csvreports->addGroup(&group);
     }
   }
@@ -1011,7 +1015,9 @@ void TableDockWidget::deleteGroup(PeakGroup *groupX) {
       item->setHidden(true);
 
       if (group->children.size() > 0)
-            labeledGroups--;
+        _labeledGroups--;
+      if (group->compound)
+        _targetedGroups--;
 
       // Deleting
       int posTree = treeWidget->indexOfTopLevelItem(item);
@@ -1913,6 +1919,16 @@ void TableDockWidget::switchTableView() {
   updateTable();
 }
 
+int TableDockWidget::getTargetedGroupCount()
+{
+  return _targetedGroups;
+}
+
+int TableDockWidget::getLabeledGroupCount()
+{
+  return _labeledGroups;
+}
+
 QWidget *TableToolBarWidgetAction::createWidget(QWidget *parent) {
   if (btnName == "titlePeakTable") {
 
@@ -2457,8 +2473,10 @@ void BookmarkTableDockWidget::deleteGroup(PeakGroup *groupX) {
     if (group != NULL and group == groupX) {
         item->setHidden(true);
 
-	    if (group->children.size() > 0)
-            	labeledGroups--;
+    if (group->children.size() > 0)
+      _labeledGroups--;
+    if (group->compound)
+      _targetedGroups--;
 
       	// Deleting
         int posTree = treeWidget->indexOfTopLevelItem(item);

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -698,21 +698,23 @@ void TableDockWidget::prepareDataForPolly(QString writableTempDir,
 
   csvreports->setUserQuantType(_mainwindow->getUserQuantType());
 
-  auto prmGroupAt = find_if(begin(allgroups),
+  auto ddaGroupAt = find_if(begin(allgroups),
                             end(allgroups),
                             [] (PeakGroup& group) {
+                              if (!group.compound)
+                                return false;
                               return group.compound->type() == Compound::Type::PRM;
                             });
-  bool prmGroupExists = prmGroupAt != end(allgroups);
+  bool ddaGroupExists = ddaGroupAt != end(allgroups);
   bool includeSetNamesLines = true;
 
   if (sFilterSel == groupsSCSV) {
     csvreports->openGroupReport(fileName.toStdString(),
-                                prmGroupExists,
+                                ddaGroupExists,
                                 includeSetNamesLines);
   } else if (sFilterSel == groupsSTAB) {
     csvreports->openGroupReport(fileName.toStdString(),
-                                prmGroupExists,
+                                ddaGroupExists,
                                 includeSetNamesLines);
   } else if (sFilterSel == peaksCSV) {
     csvreports->openPeakReport(fileName.toStdString());
@@ -720,7 +722,7 @@ void TableDockWidget::prepareDataForPolly(QString writableTempDir,
     csvreports->openPeakReport(fileName.toStdString());
   } else {
     // default to group summary
-    csvreports->openGroupReport(fileName.toStdString(), prmGroupExists);
+    csvreports->openGroupReport(fileName.toStdString(), ddaGroupExists);
   }
 
   QList<PeakGroup *> selectedGroups = getSelectedGroups();

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -31,7 +31,6 @@ public:
   QTreeWidget *treeWidget;
   QLabel *titlePeakTable;
   JSONReports *jsonReports;
-  int labeledGroups = 0;
   int numberOfGroupsMarked = 0;
   QString writableTempS3Dir;
   /**
@@ -97,6 +96,18 @@ public:
    * @return Floating precision value of maximum intensity
    */
   float extractMaxIntensity(PeakGroup *group);
+
+  /**
+   * @brief Get the number of targeted groups in this peak table.
+   * @return Targeted group count as integer.
+   */
+  int getTargetedGroupCount();
+
+  /**
+   * @brief Get the number of labeled groups in this peak table.
+   * @return Targeted group count as integer.
+   */
+  int getLabeledGroupCount();
 
 public Q_SLOTS:
   void updateCompoundWidget();
@@ -199,6 +210,8 @@ public Q_SLOTS:
 protected:
   MainWindow *_mainwindow;
   tableViewType viewType;
+  int _labeledGroups;
+  int _targetedGroups;
   void dragEnterEvent(QDragEnterEvent *event);
   void dropEvent(QDropEvent *event);
   void focusInEvent(QFocusEvent *event);


### PR DESCRIPTION
This PR contains the following fixes:
 -  Prevent crash while preparing untargeted groups for Polly.
 -  Prevent crash while preparing untargeted groups in CLI.
 -  Block untargeted groups from being uploaded to Polly.