### PR TITLE
Write Polly's post-upload redirection URL in file

### DIFF
--- a/src/cli/peakdetector/peakdetectorcli.cpp
+++ b/src/cli/peakdetector/peakdetectorcli.cpp
@@ -875,6 +875,17 @@ void PeakDetectorCLI::writeReport(string setName,
                 cerr << "Unable to upload data to Polly." << endl;
             }
 
+            // NOTE: Adding this to help clients of this CLI to be able to
+            // access the redirection URL.
+            QString fname = "polly_redirection_url.txt";
+            QString fpath = QStandardPaths::writableLocation(
+                                QStandardPaths::GenericConfigLocation)
+                            + QDir::separator()
+                            + fname;
+            ofstream ofs(fpath.toStdString());
+            ofs << redirectionUrl.toStdString() << endl;
+            ofs.close();
+
             // if redirection URL is not empty then we can print it on console
             // and send the user an email with that URL
             if (!redirectionUrl.isEmpty()) {


### PR DESCRIPTION
This change implements an internal request, but may be useful for other application developers who want to use the redirection URL returned from any of the Polly applications (supported by El-MAVEN's CLI). The URL is written to a file in the user's local temporary directory.