### PR TITLE
Change match compound behavior from hover to click

### DIFF
--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -845,6 +845,9 @@ void SpectraWidget::mouseReleaseEvent(QMouseEvent *event)
     int deltaX = _mouseEndPos.x() - _mouseStartPos.x();
     float deltaXfrac = (float) deltaX / (width() + 1);
 
+    auto nearest = findNearestMz(_mouseEndPos);
+    if (mainwindow->massCalcWidget->isVisible())
+        mainwindow->massCalcWidget->setMass(_currentScan->mz[nearest]);
 
     if (deltaXfrac > 0.01) {
         float xmin = invX(std::min(_mouseStartPos.x(), _mouseEndPos.x()));
@@ -960,8 +963,6 @@ void SpectraWidget::mouseMoveEvent(QMouseEvent* event)
     if (nearestPos >= 0) {
 		_nearestCoord = QPointF(_currentScan->mz[nearestPos], _currentScan->intensity[nearestPos]);
 		drawArrow(_currentScan->mz[nearestPos], _currentScan->intensity[nearestPos], invX(pos.x()), invY(pos.y()));
-        if (mainwindow->massCalcWidget->isVisible())
-			mainwindow->massCalcWidget->setMass(_currentScan->mz[nearestPos]);
     } else {
         _vnote->hide(); _note->hide(); _varrow->hide(); _arrow->hide();
     }


### PR DESCRIPTION
Moving the mouse around in the spectra widget sets the m/z value of match compound widget, which is helpful but not the best UX, due to the fact that its extremely difficult to preserve the set m/z value.
The same feature will now be available with mouse clicks instead of hovering.

Issue: #888