### PR TITLE
Set the correct suffix and mass cutoff type

### DIFF
--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -193,9 +193,10 @@ void PeakDetectionDialog::onReset()
 
 void PeakDetectionDialog::setMassCutoffType(QString type)
 {
-    massCutoffType = QString(" %1").arg(type);
-    ppmStep->setSuffix(type);
-    compoundPPMWindow->setSuffix(type);
+    massCutoffType = type;
+    auto suffix = QString(" %1").arg(type);
+    ppmStep->setSuffix(suffix);
+    compoundPPMWindow->setSuffix(suffix);
     emit updateSettings(peakSettings);
 }
 


### PR DESCRIPTION
This commit fixes the issue where the actual mass cutoff type and the type suffix to be added were being interchanged, leading to unrecognized cutoff type which raised an assertion -- causing a
crash.

Issue: #1088