### PR TITLE
Handle EPI index.js fetch errors

### DIFF
--- a/src/gui/mzroll/loginform.cpp
+++ b/src/gui/mzroll/loginform.cpp
@@ -37,6 +37,12 @@ LoginForm::LoginForm(PollyElmavenInterfaceDialog* pollyelmaveninterfacedialog) :
                 showAboutPolly();
                 analytics->hitEvent("PollyDialog", "AboutPolly");
             });
+    connect(_pollyintegration,
+            &PollyIntegration::receivedEPIError,
+            [=] {
+                ui->login_label->clear();
+                ui->pushButton->setEnabled(true);
+            });
 }
 
 LoginForm::~LoginForm()

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -738,7 +738,7 @@ void PollyElmavenInterfaceDialog::_showErrorMessage(QString title,
                                                     QString message,
                                                     QMessageBox::Icon icon)
 {
-    QMessageBox msgBox(icon, title, message, QMessageBox::Ok, this);
+    QMessageBox msgBox(icon, title, message, QMessageBox::Ok, _mainwindow);
     msgBox.exec();
 }
 

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -382,7 +382,9 @@ bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
         }
 
         // the most likely other reason could be…
-        emit receivedEPIError("Error: Unable to connect to the internet.\n\n"
+        emit receivedEPIError("There was an unexpected error. Please make sure "
+                              "you are connected to the internet and try again."
+                              "\n\n"
                               + supportMessage);
         return true;
     }

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -358,7 +358,7 @@ bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
         QString errorString = QString::fromStdString(errorResponse.toStdString());
         errorString.replace("\n", "");
         if (!errorString.isEmpty()) {
-            QString errorMessage = "Unknown error: " + errorString + "\n\n" +
+            QString errorMessage = "Error: " + errorString + "\n\n" +
                                    supportMessage;
             emit receivedEPIError(errorMessage);
             return true;

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -326,7 +326,8 @@ QStringList PollyIntegration::get_project_upload_url_commands(QString url_with_w
 
 bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
 {
-    QString supportMessage = "Contact tech support at elmaven@elucidata.io if the problem persists";
+    QString supportMessage = "Please contact tech support at "
+                             "elmaven@elucidata.io if the problem persists.";
     if (resultAndError.size() > 1) {
         //if there is standard error look for error message
         QByteArray errorResponse = resultAndError.at(1);
@@ -346,7 +347,7 @@ bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
 
         if (!message.isEmpty() || !type.isEmpty()) {
             QString errorMessage = message + "\n" +
-                                   type + "\n" +
+                                   type + "\n\n" +
                                    supportMessage;
             emit receivedEPIError(errorMessage);
             return true;
@@ -357,14 +358,22 @@ bool PollyIntegration::_hasError(QList<QByteArray> resultAndError)
         QString errorString = QString::fromStdString(errorResponse.toStdString());
         errorString.replace("\n", "");
         if (!errorString.isEmpty()) {
-            QString errorMessage = "Unknown error: " + errorString + "\n" +
+            QString errorMessage = "Unknown error: " + errorString + "\n\n" +
                                    supportMessage;
             emit receivedEPIError(errorMessage);
             return true;
         }
     } else if (resultAndError.size() == 0) {
-        //no response or error
-        emit receivedEPIError("Error: QProcess failure.\n" + supportMessage);
+        // no response or error
+        if (_fPtr && !_fPtr->exists()) {
+            emit receivedEPIError("Error: Unable to fetch file required for "
+                                  "integration with Polly.");
+            return true;
+        }
+
+        // the most likely other reason could be…
+        emit receivedEPIError("Error: Unable to connect to the internet.\n\n"
+                              + supportMessage);
         return true;
     }
 

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -190,7 +190,7 @@ private:
     QString indexFileURL;
 
     QPair<ErrorStatus, QMap<QString, QStringList>> _fetchAppLicense();
-    void checkForIndexFile();
+    bool _checkForIndexFile();
     bool validCohorts(QStringList cohorts);
     bool _hasError(QList<QByteArray>);
 };


### PR DESCRIPTION
This set of commits includes the following changes:
1. Add better message for missing `index.js` file.
2. Fix login form button and status not being reset after EPI failure message box is accepted.
3. Fix EPI error message box spawning at random position on user's screen, when errors occur at login window.
4. Minor - change miscellaneous error labels to have a more appropriate prefix.
5. Add another check for `index.js` file before starting any process for communication through it.