### PR TITLE
Change peak quantification type for mzrollDB

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1760,6 +1760,7 @@ void MainWindow::open()
             emdbProjectBeingLoaded = fileLoader->swapFilenameExtension(filename,
                                                                        "emDB");
             analytics->hitEvent("Project Load", "mzrollDB");
+            quantType->setCurrentText("AreaTopNotCorrected");
         } else if (fileLoader->isMzRollProject(filename)) {
             analytics->hitEvent("Project Load", "mzroll");
         }


### PR DESCRIPTION
mzrollDB format does not save corrected peak area top, our current
preferred default for peak quantification type. MAVEN's default
quantification type is peak area corrected, which from now on will
be automatically set whenever a user loads in an mzrollDB file.