### PR TITLE
[GA] Add a unique userID for every system

### DIFF
--- a/src/gui/mzroll/analytics.cpp
+++ b/src/gui/mzroll/analytics.cpp
@@ -23,6 +23,7 @@ QUrlQuery Analytics::intialSetup()
     query.addQueryItem("v", "1"); // Version
     query.addQueryItem("tid", trackerID); // Tracking ID
     query.addQueryItem("cid", clientID); // Client ID
+    query.addQueryItem("uid", clientID); //User ID same as Client ID for now
     query.addQueryItem("ul", language); // Language
     query.addQueryItem("an", qApp->applicationName()); // Application Name
     query.addQueryItem("av", qApp->applicationVersion()); // Application Version


### PR DESCRIPTION
Currently the userID is the same as the clientID.
If/when a login feature is added to El-MAVEN, we can map the credentials to the userIDs


Need to test this on an instance, since Delhi users are excluded from the GA view and changing the filter takes 24 hours to take effect.

Used [this](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters) as a reference for parameters to be used.