### PR TITLE
Allow an extra argument to be passed to CLI

### DIFF
--- a/mzroll.pri
+++ b/mzroll.pri
@@ -15,7 +15,7 @@ win32 {
 unix: {
     INCLUDEPATH += /usr/local/include/ $$top_srcdir/3rdparty/obiwarp
     QMAKE_LFLAGS += -L/usr/local/lib/ -L$$top_builddir/libs/
-    LIBS +=  -lboost_signals -lErrorHandling -lobiwarp -lboost_iostreams
+    LIBS += -lErrorHandling -lobiwarp -lboost_iostreams
 }
 
 !isEmpty(ON_TRAVIS)|!isEmpty(ON_APPVEYOR) {

--- a/src/cli/peakdetector/peakdetectorcli.cpp
+++ b/src/cli/peakdetector/peakdetectorcli.cpp
@@ -96,7 +96,6 @@ void PeakDetectorCLI::processOptions(int argc, char* argv[])
             break;
 
         case 'E':
-            // parse sample cohort filename here
             _pollyExtraInfo = QString(optarg);
             break;
 
@@ -513,9 +512,13 @@ void PeakDetectorCLI::_processGeneralArgsXML(xml_node& generalArgs)
             if (atoi(node.attribute("value").value()) == 0)
                 saveMzrollFile = false;
 
+        } else if (strcmp(node.name(), "pollyExtra") == 0) {
+            _pollyExtraInfo = QString(node.attribute("value").value());
+
         } else if (strcmp(node.name(), "samples") == 0) {
             string sampleStr = node.attribute("value").value();
             filenames.push_back(sampleStr);
+
         } else {
             cout << endl << "Unknown node : " << node.name() << endl;
         }

--- a/src/cli/peakdetector/peakdetectorcli.cpp
+++ b/src/cli/peakdetector/peakdetectorcli.cpp
@@ -95,6 +95,11 @@ void PeakDetectorCLI::processOptions(int argc, char* argv[])
                 mavenParameters->processAllSlices = false;
             break;
 
+        case 'E':
+            // parse sample cohort filename here
+            _pollyExtraInfo = QString(optarg);
+            break;
+
         case 'f': {
             mavenParameters->pullIsotopesFlag = 0;
             int label = 0;
@@ -944,7 +949,8 @@ QString PeakDetectorCLI::_getRedirectionUrl(QString datetimestamp,
             _pollyIntegration->obtainComponentId(PollyApp::QuantFit);
         QString runRequestId =
             _pollyIntegration->createRunRequest(componentId,
-                                                uploadProjectId);
+                                                uploadProjectId,
+                                                _pollyExtraInfo);
         if (!runRequestId.isEmpty()) {
             redirectionUrl =
                 _pollyIntegration->getComponentEndpoint(componentId,

--- a/src/cli/peakdetector/peakdetectorcli.h
+++ b/src/cli/peakdetector/peakdetectorcli.h
@@ -209,6 +209,7 @@ public:
             "A?pollyApp: Polly application to upload to after peak detection finishes. Enter 1 for PollyPhi or 2 for QuantFit. <int>",
             "N?pollyProject: Polly project where we want to upload our files. <string>",
             "S?sampleCohort: Sample cohort file needed for PollyPhi workflow. <string>",
+            "E?pollyExtra: Any miscellaneous information that needs to be sent to Polly. <string>",
             nullptr
         };
         return options;
@@ -226,6 +227,7 @@ private:
     JSONReports* _jsonReports;
     bool _reduceGroupsFlag;
     PollyApp _currentPollyApp;
+    QString _pollyExtraInfo;
 
     /**
      * [Load Arguments for Options Dialog]

--- a/src/cli/peakdetector/peakdetectorcli.h
+++ b/src/cli/peakdetector/peakdetectorcli.h
@@ -289,6 +289,7 @@ struct Arguments
         generalArgs << "int" << "saveEicJson" << "0";
         generalArgs << "string" << "outputdir" << "0";
         generalArgs << "int" << "savemzroll" << "0";
+        generalArgs << "string" << "pollyExtra" << "";
         generalArgs << "string" << "samples" << "path/to/sample1";
         generalArgs << "string" << "samples" << "path/to/sample2";
         generalArgs << "string" << "samples" << "path/to/sample3";

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -594,13 +594,15 @@ QString PollyIntegration::createWorkflowRequest(QString projectId,
 }
 
 QString PollyIntegration::createRunRequest(QString componentId,
-                                           QString projectId)
+                                           QString projectId,
+                                           QString extraInfo)
 {
     QString runId;
     QString command = "createRunRequest";
     QStringList arguments = QStringList() << credFile
                                           << componentId
-                                          << projectId;
+                                          << projectId
+                                          << extraInfo;
     QList<QByteArray> resultAndError = runQtProcess(command, arguments);
     if (_hasError(resultAndError))
         return runId;

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -47,9 +47,13 @@ public:
      * @brief This creates a run request for QuantFit and returns its ID.
      * @param componentName The name of Polly component to create run for.
      * @param projectId The ID of the project for which to create run.
+     * @param extraInfo Extra information that can be used on Polly however it
+     * may be required.
      * @return Returns run request ID as a QString.
      */
-    QString createRunRequest(QString componentId, QString projectId);
+    QString createRunRequest(QString componentId,
+                             QString projectId,
+                             QString extraInfo="");
 
     /**
      * @brief Execute terminal commands from c++


### PR DESCRIPTION
An extra parameter has been added to the CLI that can be used on
Polly or any other applications that use the CLI for their custom
pipelines.

Additionally, in this PR the extra information will be sent to
QuantFit when making a run request.