### PR TITLE
Clear license data on logout

### DIFF
--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -960,6 +960,7 @@ QStringList PollyElmavenInterfaceDialog::_prepareFilesToUpload(QDir qdir,
 void PollyElmavenInterfaceDialog::_logout()
 {
     usernameLabel->setText("");
+    _licenseMap.clear();
     _pollyIntegration->logout();
     _projectNameIdMap = QVariantMap();
     _loadingDialog->close();


### PR DESCRIPTION
The license map was not cleared on logout. If another user logs in within the same session, the license information will not be updated.

This has been fixed in this PR.