### PR TITLE
Fix filterline 

### DIFF
--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -340,7 +340,7 @@ void mzSample::parseMzMLChromatogramList(const xml_node& chromatogramList)
         string chromatogramId = chromatogram.attribute("id").value();
         int sampleNo = getSampleNoChromatogram(chromatogramId);
 
-        filterChromatogramId(chromatogramId);
+        cleanFilterLine(chromatogramId);
 
         vector<float> timeVector;
         vector<float> intsVector;
@@ -437,15 +437,15 @@ int mzSample::getSampleNoChromatogram(const string& chromatogramId)
         return -1;
 }
 
-void mzSample::filterChromatogramId(string& chromatogramId)
-{
+void mzSample::cleanFilterLine(string &filterline) {
+
     string filterRegex;
     regex rx;
     for (const string& filterId : filterChromatogram) {
         filterRegex = filterId + "\ *\=\ *[0-9]*\.?[0-9]+";
         rx = filterRegex;
-        chromatogramId = std::regex_replace(chromatogramId, rx, "");
-    }
+        filterline = std::regex_replace(filterline, rx, "");
+	}
 }
 
 void mzSample::parseMzMLSpectrumList(const xml_node& spectrumList)
@@ -486,6 +486,11 @@ void mzSample::parseMzMLSpectrumList(const xml_node& spectrumList)
             string rtStr = scanAttr["scan start time"];
             rt = string2float(rtStr);
         }
+
+        if (scanAttr.count("filter string")) {
+            spectrumId = scanAttr["filter string"];
+        }
+        cleanFilterLine(spectrumId);
 
         map<string, string> isolationWindow =
             mzML_cvParams(spectrum.first_element_by_path(

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -749,7 +749,8 @@ class mzSample
         "sample", 
         "start",
         "end",
-        "index"
+        "index",
+        "scan"
     };
 };
 

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -267,7 +267,7 @@ class mzSample
 
     int getSampleNoChromatogram(const string &chromatogramId);
 
-    void filterChromatogramId(string &chromatogramId);
+    void cleanFilterLine(string &filterline);
 
     /**
     * @brief Parse mzML spectrum list


### PR DESCRIPTION
This PR makes the following changes:
- Remove 'scan' attribute from filterline
- Read `filter string` attribute as filterline from spectrum list, if available. Continue to use `runId`, otherwise