### PR TITLE
[CLI] Inform user if data is incompatible with Polly apps

### DIFF
--- a/src/cli/peakdetector/peakdetectorcli.h
+++ b/src/cli/peakdetector/peakdetectorcli.h
@@ -272,6 +272,8 @@ private:
      * @return Redirection URL as a QString.
      */
     QString _getRedirectionUrl(QString datetimestamp, QString uploadProjectId);
+
+    bool _incompatibleWithPollyApp();
 };
 
 struct Arguments


### PR DESCRIPTION
3 checks have been added to CLI:
- untargeted data should not be sent to any Polly apps
- unlabeled data should not be sent to PollyPhi
- MRM data should not be sent to PollyPhi