### PR TITLE
Remove breakpoint in untargeted detection

### DIFF
--- a/src/cli/peakdetector/main.cpp
+++ b/src/cli/peakdetector/main.cpp
@@ -82,7 +82,6 @@ int main(int argc, char *argv[]) {
 	//process all mass slices
 	if (peakdetectorCLI->mavenParameters->processAllSlices == true) {
 		peakdetectorCLI->mavenParameters->matchRtFlag = false;
-		peakdetectorCLI->mavenParameters->checkConvergance = true;
 		peakdetectorCLI->peakDetector->processMassSlices();
 	}
 

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -161,7 +161,6 @@ void PeakDetector::processMassSlices() {
     // TODO: what is this doing?
     // TODO: cant this be in background_peaks_update parameter setting function
     mavenParameters->showProgressFlag = true;
-    mavenParameters->checkConvergance = true;
     QTime timer;
     timer.start();
 
@@ -311,9 +310,6 @@ void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)
 
     sort(slices.begin(), slices.end(), mzSlice::compIntensity);
 
-    int converged = 0;
-    int foundGroups = 0;
-
     int eicCount = 0;
     for (unsigned int s = 0; s < slices.size(); s++)
     {
@@ -326,20 +322,6 @@ void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)
 
         if (compound != NULL && compound->hasGroup())
             compound->unlinkGroup();
-
-        //TODO: what is this for? this is not used
-        //mavenParameters->checkConvergance is not always 0
-        if (mavenParameters->checkConvergance)
-        {
-            mavenParameters->allgroups.size() - foundGroups > 0 ? converged =
-                                                                      0
-                                                                : converged++;
-            if (converged > 1000)
-            {
-                break;
-            }
-            foundGroups = mavenParameters->allgroups.size();
-        }
 
         vector<EIC *> eics = pullEICs(slice,
                                       mavenParameters->samples,

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -18,7 +18,6 @@ MavenParameters::MavenParameters(string settingsPath):lastUsedSettingsPath(setti
         processAllSlices = false;
         pullIsotopesFlag = false;
         matchRtFlag = false;
-        checkConvergance = false;
         stop = false;
 
         outputdir = "reports" + string(DIR_SEPARATOR_STR);

--- a/src/core/libmaven/mavenparameters.h
+++ b/src/core/libmaven/mavenparameters.h
@@ -105,7 +105,6 @@ class MavenParameters
         bool pullIsotopesFlag;
         bool showProgressFlag;
         bool matchRtFlag;
-        bool checkConvergance;
         bool alignWrtExpectedRt;
 
         /**

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3477,8 +3477,6 @@ void MainWindow::Align() {
     mavenParameters->minSignalBlankRatio = 0; //TODO: Sahil-Kiran, Added while merging mainwindow
     mavenParameters->alignMaxIterations = alignmentDialog->maxIterations->value(); //TODO: Sahil-Kiran, Added while merging mainwindow
     mavenParameters->alignPolynomialDegree = alignmentDialog->polynomialDegree->value(); //TODO: Sahil-Kiran, Added while merging mainwindow
-
-    mavenParameters->checkConvergance=false; //TODO: Sahil-Kiran, Added while merging mainwindow
 	mavenParameters->alignSamplesFlag = true;
 	mavenParameters->keepFoundGroups = true;
     mavenParameters->eicMaxGroups = peakDetectionDialog->eicMaxGroups->value();


### PR DESCRIPTION
There was a breakpoint in untargeted peak detection.
If there were 1000 consecutive mass slices without any valid groups, the peak detection process was aborted.

Removing this breakpoint as it provides no obvious advantage.
At the same time, certain low-intensity datasets hit the breakpoint very frequently leading to fewer groups reported in untargeted detection