### PR TITLE
Ignore MS2+ scans

### DIFF
--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -396,8 +396,8 @@ void mzSample::parseMzMLChromatogramList(const xml_node &chromatogramList)
 
 		// if (precursorMz and precursorMz ) {
 		if (precursorMz)
-		{					 //naman Same expression on both sides of '&&'.
-			int mslevel = 2; //naman The scope of the variable 'mslevel' can be reduced.
+		{
+			int mslevel = 2; //msLevel information cannot be read from the sample?
 			for (unsigned int i = 0; i < timeVector.size(); i++)
 			{
 				Scan *scan = new Scan(this, scannum++, mslevel, timeVector[i], precursorMz, -1);
@@ -1175,7 +1175,7 @@ EIC *mzSample::getEIC(float precursorMz, float collisionEnergy, float productMz,
 		Scan *scan = scans[i];
 		if (!(scan->filterLine == filterline || filterline == ""))
 			continue;
-		if (scan->mslevel < 2)
+		if (scan->mslevel != 2)
 			continue;
 		if (precursorMz && abs(scan->precursorMz - precursorMz) > amuQ1)
 			continue;
@@ -1847,7 +1847,7 @@ vector<Scan*> mzSample::getFragmentationEvents(mzSlice* slice)
 {
     vector<Scan*> matchedScans;
     for (auto scan : scans) {
-        if (scan->mslevel <= 1) continue; //ms2 + scans only
+        if (scan->mslevel != 2) continue; //ms2 scans only
         if (scan->rt < slice->rtmin) continue;
         if (scan->rt > slice->rtmax) break;
         if( scan->precursorMz >= slice->mzmin && scan->precursorMz <= slice->mzmax) {

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -2009,7 +2009,7 @@ void EicWidget::addMS2Events(float mzmin, float mzmax)
     for (auto const& sample : samples) {
 		if (sample->ms1ScanCount() == 0) continue;
         for (auto const& scan : sample->scans) {
-            if (scan->mslevel > 1 &&
+            if (scan->mslevel == 2 &&
 				scan->precursorMz >= mzmin &&
 				scan->precursorMz <= mzmax) {
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3660,7 +3660,7 @@ void MainWindow::showFragmentationScans(float pmz)
             continue;
 
         for (auto scan : sample->scans) {
-	        if (scan->mslevel < 2) continue;
+	        if (scan->mslevel != 2) continue;
 	        if (massCutoffDist(scan->precursorMz,
                                pmz,
                                massCutoff) > massCutoff->getMassCutoff()) {

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -176,7 +176,7 @@ void EicPoint::_updateWidgetsForScan(MainWindow* mw, Scan* scan)
         }
         if (mw->spectraWidget->isVisible())
             mw->spectraWidget->setScan(scan);
-        if(scan->mslevel >= 2)
+        if(scan->mslevel == 2)
             mw->spectralHitsDockWidget->limitPrecursorMz(scan->precursorMz);
     }
 }

--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -295,7 +295,7 @@ void SpectraWidget::overlayCompoundFragmentation(Compound* c)
 
     cerr << "SpectraWidge::overlayCompoundfragmentation(Compound)" << c->name << " " << c->precursorMz << endl;
 
-    if (_currentScan && _currentScan->mslevel != 1) {
+    if (_currentScan && _currentScan->mslevel == 2) {
         _showOverlay = true;
         overlaySpectralHit(_spectralHit);
         resetZoom();


### PR DESCRIPTION
Currently, El-MAVEN only has proper workflows for MS1 and MS2 data.

While El-MAVEN can read the MS3 data, there is no point in processing
those scans till a workflow is put in place.

Going forward, only MS2 scans will be processed for fragmentation related functions, not MS2+

Note: This commit also resolves a crash in untargeted workflow when MS3 scans are present.