### PR TITLE
Reset precursorMzs in DDA to avoid precision errors

### DIFF
--- a/src/core/libmaven/Scan.cpp
+++ b/src/core/libmaven/Scan.cpp
@@ -549,6 +549,30 @@ Scan* Scan::getLastFullScan(int historySize)
 	return 0;
 }
 
+void Scan::recalculatePrecursorMz(float ppm)
+{
+    if (mslevel != 2)
+        return;
+    
+    Scan* fullScan = getLastFullScan(50);
+    if (!fullScan)
+        return;
+    
+    MassCutoff* massCutoff = new MassCutoff();
+    massCutoff->setMassCutoffAndType(ppm, "ppm");
+
+    //find highest intensity precursor for this ms2 scan
+    //increase the error range till a precursor is found
+    for (int i : {1, 2, 3, 4, 5}) {
+        massCutoff->setMassCutoff(ppm * i);
+        int pos = fullScan->findHighestIntensityPos(this->precursorMz, massCutoff);
+        if (pos > 0 && pos < fullScan->nobs()) {
+            this->precursorMz = fullScan->mz[pos];
+            break;
+        }
+    }
+}
+
 vector<mzPoint> Scan::getIsolatedRegion(float isolationWindowAmu)
 {
 	vector<mzPoint> isolatedSegment;

--- a/src/core/libmaven/Scan.h
+++ b/src/core/libmaven/Scan.h
@@ -167,6 +167,17 @@ class Scan
     void quantileFilter(int minQuantile);
 
     /**
+    * @brief adjusts precursor m/z for MS2 scans
+    * @details precursor m/z available in the MS2 scans have
+    * lower precision than m/z values recorded in the MS1 fullscans
+    * To ensure correct mapping of MS2 scans to parent scans, precursor
+    * m/z needs to be adjusted
+    * @param ppm lowest ppm range for finding the correct
+    * precursor m/z
+    */
+    void recalculatePrecursorMz(float ppm);
+
+    /**
      * @brief calculates purity of the spectra
      * @details if the parent full scan has multiple readings within a precursor m/z window
      * the fragmentation scan would be a mixture of fragments from all those species

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -78,11 +78,18 @@ void mzSample::addScan(Scan *s)
 	//unsigned int sizeAfter3 = s->intensity.size();
         //cerr << "addScan " << sizeBefore <<  " " << sizeAfter1 << " " << sizeAfter2 << " " << sizeAfter3 << endl;
 
-        if (s->mslevel == 1) ++_numMS1Scans;
-        if (s->mslevel == 2) ++_numMS2Scans;
+    if (s->mslevel == 1) ++_numMS1Scans;
+    if (s->mslevel == 2) ++_numMS2Scans;
 
-        scans.push_back(s);
-        s->scannum = scans.size() - 1;
+    scans.push_back(s);
+    s->scannum = scans.size() - 1;
+
+    //recalculate precursorMz of MS2 scans
+    if (s->mslevel == 2 && _numMS1Scans > 0) {
+        float ppm = 10;
+        s->recalculatePrecursorMz(ppm);
+    }
+
 }
 
 string mzSample::getFileName(const string &filename)


### PR DESCRIPTION
In case of DDA data, some MS2 scans have precursor m/z recorded at lower precision than m/z values in MS1 fullscans
As a result, El-MAVEN was not able to map the MS2 events with their correct precursors, leading to missing ms2 events