### PR TITLE
Segmented alignment (read and write)

### DIFF
--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -581,15 +581,15 @@ bool Aligner::alignWithObiWarp(vector<mzSample*> samples,
 float AlignmentSegment::updateRt(float oldRt)
 {
     // fractional distance from start of a segement
-    if (oldRt >= seg_start and oldRt <= seg_end) {
-        float frac = (oldRt - seg_start) / (seg_end - seg_start);
-        return new_start + frac * (new_end - new_start);
+    if (oldRt >= segStart and oldRt <= segEnd) {
+        float frac = (oldRt - segStart) / (segEnd - segStart);
+        return newStart + frac * (newEnd - newStart);
     } else {
         cerr << "Bad Map: "
              << oldRt << "\t"
-             << seg_start
+             << segStart
              << "\t"
-             << seg_end
+             << segEnd
              << endl;
 
         // could not correct return old rt
@@ -621,8 +621,8 @@ void Aligner::performSegmentedAlignment()
         for (auto scan : sample->scans) {
             AlignmentSegment* seg = nullptr;
             for (auto segment : _alignmentSegments[sampleName]) {
-                if (scan->rt >= segment->seg_start
-                    && scan->rt <= segment->seg_end) {
+                if (scan->rt >= segment->segStart
+                    && scan->rt <= segment->segEnd) {
                     seg = segment;
                     break;
                 }

--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -581,7 +581,7 @@ bool Aligner::alignWithObiWarp(vector<mzSample*> samples,
 float AligmentSegment::updateRt(float oldRt)
 {
     // fractional distance from start of a segement
-    if (oldRt >= seg_start and oldRt < seg_end) {
+    if (oldRt >= seg_start and oldRt <= seg_end) {
         float frac = (oldRt - seg_start) / (seg_end - seg_start);
         return new_start + frac * (new_end - new_start);
     } else {
@@ -623,7 +623,7 @@ void Aligner::performSegmentedAligment()
             AligmentSegment* seg = nullptr;
             for (auto segment : _alignmentSegments[sampleName]) {
                 if (scan->rt >= segment->seg_start
-                    && scan->rt < segment->seg_end) {
+                    && scan->rt <= segment->seg_end) {
                     seg = segment;
                     break;
                 }

--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -618,7 +618,6 @@ void Aligner::performSegmentedAlignment()
             continue;
         }
 
-        int corcount = 0;
         for (auto scan : sample->scans) {
             AlignmentSegment* seg = nullptr;
             for (auto segment : _alignmentSegments[sampleName]) {
@@ -632,7 +631,6 @@ void Aligner::performSegmentedAlignment()
             if (seg) {
                 double newRt = seg->updateRt(scan->rt);
                 scan->rt = newRt;
-                corcount++;
             } else {
                 cerr << "Cannot find segment for: "
                      << sampleName

--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -578,7 +578,7 @@ bool Aligner::alignWithObiWarp(vector<mzSample*> samples,
     return(stopped);
 }
 
-float AligmentSegment::updateRt(float oldRt)
+float AlignmentSegment::updateRt(float oldRt)
 {
     // fractional distance from start of a segement
     if (oldRt >= seg_start and oldRt <= seg_end) {
@@ -597,14 +597,14 @@ float AligmentSegment::updateRt(float oldRt)
     }
 }
 
-void Aligner::addSegment(string sampleName, AligmentSegment* seg) {
+void Aligner::addSegment(string sampleName, AlignmentSegment* seg) {
     if (_alignmentSegments.count(sampleName) == 0) {
         _alignmentSegments[sampleName] = {};
     }
     _alignmentSegments.at(sampleName).push_back(seg);
 }
 
-void Aligner::performSegmentedAligment()
+void Aligner::performSegmentedAlignment()
 {
     for (auto sample : samples) {
         if (sample == nullptr)
@@ -620,7 +620,7 @@ void Aligner::performSegmentedAligment()
 
         int corcount = 0;
         for (auto scan : sample->scans) {
-            AligmentSegment* seg = nullptr;
+            AlignmentSegment* seg = nullptr;
             for (auto segment : _alignmentSegments[sampleName]) {
                 if (scan->rt >= segment->seg_start
                     && scan->rt <= segment->seg_end) {

--- a/src/core/libmaven/mzAligner.h
+++ b/src/core/libmaven/mzAligner.h
@@ -14,7 +14,7 @@ class MavenParameters;
 
 using namespace std;
 
-struct AligmentSegment {
+struct AlignmentSegment {
     string sampleName;
     float seg_start;
     float seg_end;
@@ -71,14 +71,14 @@ class Aligner {
      * @param sampleName Name of the sample associated with this segment.
      * @param seg Pointer to the AlignmentSegment to be added.
      */
-    void addSegment(string sampleName, AligmentSegment* seg);
+    void addSegment(string sampleName, AlignmentSegment* seg);
 
     /**
      * @brief Perform alignment using segments of known retention times, where
      * the rt values in-between these known (aligned) segments will be simply
      * interpolated.
      */
-    void performSegmentedAligment();
+    void performSegmentedAlignment();
 
     /**
      * @brief Set the samples for the next alignment operation.
@@ -93,7 +93,7 @@ public:
     vector<PeakGroup*> allgroups;
     int maxIterations;
     int polynomialDegree;
-    map<string,vector<AligmentSegment*>> _alignmentSegments;
+    map<string,vector<AlignmentSegment*>> _alignmentSegments;
 };
 
 

--- a/src/core/libmaven/mzAligner.h
+++ b/src/core/libmaven/mzAligner.h
@@ -16,10 +16,10 @@ using namespace std;
 
 struct AlignmentSegment {
     string sampleName;
-    float seg_start;
-    float seg_end;
-    float new_start;
-    float new_end;
+    float segStart;
+    float segEnd;
+    float newStart;
+    float newEnd;
     float updateRt(float oldRt);
 };
 

--- a/src/core/libmaven/mzAligner.h
+++ b/src/core/libmaven/mzAligner.h
@@ -14,6 +14,15 @@ class MavenParameters;
 
 using namespace std;
 
+struct AligmentSegment {
+    string sampleName;
+    float seg_start;
+    float seg_end;
+    float new_start;
+    float new_end;
+    float updateRt(float oldRt);
+};
+
 class Aligner {
    public:
     Aligner();
@@ -56,6 +65,27 @@ class Aligner {
     static mzSample* refSample;
     static void setRefSample(mzSample* sample);
 
+    /**
+     * @brief Add an AlignmentSegment that will be used when performing
+     * segmented alignment on the next call to `performSegmentedAlignment`.
+     * @param sampleName Name of the sample associated with this segment.
+     * @param seg Pointer to the AlignmentSegment to be added.
+     */
+    void addSegment(string sampleName, AligmentSegment* seg);
+
+    /**
+     * @brief Perform alignment using segments of known retention times, where
+     * the rt values in-between these known (aligned) segments will be simply
+     * interpolated.
+     */
+    void performSegmentedAligment();
+
+    /**
+     * @brief Set the samples for the next alignment operation.
+     * @param set A vector of pointers to samples.
+     */
+    void setSamples(vector<mzSample*> set) { samples = set; }
+
 public:
     boost::signals2::signal< void (const string&,unsigned int , int ) > setAlignmentProgress;
 
@@ -63,7 +93,7 @@ public:
     vector<PeakGroup*> allgroups;
     int maxIterations;
     int polynomialDegree;
-
+    map<string,vector<AligmentSegment*>> _alignmentSegments;
 };
 
 

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -487,19 +487,19 @@ void ProjectDatabase::saveAlignment(const vector<mzSample*>& samples)
         if (s->ms1ScanCount() == 0)
             continue;
 
-        for (auto scan : s->scans) {
-            if (scan->mslevel > 1)
-                continue;
-
-            float rt_original = scan->originalRt;
-            float rt_updated = scan->rt;
-            alignmentQuery->bind(":sample_id", s->getSampleId());
-            alignmentQuery->bind(":scannum", scan->scannum);
-            alignmentQuery->bind(":rt_original", rt_original);
-            alignmentQuery->bind(":rt_updated", rt_updated);
-
-            if (!alignmentQuery->execute())
-                cerr << "Error: failed to write alignment data" << endl;
+        for (int i = 0; i < s->scans.size(); i++) {
+            // save rt for every 200th scan (and last scan)
+            if (i % 200 == 0 || i == s->scans.size() - 1) {
+                auto scan = s->scans[i];
+                float rt_updated = scan->rt;
+                float rt_original = scan->originalRt;
+                alignmentQuery->bind(":sample_id", s->getSampleId());
+                alignmentQuery->bind(":scannum", -1);
+                alignmentQuery->bind(":rt_original", rt_original);
+                alignmentQuery->bind(":rt_updated", rt_updated);
+                if (!alignmentQuery->execute())
+                    cerr << "Error: failed to write alignment data" << endl;
+            }
         }
     }
 

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -1231,14 +1231,14 @@ void ProjectDatabase::loadAndPerformAlignment(const vector<mzSample*>& loaded)
             segCount++;
             AlignmentSegment* seg = new AlignmentSegment();
             seg->sampleName = sampleName;
-            seg->seg_start = 0;
-            seg->seg_end   = alignmentQuery->floatValue("rt_original");
-            seg->new_start = 0;
-            seg->new_end   = alignmentQuery->floatValue("rt_updated");
+            seg->segStart = 0;
+            seg->segEnd   = alignmentQuery->floatValue("rt_original");
+            seg->newStart = 0;
+            seg->newEnd   = alignmentQuery->floatValue("rt_updated");
 
             if (lastSegment and lastSegment->sampleName == seg->sampleName) {
-                seg->seg_start = lastSegment->seg_end;
-                seg->new_start = lastSegment->new_end;
+                seg->segStart = lastSegment->segEnd;
+                seg->newStart = lastSegment->newEnd;
             }
 
             aligner.addSegment(sampleName, seg);

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -1203,7 +1203,7 @@ void ProjectDatabase::loadAndPerformAlignment(const vector<mzSample*>& loaded)
 
     Aligner aligner;
     aligner.setSamples(loaded);
-    AligmentSegment* lastSegment = nullptr;
+    AlignmentSegment* lastSegment = nullptr;
     int segCount = 0;
 
     while (alignmentQuery->next()) {
@@ -1229,7 +1229,7 @@ void ProjectDatabase::loadAndPerformAlignment(const vector<mzSample*>& loaded)
         } else {
             // perform segmented alignment
             segCount++;
-            AligmentSegment* seg = new AligmentSegment();
+            AlignmentSegment* seg = new AlignmentSegment();
             seg->sampleName = sampleName;
             seg->seg_start = 0;
             seg->seg_end   = alignmentQuery->floatValue("rt_original");
@@ -1247,7 +1247,7 @@ void ProjectDatabase::loadAndPerformAlignment(const vector<mzSample*>& loaded)
     }
 
     if (segCount > 0)
-        aligner.performSegmentedAligment();
+        aligner.performSegmentedAlignment();
 }
 
 map<string, variant> ProjectDatabase::loadSettings()


### PR DESCRIPTION
This PR involves the following related changes:
1. Alignment data from `mzrollDB` will now be read in successfully, and restored using the segmented alignment technique used in MAVEN.
2. El-MAVEN will also use the same technique to save and restore alignment data, from now on, because it is potentially faster and shows minimal deviation from true alignment.