### PR TITLE
Remove un-necessary function call

### DIFF
--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -403,8 +403,7 @@ void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)
             if (j >= mavenParameters->eicMaxGroups)
                 break;
 
-            PeakGroup group = peakgroups[j];
-            addPeakGroup(group);
+            mavenParameters->allgroups.push_back(peakgroups[j]);
         }
 
         //cleanup
@@ -429,24 +428,4 @@ void PeakDetector::processSlices(vector<mzSlice *> &slices, string setName)
             sendBoostSignal(progressText, s + 1, std::min((int)slices.size(), mavenParameters->limitGroupCount));
         }
     }
-}
-
-bool PeakDetector::addPeakGroup(PeakGroup& grup1) {
-        bool noOverlap = true;
-
-        for (unsigned int i = 0; i < mavenParameters->allgroups.size(); i++) {
-                PeakGroup& grup2 = mavenParameters->allgroups[i];
-                float rtoverlap = mzUtils::checkOverlap(grup1.minRt, grup1.maxRt,
-                                                        grup2.minRt, grup2.maxRt);
-                if (rtoverlap > 0.9
-                    && massCutoffDist(grup2.meanMz, grup1.meanMz,mavenParameters->massCutoffMerge)
-                    < mavenParameters->massCutoffMerge->getMassCutoff()) {
-                        noOverlap = false;
-                break;
-                }
-        }
-
-        //push the group to the allgroups vector
-        mavenParameters->allgroups.push_back(grup1);
-        return noOverlap;
 }

--- a/src/core/libmaven/PeakDetector.h
+++ b/src/core/libmaven/PeakDetector.h
@@ -151,7 +151,6 @@ public:
 	 * @param  group        [pointer to PeakGroup]
 	 * @return [True if group is added to all groups, else False]
 	 */
-	bool addPeakGroup(PeakGroup& grup1);
 	MavenParameters* mavenParameters;
 	bool zeroStatus;
 };

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1026,47 +1026,44 @@ void mzSample::summary()
 void mzSample::calculateMzRtRange()
 {
 
-	if (scans.size() == 0)
-	{
-		cerr << "sample has no data" << endl;
-		return;
-	}
+    if (scans.size() == 0) {
+        cerr << "sample has no data" << endl;
+        return;
+    }
 
-	minRt = scans[0]->rt;
-	maxRt = scans[scans.size() - 1]->rt;
-	minMz = FLT_MAX;
-	maxMz = 0;
-	minIntensity = FLT_MAX;
-	maxIntensity = 0;
-	totalIntensity = 0;
-	int nobs = 0;
+    minRt = scans[0]->rt;
+    maxRt = scans[scans.size() - 1]->rt;
+    minMz = FLT_MAX;
+    maxMz = 0;
+    minIntensity = FLT_MAX;
+    maxIntensity = 0;
+    totalIntensity = 0;
+    int nobs = 0;
 
     unsigned int numOfScans = scans.size();
-    for (unsigned int j = 0; j < numOfScans; j++)
-	{
+    for (unsigned int j = 0; j < numOfScans; j++) {
         Scan* currentScan = scans[j];
         unsigned int mzSize = currentScan->mz.size();
-        for (unsigned int i = 0; i < mzSize; i++)
-		{
+        for (unsigned int i = 0; i < mzSize; i++) {
             float intensity = currentScan->intensity[i];
             float mz = currentScan->mz[i];
             totalIntensity += intensity;
-			if (mz < minMz && mz > 0)
-				minMz = mz; //sanity check must be greater > 0
-			if (mz > maxMz && mz < 1e9)
-				maxMz = mz; //sanity check m/z over a billion
+            if (mz < minMz && mz > 0)
+                minMz = mz; //sanity check must be greater > 0
+            if (mz > maxMz && mz < 1e9)
+                maxMz = mz; //sanity check m/z over a billion
             if (intensity < minIntensity)
                 minIntensity = intensity;
             if (intensity > maxIntensity)
                 maxIntensity = intensity;
-			nobs++;
-		}
-	}
-	//sanity check
-	if (minRt <= 0)
-		minRt = 0;
-	if (maxRt >= 1e4)
-		maxRt = 1e4;
+            nobs++;
+        }
+    }
+    //sanity check
+    if (minRt <= 0)
+        minRt = 0;
+    if (maxRt >= 1e4)
+        maxRt = 1e4;
 }
 
 mzSlice mzSample::getMinMaxDimentions(const vector<mzSample *> &samples)

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1041,20 +1041,24 @@ void mzSample::calculateMzRtRange()
 	totalIntensity = 0;
 	int nobs = 0;
 
-	for (unsigned int j = 0; j < scans.size(); j++)
+    unsigned int numOfScans = scans.size();
+    for (unsigned int j = 0; j < numOfScans; j++)
 	{
-		for (unsigned int i = 0; i < scans[j]->mz.size(); i++)
+        Scan* currentScan = scans[j];
+        unsigned int mzSize = currentScan->mz.size();
+        for (unsigned int i = 0; i < mzSize; i++)
 		{
-			totalIntensity += scans[j]->intensity[i];
-			float mz = scans[j]->mz[i];
+            float intensity = currentScan->intensity[i];
+            float mz = currentScan->mz[i];
+            totalIntensity += intensity;
 			if (mz < minMz && mz > 0)
 				minMz = mz; //sanity check must be greater > 0
 			if (mz > maxMz && mz < 1e9)
 				maxMz = mz; //sanity check m/z over a billion
-			if (scans[j]->intensity[i] < minIntensity)
-				minIntensity = scans[j]->intensity[i];
-			if (scans[j]->intensity[i] > maxIntensity)
-				maxIntensity = scans[j]->intensity[i];
+            if (intensity < minIntensity)
+                minIntensity = intensity;
+            if (intensity > maxIntensity)
+                maxIntensity = intensity;
 			nobs++;
 		}
 	}


### PR DESCRIPTION
I have been profiling `libmaven` lately, mainly because I wanted to find out the reason as to why MavenTests take so much time to run in debug mode(CI needs to run tests in debug mode for test coverage info). The profiling information generated led me to one of the functions, `PeakDetector::addPeakGroup`, which was being called inside a loop and the result of which was not being used anywhere, I used GCC's warning to double check this. 
```
PeakDetector.cpp:407:32: warning: ignoring return value of ‘bool PeakDetector::addPeakGroup(PeakGroup&)’, declared with attribute warn_unused_result [-Wunused-result] addPeakGroup(group);
```

The function, `PeakDetector::addPeakGroup`, was being used to check the `rtOverlap` between the groups but was not being used in any decision making.  

Irrespective of whether the overall running time of MavenTests gets better or not, this function call should be removed. 

Please let me know if there's a reason why this function exists that I might have missed


**Update**
The second commit, 98247f71e449cd9db69b5fd95f1584dab88e7f28,  reduces the amount of time spent in `mzSample::caluclatemzRtRange`.   Reason being, Deque's [] operator is slow and it was being used at a lot of places that too inside a loop 


