### PR TITLE
Disable EPI group subset options

### DIFF
--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -445,6 +445,13 @@ private Q_SLOTS:
      */
     void _hideFormIfNotLicensed();
 
+    /**
+     * @brief Enable or disables group subset options, based on the table name
+     * passed.
+     * @param tableName Name of the table for which the group options have to be
+     * revised.
+     */
+    void _reviseGroupOptions(QString tableName);
 };
 
 #endif


### PR DESCRIPTION
The ability to export good groups should only be available if the
user has any good groups in their table. Similarly, Excluding bad
groups should not be an option if all groups are bad in a table.
This patch makes sure that these options are disabled in the
respective scenarios so that its not possible to send empty groups
file to Polly.