### PR TITLE
Allow filtering untargeted groups having no MS2 events

### DIFF
--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -377,15 +377,19 @@ void BackgroundPeakUpdate::writeCSVRep(string setName)
     peakDetector->pullAllIsotopes();
 
         for (int j = 0; j < mavenParameters->allgroups.size(); j++) {
-			PeakGroup& group = mavenParameters->allgroups[j];
+            PeakGroup& group = mavenParameters->allgroups[j];
 
-			if (csvreports != NULL) csvreports->addGroup(&group);
+            if (csvreports != NULL)
+                csvreports->addGroup(&group);
 
+            if (mavenParameters->keepFoundGroups) {
+                if (_untargetedMustHaveMs2
+                    && mavenParameters->allgroups[j].ms2EventCount == 0)
+                    continue;
 
-			if (mavenParameters->keepFoundGroups) {
-				Q_EMIT(newPeakGroup(&(mavenParameters->allgroups[j])));
-				QCoreApplication::processEvents();
-			}
+                Q_EMIT(newPeakGroup(&(mavenParameters->allgroups[j])));
+                QCoreApplication::processEvents();
+            }
         }
 
         if (csvreports != NULL) {

--- a/src/gui/mzroll/background_peaks_update.h
+++ b/src/gui/mzroll/background_peaks_update.h
@@ -105,7 +105,11 @@ public:
 	void writeToPythonProcess( QByteArray data);
 
     PeakDetector* peakDetector;
-	MavenParameters* mavenParameters;
+    MavenParameters* mavenParameters;
+
+    inline void setUntargetedMustHaveMs2(bool pred) {
+        _untargetedMustHaveMs2 = pred;
+    }
 
 Q_SIGNALS:
 
@@ -147,6 +151,7 @@ private Q_SLOTS:
 	void readDataFromPython();
 	
 private:
+    bool _untargetedMustHaveMs2;
 	string runFunction;
 	MainWindow *mainwindow;
 	QProcess* pythonProg;

--- a/src/gui/mzroll/forms/peakdetectiondialog.ui
+++ b/src/gui/mzroll/forms/peakdetectiondialog.ui
@@ -61,34 +61,40 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
-           <widget class="QLabel" name="label_19">
-            <property name="text">
-             <string>Limit Intensity Range</string>
+          <item row="0" column="3">
+           <widget class="QDoubleSpinBox" name="mzMin">
+            <property name="maximum">
+             <double>999999999.000000000000000</double>
             </property>
            </widget>
           </item>
-          <item row="1" column="4">
-           <widget class="QDoubleSpinBox" name="rtMax">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Time Domain Resolution</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="4">
+           <widget class="QSpinBox" name="chargeMax">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+            <property name="value">
+             <number>0</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QDoubleSpinBox" name="mzMax">
             <property name="maximum">
              <double>999999999.000000000000000</double>
             </property>
             <property name="value">
              <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QLabel" name="label_20">
-            <property name="text">
-             <string>Limit Charged Species</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QRadioButton" name="ignoreIsotopes">
-            <property name="text">
-             <string>Auto Detect And Ignore Isotopes</string>
             </property>
            </widget>
           </item>
@@ -149,6 +155,13 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="3">
+           <widget class="QDoubleSpinBox" name="rtMin">
+            <property name="maximum">
+             <double>999999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="3">
            <widget class="QSpinBox" name="chargeMin">
             <property name="minimum">
@@ -162,6 +175,13 @@
             </property>
            </widget>
           </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="label_20">
+            <property name="text">
+             <string>Limit Charged Species</string>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="4">
            <widget class="QDoubleSpinBox" name="maxIntensity">
             <property name="maximum">
@@ -172,39 +192,26 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label">
+          <item row="2" column="2">
+           <widget class="QLabel" name="label_19">
             <property name="text">
-             <string>Time Domain Resolution</string>
+             <string>Limit Intensity Range</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="4">
-           <widget class="QSpinBox" name="chargeMax">
-            <property name="minimum">
-             <number>0</number>
-            </property>
-            <property name="maximum">
-             <number>999999999</number>
-            </property>
-            <property name="value">
-             <number>0</number>
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Limit Time Range</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="4">
-           <widget class="QDoubleSpinBox" name="mzMax">
+          <item row="1" column="4">
+           <widget class="QDoubleSpinBox" name="rtMax">
             <property name="maximum">
              <double>999999999.000000000000000</double>
             </property>
             <property name="value">
-             <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QDoubleSpinBox" name="rtMin">
-            <property name="maximum">
              <double>999999999.000000000000000</double>
             </property>
            </widget>
@@ -216,17 +223,10 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="3">
-           <widget class="QDoubleSpinBox" name="mzMin">
-            <property name="maximum">
-             <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="label_18">
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="mustHaveMs2">
             <property name="text">
-             <string>Limit Time Range</string>
+             <string>Exclude unfragmented groups</string>
             </property>
            </widget>
           </item>
@@ -1065,7 +1065,7 @@
   <tabstop>rtStep</tabstop>
   <tabstop>rtMin</tabstop>
   <tabstop>rtMax</tabstop>
-  <tabstop>ignoreIsotopes</tabstop>
+  <tabstop>mustHaveMs2</tabstop>
   <tabstop>minIntensity</tabstop>
   <tabstop>maxIntensity</tabstop>
   <tabstop>chargeMin</tabstop>

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -31,6 +31,7 @@ PeakDetectionSettings::PeakDetectionSettings(PeakDetectionDialog* dialog):pd(dia
     settings.insert("maxIntensity", QVariant::fromValue(pd->maxIntensity));
     settings.insert("chargeMax", QVariant::fromValue(pd->chargeMax));
     settings.insert("chargeMin", QVariant::fromValue(pd->chargeMin));
+    settings.insert("mustHaveFragmentation", QVariant::fromValue(pd->mustHaveMs2));
 
     // db search settings
     settings.insert("databaseSearch", QVariant::fromValue(pd->dbOptions));

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -496,12 +496,12 @@ void PeakDetectionDialog::findPeaks()
     if (peakupdater == NULL) return;
     if (peakupdater->isRunning()) cancel();
     if (peakupdater->isRunning()) return;
+    peakupdater->setUntargetedMustHaveMs2(false);
 
     updateQSettingsWithUserInput(settings);
     setMavenParameters(settings);
 
     mainwindow->setTotalCharge();
-
 
     if (dbOptions->isChecked() && !(featureOptions->isChecked())) {
         _featureDetectionType = CompoundDB;
@@ -509,8 +509,17 @@ void PeakDetectionDialog::findPeaks()
         mainwindow->massCutoffWindowBox->setValue(compoundPPMWindow->value());
     } else if (!(dbOptions->isChecked()) && (featureOptions->isChecked())) {
         _featureDetectionType = FullSpectrum;
-        mainwindow->getAnalytics()->hitEvent("Peak Detection", "Untargeted");
         mainwindow->massCutoffWindowBox->setValue(ppmStep->value());
+        if (mustHaveMs2->isChecked()) {
+            peakupdater->setUntargetedMustHaveMs2(true);
+            mainwindow->getAnalytics()->hitEvent("Peak Detection",
+                                                 "Untargeted",
+                                                 "Filter for MS2 events");
+        } else {
+            mainwindow->getAnalytics()->hitEvent("Peak Detection",
+                                                 "Untargeted"
+                                                 "No filter");
+        }
     } else {
         _featureDetectionType = FullSpectrum;
     }

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -319,6 +319,21 @@ void PeakDetectionDialog::show() {
 
     if (mainwindow == NULL) return;
 
+    auto samples = mainwindow->getVisibleSamples();
+    auto iter = find_if(begin(samples),
+                        end(samples),
+                        [](mzSample* s) {
+                           return ((s->ms1ScanCount() > 0)
+                                   && (s->ms2ScanCount() > 0));
+                        });
+    bool foundDda = iter != end(samples);
+    if (foundDda && featureOptions->isEnabled()) {
+        mustHaveMs2->setEnabled(true);
+    } else {
+        mustHaveMs2->setEnabled(false);
+        mustHaveMs2->setChecked(false);
+    }
+
 	mainwindow->getAnalytics()->hitScreenView("PeakDetectionDialog");
     // delete(peakupdater);
     peakupdater = new BackgroundPeakUpdate(this);

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -675,7 +675,8 @@ void ProjectDatabase::saveSettings(const map<string, variant>& settingsMap)
                       , :main_window_selected_db_name     \
                       , :main_window_charge               \
                       , :main_window_peak_quantitation    \
-                      , :main_window_mass_resolution      )");
+                      , :main_window_mass_resolution      \
+                      , :must_have_fragmentation          )");
 
     settingsQuery->bind(":ionization_mode", BINT(settingsMap.at("ionizationMode")));
     settingsQuery->bind(":ionization_type", BINT(settingsMap.at("ionizationType")));
@@ -745,6 +746,7 @@ void ProjectDatabase::saveSettings(const map<string, variant>& settingsMap)
     settingsQuery->bind(":max_rt", BDOUBLE(settingsMap.at("maxRt")));
     settingsQuery->bind(":min_intensity", BDOUBLE(settingsMap.at("minIntensity")));
     settingsQuery->bind(":max_intensity", BDOUBLE(settingsMap.at("maxIntensity")));
+    settingsQuery->bind(":must_have_fragmentation", BINT(settingsMap.at("mustHaveFragmentation")));
 
     settingsQuery->bind(":database_search", BINT(settingsMap.at("databaseSearch")));
     settingsQuery->bind(":compound_extraction_window", BDOUBLE(settingsMap.at("compoundExtractionWindow")));
@@ -1325,6 +1327,7 @@ map<string, variant> ProjectDatabase::loadSettings()
         settingsMap["maxRt"] = variant(settingsQuery->doubleValue("max_rt"));
         settingsMap["minIntensity"] = variant(settingsQuery->doubleValue("min_intensity"));
         settingsMap["maxIntensity"] = variant(settingsQuery->doubleValue("max_intensity"));
+        settingsMap["mustHaveFragmentation"] = variant(settingsQuery->integerValue("must_have_fragmentation"));
 
         settingsMap["databaseSearch"] = variant(settingsQuery->integerValue("database_search"));
         settingsMap["compoundExtractionWindow"] = settingsQuery->doubleValue("compound_extraction_window");

--- a/src/projectDB/projectversioning.cpp
+++ b/src/projectDB/projectversioning.cpp
@@ -17,7 +17,8 @@ namespace ProjectVersioning {
  */
 map<Version, int> appDbVersionMap = {
     {Version("0.6.0"), 0},
-    {Version("0.7.0"), 1}
+    {Version("0.7.0"), 1},
+    {Version("0.8.0"), 2}
 };
 
 /**
@@ -109,6 +110,12 @@ map<int, string> dbVersionUpgradeScripts = {
         "                   FROM compounds_old        ;"
         "DROP TABLE compounds_old;"
 
+        "COMMIT;"
+    },
+    {
+        1,
+        "BEGIN TRANSACTION;"
+        "ALTER TABLE user_settings ADD COLUMN must_have_fragmentation INTEGER;"
         "COMMIT;"
     }
 };

--- a/src/projectDB/schema.h
+++ b/src/projectDB/schema.h
@@ -241,7 +241,8 @@
                                               , main_window_selected_db_name     TEXT    \
                                               , main_window_charge               INTEGER \
                                               , main_window_peak_quantitation    INTEGER \
-                                              , main_window_mass_resolution      REAL    );"
+                                              , main_window_mass_resolution      REAL    \
+                                              , must_have_fragmentation          INTEGER );"
 
 #define CREATE_COMPOUNDS_DB_INDEX \
     "CREATE INDEX IF NOT EXISTS compounds_db_idx    \


### PR DESCRIPTION
This patch allows the user to filter untargeted groups based on whether it has any fragmentation events or not. This helps in narrowing down the number of groups they want to focus on in their DDA dataset.