### PR TITLE
Rework compound match widget

### DIFF
--- a/src/core/libmaven/mzMassCalculator.h
+++ b/src/core/libmaven/mzMassCalculator.h
@@ -3,6 +3,7 @@
 
 #include "elementMass.h"
 #include "standardincludes.h"
+#include "Fragment.h"
 
 class Adduct;
 class Compound;

--- a/src/core/libmaven/mzMassCalculator.h
+++ b/src/core/libmaven/mzMassCalculator.h
@@ -44,6 +44,8 @@ class MassCalculator {
             std::string name;
             double mass;
             double diff;
+            double rtDiff;
+            FragmentationMatchScore fragScore;
             Compound* compoundLink;
         } Match;
 

--- a/src/gui/mzroll/forms/masscalcwidget.ui
+++ b/src/gui/mzroll/forms/masscalcwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>420</width>
+    <width>693</width>
     <height>325</height>
    </rect>
   </property>
@@ -25,16 +25,81 @@
      <layout class="QHBoxLayout" name="horizontalLayout_5">
       <item>
        <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
-         <string>PrecursorMz</string>
+         <string>Precursor m/z</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="lineEdit"/>
+       <widget class="QLineEdit" name="precursorMz">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Database</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="database">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
       <item>
        <widget class="QPushButton" name="computeButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Match</string>
         </property>
@@ -43,7 +108,7 @@
      </layout>
     </item>
     <item>
-     <widget class="QTableWidget" name="mTable">
+     <widget class="QTreeWidget" name="mTable">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
@@ -62,46 +127,78 @@
       <property name="alternatingRowColors">
        <bool>false</bool>
       </property>
-      <property name="sortingEnabled">
-       <bool>true</bool>
-      </property>
-      <attribute name="horizontalHeaderVisible">
-       <bool>true</bool>
-      </attribute>
-      <attribute name="horizontalHeaderDefaultSectionSize">
-       <number>100</number>
-      </attribute>
-      <attribute name="horizontalHeaderMinimumSectionSize">
-       <number>100</number>
-      </attribute>
-      <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
-       <bool>false</bool>
-      </attribute>
-      <attribute name="horizontalHeaderStretchLastSection">
-       <bool>false</bool>
-      </attribute>
-      <attribute name="verticalHeaderStretchLastSection">
-       <bool>false</bool>
-      </attribute>
       <column>
        <property name="text">
-        <string>Compound</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>m/z</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>PPM Diff</string>
+        <string notr="true">1</string>
        </property>
       </column>
      </widget>
     </item>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <item>
+       <widget class="QLabel" name="label_3">
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string>Precursor PPM</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDoubleSpinBox" name="precursorPpm">
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Fragment PPM</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDoubleSpinBox" name="fragPpm">
+        <property name="value">
+         <double>20.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
       <item>
        <widget class="QLabel" name="label_2">
         <property name="layoutDirection">
@@ -123,21 +220,17 @@
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="label_3">
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
-        <property name="text">
-         <string>ppm</string>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QDoubleSpinBox" name="maxppmdiff">
-        <property name="maximum">
-         <double>10000.000000000000000</double>
-        </property>
-       </widget>
+       </spacer>
       </item>
      </layout>
     </item>

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -110,8 +110,12 @@ LigandWidget::LigandWidget(MainWindow* mw) {
 
   QDirIterator itr(":/databases/");
 
-  while(itr.hasNext())
-      DB.loadCompoundCSVFile(itr.next().toStdString());
+  while(itr.hasNext()) {
+    auto filename = itr.next().toStdString();
+    DB.loadCompoundCSVFile(filename);
+    string dbname = mzUtils::cleanFilename(filename);
+    _mw->massCalcWidget->database->addItem(QString::fromStdString(dbname));
+  }
 
   QSet<QString>set;
   for(int i=0; i< DB.compoundsDB.size(); i++) {

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -4,6 +4,7 @@
 #include "analytics.h"
 #include "globals.h"
 #include "mainwindow.h"
+#include "masscalcgui.h"
 #include "mavenparameters.h"
 #include "mzfileio.h"
 #include "mzSample.h"

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -490,7 +490,6 @@ using namespace mzUtils;
 	//DIALOGS
 	//
 	peakDetectionDialog = new PeakDetectionDialog(this);
-	peakDetectionDialog->setMainWindow(this);
 	peakDetectionDialog->setSettings(settings);
 	
 	// pollyelmavengui dialog
@@ -1952,6 +1951,7 @@ void MainWindow::_postCompoundsDBLoadActions(QString filename,
                                              int compoundCount)
 {
     string dbName = mzUtils::cleanFilename(filename.toStdString());
+    massCalcWidget->database->addItem(QString::fromStdString(dbName));
 
     bool reloading = false;
     deque<Compound*> compoundsDB = DB.getCompoundsDB();
@@ -3405,6 +3405,8 @@ void MainWindow::setPeakGroup(PeakGroup* group) {
         if (! setPeptideSequence(compoundName)) {
             setUrl(group->compound);
         }
+        if (massCalcWidget)
+            massCalcWidget->setPeakGroup(group);
     }
 
 	if (scatterDockWidget->isVisible()) {
@@ -3567,11 +3569,6 @@ void MainWindow::showPeakInfo(Peak* _peak) {
 
 	if (spectraDockWidget->isVisible() && scan) {
 		spectraWidget->setScan(_peak);
-	}
-
-	if (massCalcWidget->isVisible()) {
-		massCalcWidget->setMass(_peak->peakMz);
-		massCalcWidget->setCharge(ionizationMode);
 	}
 
 	if (isotopeWidget->isVisible()) {

--- a/src/gui/mzroll/masscalcgui.cpp
+++ b/src/gui/mzroll/masscalcgui.cpp
@@ -3,7 +3,7 @@
 #include "globals.h"
 #include "mainwindow.h"
 #include "masscalcgui.h"
-#include "masscutofftype.h".h"
+#include "masscutofftype.h"
 #include "mavenparameters.h"
 #include "Scan.h"
 #include "spectrawidget.h"

--- a/src/gui/mzroll/masscalcgui.cpp
+++ b/src/gui/mzroll/masscalcgui.cpp
@@ -18,19 +18,21 @@ MassCalcWidget::MassCalcWidget(MainWindow* mw) {
   setCharge(-1);
   setMassCutoff(mw->getUserMassCutoff());
 
+  database->addItem("All");
+
   connect(computeButton, SIGNAL(clicked(bool)), SLOT(compute()));
-  connect(lineEdit,SIGNAL(returnPressed()),SLOT(compute()));
+  connect(database, SIGNAL(currentIndexChanged(int)), SLOT(compute()));
+  connect(precursorMz,SIGNAL(returnPressed()),SLOT(compute()));
   connect(ionization,SIGNAL(valueChanged(double)),SLOT(compute()));
-  connect(maxppmdiff,SIGNAL(valueChanged(double)),SLOT(compute()));
-  connect(mTable, SIGNAL(currentCellChanged(int,int,int,int)), SLOT(showCellInfo(int,int,int,int)));
+  connect(precursorPpm,SIGNAL(valueChanged(double)),SLOT(compute()));
+  connect(mTable, SIGNAL(itemSelectionChanged()), SLOT(_showInfo()));
 }
 
 void MassCalcWidget::setMass(float mz) {
 	if ( mz == _mz ) return;
 
-    lineEdit->setText(QString::number(mz,'f',5));
+    precursorMz->setText(QString::number(mz,'f',5));
     _mz = mz;
-    mzUtils::delete_all(matches);
     getMatches();
     showTable();
 }
@@ -40,8 +42,8 @@ void MassCalcWidget::setCharge(float charge) {
                 ionization->setValue(charge);
                 _charge=charge;
 }
-void MassCalcWidget::setMassCutoff(MassCutoff *massCutoff) { maxppmdiff->setValue(massCutoff->getMassCutoff()); _massCutoff=massCutoff;
-    maxppmdiff->setValue(massCutoff->getMassCutoff());
+void MassCalcWidget::setMassCutoff(MassCutoff *massCutoff) { precursorPpm->setValue(massCutoff->getMassCutoff()); _massCutoff=massCutoff;
+    precursorPpm->setValue(massCutoff->getMassCutoff());
     string massCutoffType=massCutoff->getMassCutoffType();
 
     label_3->setText(QApplication::translate("MassCalcWidget", &massCutoffType[0], 0));
@@ -50,100 +52,166 @@ void MassCalcWidget::setMassCutoff(MassCutoff *massCutoff) { maxppmdiff->setValu
 
 void MassCalcWidget::compute() {
 	 bool isDouble =false;
-	 _mz = 		lineEdit->text().toDouble(&isDouble);
+         _mz = 		precursorMz->text().toDouble(&isDouble);
   	 _charge =  ionization->value();
-       _massCutoff->setMassCutoff(maxppmdiff->value());
+       _massCutoff->setMassCutoff(precursorPpm->value());
 	 if (!isDouble) return;
 	 cerr << "massCalcGui:: compute() " << _charge << " " << _mz << endl;
 
-         mzUtils::delete_all(matches);
-
 	_mw->setStatusText("Searching for formulas..");
-     mcalc.enumerateMasses(_mz,_charge,_massCutoff, matches);
 	 getMatches();
 	_mw->setStatusText(tr("Found %1 formulas").arg(matches.size()));
 
      showTable();
 }
 
-void MassCalcWidget::showTable() {
-
-    QTableWidget *p = mTable;
+void MassCalcWidget::showTable()
+{
+    QTreeWidget *p = mTable;
     p->setUpdatesEnabled(false);
     p->clear();
-    p->setColumnCount( 5 );
-    p->setRowCount(  matches.size() ) ;
-    QString massCutoffDiff=label_3->text()+"Diff";
-    p->setHorizontalHeaderLabels(  QStringList() << "Formula" << "Compound" << "Mass" << massCutoffDiff << "DB");
+    p->setColumnCount(6);
+    QString massCutoffDiff = "Δm/z (" + label_3->text() + ")";
+    p->setHeaderLabels(QStringList() << "Formula"
+                                     << "Compound"
+                                     << "Δrt"
+                                     << massCutoffDiff
+                                     << "MS2 Score"
+                                     << "DB");
     p->setSortingEnabled(false);
     p->setUpdatesEnabled(false);
 
     for(unsigned int i=0;  i < matches.size(); i++ ) {
         //no duplicates in the list
-        Compound* c = matches[i]->compoundLink;
+        auto match = matches[i];
+        Compound* c = match->compoundLink;
+
         QString compoundName="";
-        if (c != NULL) compoundName = QString(c->name.c_str());
+        if (c != nullptr)
+            compoundName = QString(c->name.c_str());
+
         QString databaseName="";
-        if(c != NULL ) databaseName = QString(c->db.c_str());
-        QString item1 = QString(matches[i]->name.c_str() );
-        QString item2 = QString(compoundName);
-        QString item3 = QString::number( matches[i]->mass , 'f', 4);
-        QString item4 = QString::number( matches[i]->diff , 'f', 4);
-        QString item5 = QString(databaseName);
+        if(c != nullptr)
+            databaseName = QString(c->db.c_str());
 
-		QTableWidgetItem* item = new QTableWidgetItem(item1,0);
+        if (database->currentIndex() != 0
+            && database->currentText() != databaseName)
+            return;
 
-        p->setItem(i,0, item );
-        p->setItem(i,1, new QTableWidgetItem(item2,0));
-        p->setItem(i,2, new QTableWidgetItem(item3,0));
-        p->setItem(i,3, new QTableWidgetItem(item4,0));
-        p->setItem(i,4, new QTableWidgetItem(item5,0));
-		if (c != NULL) item->setData(Qt::UserRole,QVariant::fromValue(c));
+        QString item1 = QString(match->name.c_str());
+        QString item2 = compoundName;
+        QString item3 = QString::number(match->rtDiff, 'f', 2);
+        QString item4 = QString::number(match->diff, 'f', 2);
+        QString item5 = QString::number(match->fragScore.mergedScore, 'f', 3);
+        QString item6 = databaseName;
+        QStringList rowItems = QStringList() << item1
+                                             << item2
+                                             << item3
+                                             << item4
+                                             << item5
+                                             << item6;
+        QTreeWidgetItem *item = new QTreeWidgetItem(rowItems);
+        item->setData(0, Qt::UserRole, QVariant(i));
+        p->addTopLevelItem(item);
     }
 
+    p->sortByColumn(3,Qt::DescendingOrder);
+    p->header()->setStretchLastSection(true);
     p->setSortingEnabled(true);
     p->setUpdatesEnabled(true);
     p->update();
-
 }
 
 void MassCalcWidget::setupSortedCompoundsDB() {
     sortedcompounds.clear();
-    sortedcompounds.resize(DB.compoundsDB.size());
-    copy(DB.compoundsDB.begin(), DB.compoundsDB.end(),   sortedcompounds.begin());
+    copy(DB.compoundsDB.begin(),
+         DB.compoundsDB.end(),
+         back_inserter(sortedcompounds));
     sort(sortedcompounds.begin(), sortedcompounds.end(), Compound::compMass);
 }
 
 QSet<Compound*> MassCalcWidget::findMathchingCompounds(float mz, MassCutoff *massCutoff, float charge) {
-	if (sortedcompounds.size() != DB.compoundsDB.size() ) { setupSortedCompoundsDB(); }
-
-	QSet<Compound*>uniqset;
+    setupSortedCompoundsDB();
     MassCalculator mcalc;
-    Compound x("find", "", "",0);
-    x.mass = mz-2;
-    vector<Compound*>::iterator itr = lower_bound(sortedcompounds.begin(), sortedcompounds.end(), &x, Compound::compMass);
-
-	//cerr << "findMathchingCompounds() mz=" << mz << " ppm=" << ppm << " charge=" <<  charge;
-    for(;itr != sortedcompounds.end(); itr++ ) {
-        Compound* c = *itr; if (!c) continue;
+    QSet<Compound*>uniqset;
+    Compound x("", "", "", 0);
+    x.mass = mz - 2;
+    vector<Compound*>::iterator itr = lower_bound(sortedcompounds.begin(),
+                                                  sortedcompounds.end(),
+                                                  &x,
+                                                  Compound::compMass);
+    for (; itr != sortedcompounds.end(); itr++) {
+        Compound* c = *itr;
+        if (!c)
+            continue;
         double cmass = MassCalculator::computeMass(c->formula, charge);
-        if ( mzUtils::massCutoffDist((double) cmass, (double) mz,massCutoff) < massCutoff->getMassCutoff() && !uniqset.contains(c) ) uniqset << c;
-        if (cmass > mz+2) break;
-	}
-	return uniqset;
+        if (mzUtils::massCutoffDist((double) cmass,
+                                    (double) mz,
+                                    massCutoff) < massCutoff->getMassCutoff()
+            && !uniqset.contains(c))
+            uniqset << c;
+        if (cmass > mz + 2)
+            break;
+    }
+    return uniqset;
 }
 
 void MassCalcWidget::getMatches() {
     int charge = _mw->mavenParameters->getCharge();
-	QSet<Compound*> compounds = findMathchingCompounds(_mz,_massCutoff,charge);
-	Q_FOREACH(Compound* c, compounds) {
-          MassCalculator::Match* m = new MassCalculator::Match();
-          m->name = c->formula;
-          m->mass = MassCalculator::computeMass(c->formula,_mw->mavenParameters->getCharge(c));
-          m->diff = mzUtils::massCutoffDist((double) m->mass,(double) _mz,_massCutoff);
-          m->compoundLink = c;
-          matches.push_back(m);
+    QSet<Compound*> compounds = findMathchingCompounds(_mz,
+                                                       _massCutoff,
+                                                       charge);
+    delete_all(matches);
+    Q_FOREACH(Compound* c, compounds) {
+        MassCalculator::Match* m = new MassCalculator::Match();
+        m->name = c->formula;
+        m->mass = MassCalculator::computeMass(c->formula,
+                                              _mw->mavenParameters->getCharge(c));
+        m->diff = mzUtils::massCutoffDist((double)m->mass,
+                                          (double)_mz,
+                                          _massCutoff);
+        m->compoundLink = c;
+        matches.push_back(m);
     }
+}
+
+void MassCalcWidget::setPeakGroup(PeakGroup* grp) {
+    if(!grp)
+        return;
+
+    _mz = grp->meanMz;
+    getMatches();
+
+    if(grp->ms2EventCount == 0)
+        grp->computeFragPattern(fragPpm->value());
+
+    for(auto& m : matches) {
+        Compound* cpd = m->compoundLink;
+
+        if(grp->fragmentationPattern.nobs() != 0) {
+            m->fragScore = grp->fragMatchScore;
+        }
+
+        if (cpd->expectedRt > 0)
+            m->rtDiff = grp->meanRt - cpd->expectedRt;
+    }
+    showTable();
+}
+
+void MassCalcWidget::setFragmentationScan(Scan* scan) {
+    if(!scan)
+        return;
+
+    Fragment f(scan, 0, 0, 1024);
+    _mz = scan->precursorMz;
+    getMatches();
+
+    for(auto& m : matches ) {
+        Compound* cpd = m->compoundLink;
+        m->fragScore = cpd->scoreCompoundHit(&f, fragPpm->value(), false);
+        m->fragScore.mergedScore = m->fragScore.hypergeomScore;
+    }
+    showTable();
 }
 
 void MassCalcWidget::pubChemLink(QString formula){
@@ -162,26 +230,26 @@ void MassCalcWidget::keggLink(QString formula){
     _mw->setUrl(requestStr);
 }
 
-void MassCalcWidget::showCellInfo(int row, int col, int lrow, int lcol) {
+void MassCalcWidget::_showInfo()
+{
+    if (matches.size() == 0)
+        return;
 
-	lrow=lcol=0;
-    if ( row < 0 || col < 0 )  return;
-    if ( row < mTable->rowCount()  ) {
+    auto items = mTable->selectedItems();
+    if (items.isEmpty())
+        return;
 
-		QVariant v = mTable->item(row,0)->data(Qt::UserRole);
-    	Compound*  c =  v.value<Compound*>();
+    QTreeWidgetItem* item = items.last();
+    if(!item)
+        return;
 
-		if ( c) {
-			_mw->setCompoundFocus(c);
-			return;
-		}
+    QVariant v = item->data(0, Qt::UserRole);
+    int matchNum = v.toInt();
 
-        QString formula = mTable->item(row,0)->text();
-		if (!formula.isEmpty()) {
-			_mw->setFormulaFocus(formula);
-			return;
-		}
-
+    MassCalculator::Match* match = matches[matchNum];
+    if (match->compoundLink) {
+        _mw->getEicWidget()->setCompound(match->compoundLink);
+        _mw->fragSpectraWidget->overlayCompoundFragmentation(match->compoundLink);
     }
 }
 

--- a/src/gui/mzroll/masscalcgui.cpp
+++ b/src/gui/mzroll/masscalcgui.cpp
@@ -22,7 +22,7 @@ MassCalcWidget::MassCalcWidget(MainWindow* mw) {
   database->addItem("All");
 
   connect(computeButton, SIGNAL(clicked(bool)), SLOT(compute()));
-  connect(database, SIGNAL(currentIndexChanged(int)), SLOT(compute()));
+  connect(database, SIGNAL(currentIndexChanged(int)), SLOT(showTable()));
   connect(precursorMz,SIGNAL(returnPressed()),SLOT(compute()));
   connect(ionization,SIGNAL(valueChanged(double)),SLOT(compute()));
   connect(precursorPpm,SIGNAL(valueChanged(double)),SLOT(compute()));
@@ -97,7 +97,7 @@ void MassCalcWidget::showTable()
 
         if (database->currentIndex() != 0
             && database->currentText() != databaseName)
-            return;
+            continue;
 
         QString item1 = QString(match->name.c_str());
         QString item2 = compoundName;

--- a/src/gui/mzroll/masscalcgui.cpp
+++ b/src/gui/mzroll/masscalcgui.cpp
@@ -1,4 +1,5 @@
 #include "Compound.h"
+#include "eicwidget.h"
 #include "globals.h"
 #include "mainwindow.h"
 #include "masscalcgui.h"

--- a/src/gui/mzroll/masscalcgui.cpp
+++ b/src/gui/mzroll/masscalcgui.cpp
@@ -103,7 +103,7 @@ void MassCalcWidget::showTable()
         QString item2 = compoundName;
         QString item3 = QString::number(match->rtDiff, 'f', 2);
         QString item4 = QString::number(match->diff, 'f', 2);
-        QString item5 = QString::number(match->fragScore.mergedScore, 'f', 3);
+        QString item5 = QString::number(match->fragScore.hypergeomScore, 'f', 3);
         QString item6 = databaseName;
         QStringList rowItems = QStringList() << item1
                                              << item2
@@ -190,7 +190,8 @@ void MassCalcWidget::setPeakGroup(PeakGroup* grp) {
         Compound* cpd = m->compoundLink;
 
         if(grp->fragmentationPattern.nobs() != 0) {
-            m->fragScore = grp->fragMatchScore;
+            m->fragScore = cpd->scoreCompoundHit(&(grp->fragmentationPattern),
+                                                 fragPpm->value());
         }
 
         if (cpd->expectedRt > 0)

--- a/src/gui/mzroll/masscalcgui.h
+++ b/src/gui/mzroll/masscalcgui.h
@@ -29,12 +29,14 @@ public Q_SLOTS:
 	  void setMassCutoff(MassCutoff *massCutoff);
       void compute();
 	  QSet<Compound*> findMathchingCompounds(float mz, MassCutoff *massCutoff, float charge);
+      void setPeakGroup(PeakGroup* grp);
+      void setFragmentationScan(Scan* scan);
 
 private Q_SLOTS:
-      void showCellInfo(int row, int col, int lrow, int lcol);
+      void _showInfo();
 	  void getMatches();
       void showTable();
-   
+
 private:
       MainWindow* _mw;
       MassCalculator mcalc;

--- a/src/gui/mzroll/masscalcgui.h
+++ b/src/gui/mzroll/masscalcgui.h
@@ -12,6 +12,7 @@ class MassCalculator;
 class Database;
 class MassCutoff;
 class Compound;
+class PeakGroup;
 
 class MassCalcWidget: public QDockWidget,  public Ui_MassCalcWidget {
       Q_OBJECT

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -9,6 +9,7 @@
 #include "database.h"
 #include "ligandwidget.h"
 #include "mainwindow.h"
+#include "masscalcgui.h"
 #include "mavenparameters.h"
 #include "mzSample.h"
 #include "peakdetectiondialog.h"

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -114,13 +114,13 @@ void PeakDetectionSettings::updatePeakSettings(string key, string value)
     }
 }
 
-PeakDetectionDialog::PeakDetectionDialog(QWidget *parent) :
+PeakDetectionDialog::PeakDetectionDialog(MainWindow* parent) :
         QDialog(parent)
 {
         setupUi(this);
 
         settings = NULL;
-        mainwindow = NULL;
+        mainwindow = parent;
 
         setModal(false);
         peakupdater = NULL;
@@ -168,6 +168,10 @@ PeakDetectionDialog::PeakDetectionDialog(QWidget *parent) :
                             ->hitEvent("PRM", "PRM Analysis");
                     }
                 });
+        connect(fragmentTolerance,
+                SIGNAL(valueChanged(double)),
+                mainwindow->massCalcWidget->fragPpm,
+                SLOT(setValue(double)));
         connect(saveMethodButton,SIGNAL(clicked()),this,SLOT(saveMethod())); //TODO: Sahil - Kiran, Added while merging mainwindow
         connect(loadMethodButton,SIGNAL(clicked()),this,SLOT(loadMethod())); //TODO: Sahil - Kiran, Added while merging mainwindow
         connect(loadModelButton,SIGNAL(clicked()),this,SLOT(loadModel()));

--- a/src/gui/mzroll/peakdetectiondialog.h
+++ b/src/gui/mzroll/peakdetectiondialog.h
@@ -15,7 +15,7 @@ class PeakDetectionDialog : public QDialog, public Ui_PeakDetectionDialog
 
 		public:
 				 enum FeatureDetectionType { FullSpectrum=0, CompoundDB, QQQ };
-				 PeakDetectionDialog(QWidget *parent);
+                                 PeakDetectionDialog(MainWindow* parent);
 				 ~PeakDetectionDialog();
 				 void setSettings(QSettings* settings) { this->settings = settings; }
 				 void setMainWindow(MainWindow* w) { this->mainwindow = w; }

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -50,6 +50,14 @@ EicPoint::EicPoint(float x, float y, Peak* peak, MainWindow* mw)
          connect(this, SIGNAL(peakGroupFocus(PeakGroup*)), mw->getEicWidget(), SLOT(setSelectedGroup(PeakGroup*)));
          connect(this, SIGNAL(peakGroupFocus(PeakGroup*)), mw->getEicWidget()->scene(), SLOT(update()));
     }
+    connect(this,
+            SIGNAL(peakGroupSelected(PeakGroup*)),
+            mw->massCalcWidget,
+            SLOT(setPeakGroup(PeakGroup*)));
+    connect(this,
+            SIGNAL(ms2MarkerSelected(Scan*)),
+            mw->massCalcWidget,
+            SLOT(setFragmentationScan(Scan*)));
 }
 
 EicPoint::~EicPoint() {}
@@ -155,10 +163,16 @@ void EicPoint::mousePressEvent (QGraphicsSceneMouseEvent* event) {
     }
 
     setZValue(10);
-    if (_group)
+    if (_group) {
+        cerr << "GROUP EXISTS!" << endl;
         emit peakGroupSelected(_group);
-    if (_peak)
+    }
+
+    if (_peak) {
         emit peakSelected(_peak);
+    } else {
+        emit ms2MarkerSelected(_scan);
+    }
 
     // make changes through static functions, since this object might be
     // destroyed during the execution period of those functions.

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -8,6 +8,7 @@
 #include "isotopeswidget.h"
 #include "ligandwidget.h"
 #include "mainwindow.h"
+#include "masscalcgui.h"
 #include "mzSample.h"
 #include "note.h"
 #include "pathwaywidget.h"

--- a/src/gui/mzroll/point.h
+++ b/src/gui/mzroll/point.h
@@ -71,8 +71,7 @@ Q_SIGNALS:
     void peakGroupSelected(PeakGroup*);
     void spectaFocused(Peak*);
     void peakGroupFocus(PeakGroup*);
-
-
+    void ms2MarkerSelected(Scan*);
 };
 
 #endif

--- a/src/gui/mzroll/treedockwidget.cpp
+++ b/src/gui/mzroll/treedockwidget.cpp
@@ -3,6 +3,7 @@
 #include "eicwidget.h"
 #include "globals.h"
 #include "mainwindow.h"
+#include "masscalcgui.h"
 #include "numeric_treewidgetitem.h"
 #include "pathwaywidget.h"
 #include "projectdockwidget.h"

--- a/src/gui/mzroll/treedockwidget.cpp
+++ b/src/gui/mzroll/treedockwidget.cpp
@@ -106,6 +106,10 @@ void TreeDockWidget::showInfo() {
                                         mainwindow->spectraDockWidget->setVisible(true);
                                         mainwindow->spectraDockWidget->raise();
                                     }
+
+                                    if (scan->mslevel == 2)
+                                        mainwindow->massCalcWidget->setFragmentationScan(scan);
+
                                     mainwindow->getSpectraWidget()->setScan(scan);
                                     mainwindow->getEicWidget()->setFocusLine(scan->rt);
                                     // if (scan->mslevel > 1) {


### PR DESCRIPTION
The compound match widget can be helpful when all compounds in the global database having a specific mass (within a tolerance) need to be highlighted. This commit includes the following changes made to the widget:
 1. Added a combo box to allow showing compounds from only a specific database.
 2. Removed redundant columns and added more useful ones.
 3. Added a value setter for fragment tolerance, used to calculate fragmentation score (for groups/scans having fragmentation events).
 4. Some miscellaneous polish and interactivity between different widgets and controls that should affect compound match widget.