### PR TITLE
Remove unnecessary vector copy

### DIFF
--- a/3rdparty/obiwarp/dynprog.cpp
+++ b/3rdparty/obiwarp/dynprog.cpp
@@ -1301,10 +1301,5 @@ void DynProg::find_path(MatF& smat, VecF &gap_penalty, int minimize, float diag_
     _traceback(tmp_tb, smat, optimal_m, optimal_n, tmp_tbpath, _mCoords, _nCoords, _sCoords); 
     int _equivLastInd = _mCoords.dim()-1;
     _bestScore = tmp_asmat(_mCoords[_equivLastInd],_nCoords[_equivLastInd]);
-
-    _asmat.take(tmp_asmat);
-    _tb.take(tmp_tb);
-    _tbpath.take(tmp_tbpath);
-    _gapmat.take(tmp_gapmat);
 }
 


### PR DESCRIPTION
Temporary matrices being used in `find_path` method are attempted
to be copied into ObiWarp's class matrices at the end. But these
matrices themselves are not being used anywhere else. The copy
operation was causing a crash due to attempts to free unallocated
memory. The copy operations have been removed to prevent this
crash.

Issue: #859