### PR TITLE
Fix fragmentation spectra overlay

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -774,7 +774,7 @@ Scan* PeakGroup::getAverageFragmentationScan(float productPpmTolr)
 {
     //build consensus ms2 specta
     computeFragPattern(productPpmTolr);
-    Scan* avgScan = new Scan(NULL, 0, 0, 0, 0, 0);
+    Scan* avgScan = new Scan(NULL, 0, 2, 0, 0, 0);
 
     for(unsigned int i = 0; i < fragmentationPattern.mzValues.size(); i++) {
         avgScan->mz.push_back(fragmentationPattern.mzValues[i]);

--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -337,11 +337,7 @@ void SpectraWidget::showConsensusSpectra(PeakGroup* group)
 
     if (consensus) {
         _scanset = group->getFragmentationEvents();
-        _currentScan = consensus;
-        _currentScan->scannum = 0;
-        _currentScan->sample = 0;
-        _currentScan->rt = group->meanRt;
-        _currentScan->precursorMz = group->meanMz;
+        _currentScan->deepcopy(consensus);
         this->findBounds(true, true);
         this->drawGraph();
     }


### PR DESCRIPTION
Spectra overlay is displayed only for MSMS scans.
Since representative spectrum did not have an assigned msLevel 2,
only the group spectra was being displayed.

This commit assigns the msLevel value to the average scan and makes a deepcopy instead of assigning choice values one by one.