### PR TITLE
Automated installer deployment

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -204,10 +204,9 @@ artifacts:
 deploy:
     provider: GitHub
     auth_token:
-        secure: "INSERT_OAUTH_TOKEN"
+        secure: moaFAAsmGMUIXff8cdjiY70PtJD8M8x3e7h1qCWw6jcQX3qYYrD5qNFlbSDZtapF
     artifact: $(PACKAGING_REPO)\$(INSTALLER).exe
     draft: true
-    prerelease: true
     on:
         branch: develop                # release from develop branch only
         APPVEYOR_REPO_TAG: true        # deploy to release page on tag push only

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -206,6 +206,7 @@ deploy:
     provider: GitHub
     auth_token:
         secure: moaFAAsmGMUIXff8cdjiY70PtJD8M8x3e7h1qCWw6jcQX3qYYrD5qNFlbSDZtapF
+    release: $(APPVEYOR_REPO_TAG_NAME)
     artifact: $(PACKAGING_REPO)\$(INSTALLER).exe
     draft: true
     force_update: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -101,7 +101,7 @@ after_build:
           if ( -Not (Test-Path $BIN -PathType Container) ) { mkdir $BIN }
           cd $BIN ; rm -Recurse -Force *
 
-          $excludes = "linux","node","node_bin","node_modules","node.exe"
+          $excludes = "linux","node","node_bin","node_modules","node.exe","MavenTests.exe"
           Get-ChildItem $ELMAVEN_BIN |
               Where-Object{$_.Name -notin $excludes} |
               Copy-Item -Destination $BIN -Recurse -Force

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,8 @@ environment:
   BIT: 64
   SENTRY_OAUTH:
     secure: +59H0p7EcOrHb6126nylf5sN7HF40cJMNa1skgWKDJNK6YZStg+agGdsX8cfqC5QBVMTK8ir/S3W1X35r4ElsgadQD54Zr8y0jvfyKN5hAw=
+  CODECOV_TOKEN:
+    secure: kDB13lf6yyaC7d63D0DcRbEjf5vZ77xt2WMxHtxx7Jz32OUaR8Ouxso7WBQoubMO
 
 
 cache:
@@ -203,8 +205,7 @@ deploy:
 
 
 on_success:
-    -bash -lc "export CODECOV_TOKEN='9a0f9704-6d63-48c6-8c1a-ded361a26597'"
-    -bash -lc "cd $APPVEYOR_BUILD_FOLDER ; bash <(curl -s https://codecov.io/bash)"
+    - bash -lc "cd /c/projects/ElMaven/ ; bash <(curl -s https://codecov.io/bash)"
 
 
 notifications:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -207,6 +207,7 @@ deploy:
         secure: moaFAAsmGMUIXff8cdjiY70PtJD8M8x3e7h1qCWw6jcQX3qYYrD5qNFlbSDZtapF
     artifact: $(PACKAGING_REPO)\$(INSTALLER).exe
     draft: true
+    force_update: true
     on:
         APPVEYOR_REPO_TAG: true        # deploy to release page on tag push only
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,10 +40,19 @@ build_script:
 
 
 after_build:
-    - ps: git clone -q https://github.com/ElucidataInc/elmaven-packaging.git
-
     - ps: |
+          # we do not create installers for pull requests, to save time
+          if ( Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER ) {
+              echo "This build is for a PR. Not proceeding with installer creation."
+              return
+          }
+
+          # clone packaging repo
+          echo "Cloning packaging repo ..."
+          git clone -q https://github.com/ElucidataInc/elmaven-packaging.git
+
           # define variables
+          echo "Defining environment variables ..."
           $env:PACKAGING_REPO = "elmaven-packaging"
           $ELMAVEN_TAG = git describe --abbrev=0 --tags
           $ELMAVEN_VERSION = $ELMAVEN_TAG.TrimStart('v')
@@ -64,8 +73,8 @@ after_build:
           $env:APPNAME = "El-MAVEN"
           $env:INSTALLER = "$env:APPNAME-$ELMAVEN_BRANCH"
 
-    - ps: |
           # collect runtime plugins
+          echo "Collecting plugins ..."
           cd $PARENT_DIR
           if ( -Not (Test-Path $BIN -PathType Container) ) { mkdir $BIN }
           cd $BIN ; rm -Recurse -Force *
@@ -115,8 +124,8 @@ after_build:
           # generate qt.conf
           echo "[Paths]`nPrefix = .`n" >> qt.conf
 
-    - ps: |
           # strip and upload debug symbols
+          echo "Stripping and uploading symbols ..."
           cd $BIN
           $BREAKPAD_TOOLS = "$env:APPVEYOR_BUILD_FOLDER\$env:PACKAGING_REPO\breakpad_tools\windows"
           $exe_file = "$env:APPNAME.exe"
@@ -134,19 +143,19 @@ after_build:
           & "$BREAKPAD_TOOLS\sentry-cli.exe" --auth-token $env:SENTRY_OAUTH upload-dif -t breakpad --project el-maven-logging --org el-maven ../symbols/
           rm "$env:APPNAME.pdb"
 
-    - ps: |
           # copy node
+          echo "Copying node requirements ..."
           Get-ChildItem -Path $NODE_WIN | Move-Item -Destination $BIN
 
-    - ps: |
           # download our precompiled binaries of qt-ifw
+          echo "Downloading binaries for Qt Installer Framework ..."
           cd $PARENT_DIR
           Invoke-RestMethod https://www.dropbox.com/s/snrgft8uskxan27/archivegen.exe?dl=1 -OutFile archivegen.exe
           Invoke-RestMethod https://www.dropbox.com/s/ym2mph272rp2euj/binarycreator.exe?dl=1 -OutFile binarycreator.exe
           Invoke-RestMethod https://www.dropbox.com/s/y4s0gazvdxu34js/installerbase.exe?dl=1 -OutFile installerbase.exe
 
-    - ps: |
           # generate archive
+          echo "Generating archive ..."
           cd $PARENT_DIR
           if ( Test-Path $ARCHIVE_FILE ) { rm $ARCHIVE_FILE }
           if ( Test-Path $PACKAGE_DATA\$ARCHIVE_FILE ) { rm $PACKAGE_DATA\$ARCHIVE_FILE }
@@ -158,8 +167,8 @@ after_build:
           mkdir $PACKAGE_DATA
           Copy-Item $ARCHIVE_FILE $PACKAGE_DATA
 
-    - ps: |
           # update version
+          echo "Updating version string in config file ..."
           cd $PARENT_DIR
           if ( Get-Command "python.exe" -ErrorAction SilentlyContinue ) {
               python.exe update_version.py $ELMAVEN_VERSION
@@ -176,8 +185,8 @@ after_build:
               exit 1
           }
 
-    - ps: |
           # create installer
+          echo "Creating installer ..."
           cd $PARENT_DIR
           .\binarycreator -r extras.qrc -c config\config.xml -p packages\ $env:INSTALLER > $null
           if ( $? -eq $false ) {

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,8 +59,13 @@ after_build:
           echo "Defining environment variables ..."
           $env:PACKAGING_REPO = "elmaven-packaging"
           $ELMAVEN_TAG = git describe --abbrev=0 --tags
-          $SUBSTRING = $ELMAVEN_TAG.Substring(0, $ELMAVEN_TAG.IndexOf("-"))
-          $ELMAVEN_VERSION = $SUBSTRING.TrimStart('v')
+          $pos = $ELMAVEN_TAG.IndexOf("-")
+          if ( $pos -eq -1 ) {
+              $ELMAVEN_VERSION = $ELMAVEN_TAG.TrimStart('v')
+          } else {
+              $substr = $ELMAVEN_TAG.Substring(0, $pos)
+              $ELMAVEN_VERSION = $substr.TrimStart('v')
+          }
 
           if ( Test-Path env:APPVEYOR_REPO_TAG_NAME ) {
               $ELMAVEN_BRANCH = $env:APPVEYOR_REPO_TAG_NAME

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,8 @@ environment:
   MSYS2_DIR: msys64
   MSYSTEM: MINGW64
   BIT: 64
+  SENTRY_OAUTH:
+    secure: +59H0p7EcOrHb6126nylf5sN7HF40cJMNa1skgWKDJNK6YZStg+agGdsX8cfqC5QBVMTK8ir/S3W1X35r4ElsgadQD54Zr8y0jvfyKN5hAw=
 
 
 cache:
@@ -19,11 +21,12 @@ install:
     - bash -lc "pacman -S --needed --noconfirm zlib-devel"
 
     - bash -lc "pacman -S --noconfirm mingw64/mingw-w64-x86_64-curl"
+    - bash -lc "pacman -S --noconfirm rsync"
     - bash -lc "wget https://github.com/linux-test-project/lcov/releases/download/v1.12/lcov-1.12.tar.gz"
     - bash -lc "tar -xzf lcov-1.12.tar.gz"
     - bash -lc "ln -s $PWD/lcov-1.12/bin/lcov /c/msys64/mingw64/bin/lcov"
     - bash -lc "ln -s $PWD/lcov-1.12/bin/geninfo /c/msys64/mingw64/bin/geninfo"
-    - bash -lc "cd /c/projects/ElMaven/ ; ./gcc_v7.3.0.sh"
+    - bash -lc "cd $APPVEYOR_BUILD_FOLDER ; ./gcc_v7.3.0.sh"
 
 build_script:
     - SET "QTEST_FUNCTION_TIMEOUT=1200000"
@@ -33,6 +36,180 @@ build_script:
     - bash -lc "lcov -b /c/Projects/ElMaven/src/core/libmaven/ --capture --directory /c/projects/build/tmp/maven/ --output-file /c/projects/ElMaven/lcov.info --no-external"
     - bash -lc "lcov --summary /c/projects/ElMaven/lcov.info"
 
+
+after_build:
+    - ps: git clone -q https://github.com/ElucidataInc/elmaven-packaging.git
+
+    - ps: |
+          # define variables
+          $env:PACKAGING_REPO = "elmaven-packaging"
+          $ELMAVEN_TAG = git describe --abbrev=0 --tags
+          $ELMAVEN_VERSION = $ELMAVEN_TAG.TrimStart('v')
+
+          if ( Test-Path env:APPVEYOR_REPO_TAG_NAME ) {
+              $ELMAVEN_BRANCH = $env:APPVEYOR_REPO_TAG_NAME
+          } elseif ( Test-Path env:APPVEYOR_REPO_BRANCH ) {
+              $ELMAVEN_BRANCH = $env:APPVEYOR_REPO_BRANCH
+          }
+
+          cd $env:PACKAGING_REPO
+          $PARENT_DIR = Convert-Path .
+          $BIN = "$PARENT_DIR\bin\"
+          $ELMAVEN_BIN = "$PARENT_DIR\..\bin\"
+          $NODE_WIN = "$PARENT_DIR\node_win"
+          $ARCHIVE_FILE = "maven.7z"
+          $PACKAGE_DATA = "$PARENT_DIR\packages\com.vendor.product\data\"
+          $env:APPNAME = "El-MAVEN"
+          $env:INSTALLER = "$env:APPNAME-$ELMAVEN_BRANCH"
+
+    - ps: |
+          # collect runtime plugins
+          cd $PARENT_DIR
+          if ( -Not (Test-Path $BIN -PathType Container) ) { mkdir $BIN }
+          cd $BIN ; rm -Recurse -Force *
+
+          $excludes = "linux","node","node_bin","node_modules","node.exe"
+          Get-ChildItem $ELMAVEN_BIN |
+              Where-Object{$_.Name -notin $excludes} |
+              Copy-Item -Destination $BIN -Recurse -Force
+
+          $libs = $(ldd "$env:APPNAME.exe" peakdetector.exe)
+          if ( $? -eq $false ) {
+              echo "Failed to copy files from build folder to packaging folder."
+              exit 1
+          }
+
+          foreach ( $line in $( $libs -split "`n" ) ) {
+              if ( $line -match '.*=>\s*(.*bin.*dll).*') {
+                  $lib = $Matches[1]
+                  if ( $lib.StartsWith("/c/") ) {
+                      [regex]$p = "/c/"
+                      $lib = $p.replace($lib, "C:/", 1)
+                  } elseif ( $lib.StartsWith("/MINGW64/") ) {
+                      [regex]$p = "/MINGW64/"
+                      $lib = $p.replace($lib, "C:/$env:MSYS2_DIR/MINGW64/", 1)
+                  }
+                  if ( -Not ([io.path]::GetDirectoryName($lib) -eq $BIN) ) {
+                      Copy-item $lib BIN
+                  }
+              }
+          }
+
+          $qt_plugins_path = $(qmake -query QT_INSTALL_PLUGINS)
+          echo "Found plugins at $qt_plugins_path"
+
+          # since Qt5.9.7, windeployqt has stopped working. Going to use some
+          # copy paste magic instead to get all the extra plugins required.
+          Copy-item -recurse "$qt_plugins_path\platforms" .
+          Copy-item -recurse "$qt_plugins_path\imageformats" .
+          Copy-item -recurse "$qt_plugins_path\printsupport" .
+          Copy-item -recurse "$qt_plugins_path\sqldrivers" .
+          Copy-item -recurse "$qt_plugins_path\bearer" .
+          Copy-item -recurse "$qt_plugins_path\mediaservice" .
+
+          # QtNetwork module requires extra ssl dlls to work
+          Copy-item ..\libs\OpenSSL\* .
+
+          # generate qt.conf
+          echo "[Paths]`nPrefix = .`n" >> qt.conf
+
+    - ps: |
+          # strip and upload debug symbols
+          cd $BIN
+          $BREAKPAD_TOOLS = "$env:APPVEYOR_BUILD_FOLDER\$env:PACKAGING_REPO\breakpad_tools\windows"
+          $exe_file = "$env:APPNAME.exe"
+          $pdb_file = "$env:APPNAME.pdb"
+          $symbol_file = "$env:APPNAME.sym"
+
+          & "$BREAKPAD_TOOLS\cv2pdb.exe" $exe_file
+          & "$BREAKPAD_TOOLS\dump_syms.exe" $pdb_file > $symbol_file
+
+          $uuid = $( gc $symbol_file | select -first 1 | grep -o -P "(?<=x86_64).*(?=$pdb_file)" | xargs )
+          mkdir -p ..\symbols\"$env:APPNAME.pdb"\$uuid\
+          mv $symbol_file ..\symbols\"$env:APPNAME.pdb"\$uuid\
+
+          chmod +x $BREAKPAD_TOOLS\sentry-cli.exe
+          & "$BREAKPAD_TOOLS\sentry-cli.exe" --auth-token $env:SENTRY_OAUTH upload-dif -t breakpad --project el-maven-logging --org el-maven ../symbols/
+          rm "$env:APPNAME.pdb"
+
+    - ps: |
+          # copy node
+          Get-ChildItem -Path $NODE_WIN | Move-Item -Destination $BIN
+
+    - ps: |
+          # download our precompiled binaries of qt-ifw
+          cd $PARENT_DIR
+          Invoke-RestMethod https://www.dropbox.com/s/snrgft8uskxan27/archivegen.exe?dl=1 -OutFile archivegen.exe
+          Invoke-RestMethod https://www.dropbox.com/s/ym2mph272rp2euj/binarycreator.exe?dl=1 -OutFile binarycreator.exe
+          Invoke-RestMethod https://www.dropbox.com/s/y4s0gazvdxu34js/installerbase.exe?dl=1 -OutFile installerbase.exe
+
+    - ps: |
+          # generate archive
+          cd $PARENT_DIR
+          if ( Test-Path $ARCHIVE_FILE ) { rm $ARCHIVE_FILE }
+          if ( Test-Path $PACKAGE_DATA\$ARCHIVE_FILE ) { rm $PACKAGE_DATA\$ARCHIVE_FILE }
+          .\archivegen.exe $ARCHIVE_FILE $BIN > $null;
+          if ( $? -eq $false ) {
+              echo 'Failed to generate archive. Make sure archivegen is in system path.'
+              exit 1
+          }
+          mkdir $PACKAGE_DATA
+          Copy-Item $ARCHIVE_FILE $PACKAGE_DATA
+
+    - ps: |
+          # update version
+          cd $PARENT_DIR
+          if ( Get-Command "python.exe" -ErrorAction SilentlyContinue ) {
+              python.exe update_version.py $ELMAVEN_VERSION
+          } elseif ( Get-Command "python2.7.exe" -ErrorAction SilentlyContinue ) {
+              python2.7.exe update_version.py $ELMAVEN_VERSION
+          } elseif ( Get-Command "python3.6.exe" -ErrorAction SilentlyContinue ) {
+              python3.6.exe update_version.py $ELMAVEN_VERSION
+          } else {
+              echo 'Unable to find python.'
+              exit 1
+          }
+          if ( $? -eq $false ) {
+              echo 'Failed to update version in config file.'
+              exit 1
+          }
+
+    - ps: |
+          # create installer
+          cd $PARENT_DIR
+          .\binarycreator -r extras.qrc -c config\config.xml -p packages\ $env:INSTALLER > $null
+          if ( $? -eq $false ) {
+              echo 'Make sure binarycreator is in system path'
+              exit 1
+          }
+          cd $PARENT_DIR\..\
+
+
+artifacts:
+    - path: $(PACKAGING_REPO)\$(INSTALLER).exe
+      name: $(INSTALLER)
+
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: "INSERT_OAUTH_TOKEN"
+    artifact: $(PACKAGING_REPO)\$(INSTALLER).exe
+    draft: true
+    prerelease: true
+    on:
+        branch: develop                # release from develop branch only
+        APPVEYOR_REPO_TAG: true        # deploy to release page on tag push only
+
+
 on_success:
-    - bash -lc "export CODECOV_TOKEN="9a0f9704-6d63-48c6-8c1a-ded361a26597"
-    - bash -lc "cd /c/projects/ElMaven/ ; bash <(curl -s https://codecov.io/bash)"
+    -bash -lc "export CODECOV_TOKEN='9a0f9704-6d63-48c6-8c1a-ded361a26597'"
+    -bash -lc "cd $APPVEYOR_BUILD_FOLDER ; bash <(curl -s https://codecov.io/bash)"
+
+
+notifications:
+    # disable annoying email notifications
+    - provider: Email
+      on_build_success: false
+      on_build_failure: false
+      on_build_status_changed: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,7 +55,8 @@ after_build:
           echo "Defining environment variables ..."
           $env:PACKAGING_REPO = "elmaven-packaging"
           $ELMAVEN_TAG = git describe --abbrev=0 --tags
-          $ELMAVEN_VERSION = $ELMAVEN_TAG.TrimStart('v')
+          $SUBSTRING = $ELMAVEN_TAG.Substring(0, $ELMAVEN_TAG.IndexOf("-"))
+          $ELMAVEN_VERSION = $SUBSTRING.TrimStart('v')
 
           if ( Test-Path env:APPVEYOR_REPO_TAG_NAME ) {
               $ELMAVEN_BRANCH = $env:APPVEYOR_REPO_TAG_NAME

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,10 @@ environment:
     secure: +59H0p7EcOrHb6126nylf5sN7HF40cJMNa1skgWKDJNK6YZStg+agGdsX8cfqC5QBVMTK8ir/S3W1X35r4ElsgadQD54Zr8y0jvfyKN5hAw=
   CODECOV_TOKEN:
     secure: kDB13lf6yyaC7d63D0DcRbEjf5vZ77xt2WMxHtxx7Jz32OUaR8Ouxso7WBQoubMO
+  AWS_ACCESS_KEY:
+    secure: FBWRLw84S0Uq5xlHzaNBfg9zknKUzTQ6+jUBWeQFg38=
+  AWS_SECRET_KEY:
+    secure: uYWVMV2S2RDPMKNuTmncDT75vWfYPwJfHQjog7UO2C0OdtWNuYzxDZnlEvIC/KSA
 
 
 cache:
@@ -203,15 +207,24 @@ artifacts:
 
 
 deploy:
-    provider: GitHub
-    auth_token:
-        secure: moaFAAsmGMUIXff8cdjiY70PtJD8M8x3e7h1qCWw6jcQX3qYYrD5qNFlbSDZtapF
-    release: $(APPVEYOR_REPO_TAG_NAME)
-    artifact: $(PACKAGING_REPO)\$(INSTALLER).exe
-    draft: true
-    force_update: true
-    on:
-        APPVEYOR_REPO_TAG: true        # deploy to release page on tag push only
+    - provider: GitHub
+      auth_token:
+          secure: moaFAAsmGMUIXff8cdjiY70PtJD8M8x3e7h1qCWw6jcQX3qYYrD5qNFlbSDZtapF
+      release: $(APPVEYOR_REPO_TAG_NAME)
+      artifact: $(PACKAGING_REPO)\$(INSTALLER).exe
+      draft: true
+      force_update: true
+      on:
+          APPVEYOR_REPO_TAG: true        # deploy to release page on tag push only
+
+    - provider: S3
+      access_key_id: $(AWS_ACCESS_KEY)
+      secret_access_key: $(AWS_SECRET_KEY)
+      region: us-west-2
+      bucket: "elmaven-installers"
+      folder: "Windows"
+      set_public: true
+      artifact: $(PACKAGING_REPO)\$(INSTALLER).exe
 
 
 on_success:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -208,7 +208,6 @@ deploy:
     artifact: $(PACKAGING_REPO)\$(INSTALLER).exe
     draft: true
     on:
-        branch: develop                # release from develop branch only
         APPVEYOR_REPO_TAG: true        # deploy to release page on tag push only
 
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,8 @@ environment:
   MSYS2_DIR: msys64
   MSYSTEM: MINGW64
   BIT: 64
+  SENTRY_KEYS:
+    secure: 4h/RDAT2VRFeFncyVmupjvYW2+ZVLLt8Meb0HZnKpeXw4DgSXxy2C8PicOvkBrxGsywvi1LTBDAJdTBdCaXHXETB0zLjFrasYj9hNUYhF2hWF7XZXA9qYPyhZHNVyg8t
   SENTRY_OAUTH:
     secure: +59H0p7EcOrHb6126nylf5sN7HF40cJMNa1skgWKDJNK6YZStg+agGdsX8cfqC5QBVMTK8ir/S3W1X35r4ElsgadQD54Zr8y0jvfyKN5hAw=
   CODECOV_TOKEN:
@@ -35,6 +37,16 @@ install:
     - bash -lc "cd $APPVEYOR_BUILD_FOLDER ; ./gcc_v7.3.0.sh"
 
 build_script:
+    # write to Sentry keys file
+    - echo "$env:SENTRY_KEYS`n" >> keys
+
+    - ps: |
+          # check for Sentry keys file
+          if ( -not (Test-Path keys) ) {
+              echo "File not found - 'keys', needed for crash reporter to work properly."
+              exit 1
+          }
+
     - SET "QTEST_FUNCTION_TIMEOUT=1200000"
     - bash -lc "echo $QTEST_FUNCTION_TIMEOUT"
     - bash -lc "qmake -v"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -203,11 +203,13 @@ after_build:
               echo 'Make sure binarycreator is in system path'
               exit 1
           }
-          cd $PARENT_DIR\..\
+
+          Copy-Item "$env:INSTALLER.exe" ..\
+          cd ..\
 
 
 artifacts:
-    - path: $(PACKAGING_REPO)\$(INSTALLER).exe
+    - path: $(INSTALLER).exe
       name: $(INSTALLER)
 
 
@@ -216,7 +218,7 @@ deploy:
       auth_token:
           secure: moaFAAsmGMUIXff8cdjiY70PtJD8M8x3e7h1qCWw6jcQX3qYYrD5qNFlbSDZtapF
       release: $(APPVEYOR_REPO_TAG_NAME)
-      artifact: $(PACKAGING_REPO)\$(INSTALLER).exe
+      artifact: $(INSTALLER).exe
       draft: true
       force_update: true
       on:
@@ -229,7 +231,7 @@ deploy:
       bucket: "elmaven-installers"
       folder: "Windows"
       set_public: true
-      artifact: $(PACKAGING_REPO)\$(INSTALLER).exe
+      artifact: $(INSTALLER).exe
 
 
 on_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -251,4 +251,5 @@ deploy:
     acl: public_read
     local_dir: $PACKAGING_REPO/$INSTALLER.zip
     on:
+      all_branches: true
       condition: $TRAVIS_OS_NAME = "osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -234,8 +234,10 @@ deploy:
       condition: $TRAVIS_OS_NAME = "osx"
   - provider: releases
     skip_cleanup: true
-    api_key: "INSERT_OAUTH_TOKEN"
+    api_key: $GITHUB_RELEASE_TOKEN
     file: $PACKAGING_REPO/$INSTALLER.app
+    draft: true
+    overwrite: true
     on:
       tags: true
       condition: $TRAVIS_OS_NAME = "osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       group: deprecated-2017Q2
     - os: osx
       osx_image: xcode9.2
+      language: cpp
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,17 @@ install:
     fi
 
 script:
-  - |
+  # write to Sentry keys file
+  - printf "%s\n\n" $SENTRY_KEYS > keys
 
+  - |
+    # check for Sentry keys file
+    if [ ! -f keys ]; then
+      echo "File not found - 'keys', needed for crash reporter to work properly."
+      exit 1
+    fi
+
+  - |
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
       export LDFLAGS="-L/usr/local/opt/llvm@6/lib -Wl,-rpath,/usr/local/opt/llvm@6/lib"
       export PATH="/usr/local/opt/llvm@6/bin/:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,6 @@ script:
 
 
 after_success:
-  - export CODECOV_TOKEN="9a0f9704-6d63-48c6-8c1a-ded361a26597"
   - bash <(curl -s https://codecov.io/bash)
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ env:
     - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
 
 
+git:
+  depth: false
+
+
 before_install:
     -  if [ "$TRAVIS_OS_NAME" == "linux" ]; then
             sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0C49F3730359A14518585931BC711F9BA15703C6;
@@ -78,11 +82,12 @@ after_success:
 
 
 before_deploy:
-  # TO-DO: use regex to extract these values
+  # To-Do: use regex to extract these values
   - |
-    export ELMAVEN_TAG=`git describe --abbrev=0 --tags`
+    export ELMAVEN_TAG=`git describe --tags`
     SUBSTRING=$(echo $ELMAVEN_TAG| cut -d'-' -f 1)
     export ELMAVEN_VERSION=${SUBSTRING[@]:1}
+
   - |
 
     if [ "$TRAVIS_TAG" != "" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,13 +85,10 @@ after_success:
 
 
 before_deploy:
-  # To-Do: use regex to extract these values
   - |
     export ELMAVEN_TAG=`git describe --tags`
     SUBSTRING=$(echo $ELMAVEN_TAG| cut -d'-' -f 1)
     export ELMAVEN_VERSION=${SUBSTRING[@]:1}
-
-  - |
 
     if [ "$TRAVIS_TAG" != "" ]; then
       export ELMAVEN_BRANCH=$TRAVIS_TAG
@@ -99,9 +96,8 @@ before_deploy:
       export ELMAVEN_BRANCH=$TRAVIS_BRANCH
     fi
 
-  - export PACKAGING_REPO=elmaven-packaging
-  - git clone https://github.com/ElucidataInc/elmaven-packaging.git
-  - |
+    export PACKAGING_REPO=elmaven-packaging
+    git clone https://github.com/ElucidataInc/elmaven-packaging.git
 
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
       cd $PACKAGING_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,6 @@ before_deploy:
       ELMAVEN_BIN="$PARENT_DIR/../bin/"
       BIN="$PARENT_DIR/bin/"
       NODE_MAC="$PARENT_DIR/node_mac/"
-      NODE_WIN="$PARENT_DIR/node_win/"
       ARCHIVE_FILE="maven.7z"
       PACKAGE_DATA="$PARENT_DIR/packages/com.vendor.product/data/"
       INSTALLER="El-MAVEN-$ELMAVEN_BRANCH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -230,20 +230,25 @@ before_deploy:
 
 
 deploy:
-  - provider: script
-    skip_cleanup: true
-    script: du -h -d 1 $PACKAGING_REPO
-    on:
-      tags: false
-      all_branches: true
-      condition: $TRAVIS_OS_NAME = "osx"
   - provider: releases
     skip_cleanup: true
     name: $TRAVIS_TAG
     api_key: $GITHUB_RELEASE_TOKEN
-    file: $INSTALLER.zip
+    file: $PACKAGING_REPO/$INSTALLER.zip
     draft: true
     overwrite: true
     on:
       tags: true
+      condition: $TRAVIS_OS_NAME = "osx"
+
+  - provider: s3
+    skip_cleanup: true
+    access_key_id: $AWS_ACCESS_KEY
+    secret_access_key: $AWS_SECRET_KEY
+    region: us-west-2
+    bucket: "elmaven-installers"
+    upload-dir: "Mac"
+    acl: public_read
+    local_dir: $PACKAGING_REPO/$INSTALLER.zip
+    on:
       condition: $TRAVIS_OS_NAME = "osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,10 @@ after_success:
 
 before_deploy:
   # TO-DO: use regex to extract these values
-  - export ELMAVEN_TAG=`git describe --abbrev=0 --tags`
-  - export ELMAVEN_VERSION=${ELMAVEN_TAG[@]:1}
+  - |
+    export ELMAVEN_TAG=`git describe --abbrev=0 --tags`
+    SUBSTRING=$(echo $ELMAVEN_TAG| cut -d'-' -f 1)
+    export ELMAVEN_VERSION=${SUBSTRING[@]:1}
   - |
 
     if [ "$TRAVIS_TAG" != "" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
       compiler: gcc-5
       group: deprecated-2017Q2
     - os: osx
+      osx_image: xcode9.2
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ before_deploy:
       cd $BIN
       rm -rf *
 
-      rsync -av --progress --exclude 'windows' --exclude 'linux' --exclude 'node' --exclude 'node_bin' --exclude 'node.exe' $ELMAVEN_BIN . &>/dev/null
+      rsync -av --progress --exclude={'windows', 'linux', 'node', 'node_bin', 'node.exe', 'MavenTests'} $ELMAVEN_BIN . &>/dev/null
 
       # prepare dSYM files
       echo "Preparing debug symbol files ..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -239,6 +239,7 @@ deploy:
       condition: $TRAVIS_OS_NAME = "osx"
   - provider: releases
     skip_cleanup: true
+    name: $TRAVIS_TAG
     api_key: $GITHUB_RELEASE_TOKEN
     file: $INSTALLER.zip
     draft: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,6 @@ script:
     fi
 
 
-after_script:
+after_success:
   - export CODECOV_TOKEN="9a0f9704-6d63-48c6-8c1a-ded361a26597"
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       osx_image: xcode9.2
       language: cpp
 
+
 env:
   global:
     - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
@@ -75,3 +76,145 @@ script:
 after_success:
   - export CODECOV_TOKEN="9a0f9704-6d63-48c6-8c1a-ded361a26597"
   - bash <(curl -s https://codecov.io/bash)
+
+
+before_deploy:
+  # TO-DO: use regex to extract these values
+  - export ELMAVEN_TAG=`git describe --abbrev=0 --tags`
+  - export ELMAVEN_VERSION=${ELMAVEN_TAG[@]:1}
+  - |
+
+    if [ "$TRAVIS_TAG" != "" ]; then
+      export ELMAVEN_BRANCH=$TRAVIS_TAG
+    else
+      export ELMAVEN_BRANCH=$TRAVIS_BRANCH
+    fi
+
+  - export PACKAGING_REPO=elmaven-packaging
+  - git clone https://github.com/ElucidataInc/elmaven-packaging.git
+  - |
+
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      cd $PACKAGING_REPO
+
+      # define variables
+      PARENT_DIR=$PWD
+      BREAKPAD_TOOLS=$PWD/breakpad_tools/
+      ELMAVEN_BIN="$PARENT_DIR/../bin/"
+      BIN="$PARENT_DIR/bin/"
+      NODE_MAC="$PARENT_DIR/node_mac/"
+      NODE_WIN="$PARENT_DIR/node_win/"
+      ARCHIVE_FILE="maven.7z"
+      PACKAGE_DATA="$PARENT_DIR/packages/com.vendor.product/data/"
+      INSTALLER="El-MAVEN-$ELMAVEN_BRANCH"
+
+      # collect runtime plugins
+      echo "Collecting plugins ..."
+      cd $PARENT_DIR
+
+      if [ ! -d $BIN ]; then
+        mkdir $BIN
+      fi
+
+      cd $BIN
+      rm -rf *
+
+      rsync -av --progress --exclude 'windows' --exclude 'linux' --exclude 'node' --exclude 'node_bin' --exclude 'node.exe' $ELMAVEN_BIN . &>/dev/null
+
+      # prepare dSYM files
+      echo "Preparing debug symbol files ..."
+      dsymutil "El-MAVEN.app/Contents/MacOS/El-MAVEN" -o "El-MAVEN.dSYM" &>/dev/null
+      macdeployqt El-MAVEN.app &>/dev/null
+      macdeployqt peakdetector.app &>/dev/null
+      macdeployqt crashreporter.app &>/dev/null
+      # install_name_tool -add_rpath @executable_path/../Frameworks "El-MAVEN.app/Contents/MacOS/crashserver"
+
+      if [ $? != 0 ]; then
+        echo "Failed to create debug files."
+        exit 1
+      fi
+
+      # strip and upload debug symbols
+      echo "Stripping and uploading symbols ..."
+      cd $BIN
+      $BREAKPAD_TOOLS/mac/strip_symbols.sh $BREAKPAD_TOOLS "El-MAVEN.app/Contents/MacOS/El-MAVEN" El-MAVEN &>/dev/null
+      rm -r *.dSYM
+
+      # copy node
+      echo "Copying node executable ..."
+      cp -r $NODE_MAC $BIN
+
+      # download our precompiled binaries of qt-ifw
+      echo "Downloading binaries for Qt Installer Framework ..."
+      cd $PARENT_DIR
+
+      wget https://www.dropbox.com/s/jwzuf4howm71s1d/archivegen?dl=1 -O archivegen &> /dev/null
+      chmod u+x ./archivegen
+      wget https://www.dropbox.com/s/yl47a7wjyzy91o9/binarycreator?dl=1 -O binarycreator &> /dev/null
+      chmod u+x ./binarycreator
+      wget https://www.dropbox.com/s/m5xjddbxon5cry9/installerbase?dl=1 -O installerbase &> /dev/null
+      chmod u+x ./installerbase
+
+      # generate archive
+      echo "Generating archive ..."
+      cd $PARENT_DIR
+
+      if [ -f $ARCHIVE_FILE ]; then
+        rm $ARCHIVE_FILE
+      fi
+
+      if [ -f $PACKAGE_DATA/$ARCHIVE_FILE ]; then
+        rm $PACKAGE_DATA/$ARCHIVE_FILE
+      fi
+
+      ./archivegen $ARCHIVE_FILE $BIN
+
+      if [ $? != 0 ]; then
+        echo "Failed to generate archive. Make sure archivegen is in system path."
+        exit 1
+      fi
+
+      mkdir $PACKAGE_DATA
+      cp $ARCHIVE_FILE $PACKAGE_DATA
+
+      # update version
+      echo "Updating version string in config file ..."
+      cd $PARENT_DIR
+
+      python update_version.py $ELMAVEN_VERSION
+
+      if [ $? != 0 ]; then
+        echo "Failed to update version in config file."
+        exit 1
+      fi
+
+      # create installer
+      echo "Creating installer ..."
+      cd $PARENT_DIR
+
+      ./binarycreator --ignore-translations -r extras.qrc -c config/config.xml -p packages/ $INSTALLER
+
+      if [ $? != 0 ]; then
+        echo "Failed to create installer. Make sure binarycreator is in system path."
+        exit 1
+      fi
+
+      cd $PARENT_DIR/../
+    fi
+
+
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: du -h -d 1 $PACKAGING_REPO
+    on:
+      tags: false
+      all_branches: true
+      condition: $TRAVIS_OS_NAME = "osx"
+  - provider: releases
+    skip_cleanup: true
+    api_key: "INSERT_OAUTH_TOKEN"
+    file: $PACKAGING_REPO/$INSTALLER.app
+    on:
+      tags: true
+      condition: $TRAVIS_OS_NAME = "osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -231,6 +231,11 @@ before_deploy:
       zip -r "$INSTALLER.zip" "$INSTALLER.app" &> /dev/null
 
       cd $PARENT_DIR/../
+      cp "$PACKAGING_REPO/$INSTALLER.zip" .
+
+      # S3 provider requires the file(s) for deployment to be in a directory
+      mkdir $ELMAVEN_BRANCH
+      cp "$PACKAGING_REPO/$INSTALLER.zip" $ELMAVEN_BRANCH
     fi
 
 
@@ -239,7 +244,7 @@ deploy:
     skip_cleanup: true
     name: $TRAVIS_TAG
     api_key: $GITHUB_RELEASE_TOKEN
-    file: $PACKAGING_REPO/$INSTALLER.zip
+    file: $INSTALLER.zip
     draft: true
     overwrite: true
     on:
@@ -254,7 +259,7 @@ deploy:
     bucket: "elmaven-installers"
     upload-dir: "Mac"
     acl: public_read
-    local_dir: $PACKAGING_REPO/$INSTALLER.zip
+    local_dir: $ELMAVEN_BRANCH
     on:
       all_branches: true
       condition: $TRAVIS_OS_NAME = "osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,6 +199,28 @@ before_deploy:
         exit 1
       fi
 
+      # create keychain and import certificate
+      echo "Creating new Keychain and installing developer certificate ..."
+      security create-keychain -p dummypass build.keychain
+      security default-keychain -s build.keychain
+      security unlock-keychain -p dummypass build.keychain
+
+      echo $CERTIFICATE_OSX_P12 | base64 --decode > certificate.p12
+      security import certificate.p12 -k build.keychain -P $CERTIFICATE_OSX_PASSWORD -T /usr/bin/codesign
+      security find-identity -v
+      security set-key-partition-list -S apple-tool:,apple: -s -k dummypass build.keychain
+
+      # codesign installer
+      echo "Codesigning the installer ..."
+      cd $PARENT_DIR
+
+      codesign -s "Elucidata Corporation" $INSTALLER.app
+
+      if [ $? != 0 ]; then
+        echo "Failed to sign installer. Make sure the certificate exists."
+        exit 1
+      fi
+
       cd $PARENT_DIR/../
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,10 @@ install:
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
         brew install llvm@6;
         brew install grep;
-        brew install cppcheck qt;
+
+        # brew no longer provides Qt 5.11, so we use an older formula for the same
+        curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/56c500b569c724b049be7ab9e12d9693f85522f9/Formula/qt.rb
+        brew install ./qt.rb
         brew link qt5 --force;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -221,6 +221,10 @@ before_deploy:
         exit 1
       fi
 
+      # compressing
+      echo "Compressing installer into a zip file ..."
+      zip -r "$INSTALLER.zip" "$INSTALLER.app" &> /dev/null
+
       cd $PARENT_DIR/../
     fi
 
@@ -236,7 +240,7 @@ deploy:
   - provider: releases
     skip_cleanup: true
     api_key: $GITHUB_RELEASE_TOKEN
-    file: $PACKAGING_REPO/$INSTALLER.app
+    file: $INSTALLER.zip
     draft: true
     overwrite: true
     on:


### PR DESCRIPTION
This is an attempt to automate creation and deployment of installers for El-MAVEN following (non-PR) successful builds in the following two scenarios:
1. A release (tag event), where installers built will be automatically uploaded to GH release page and perhaps the website as well.
2. Manual branch build trigger, to create an installer for internal testing/trial.

This will help us in distributing installers for any arbitrary branch to whoever needs them as well as relieving the developers from manually creating installers on local systems and then upload them to release page and website.

#### To-Do:
- [x] Add instructions on where to deploy if the build is non-tag.
- [x] Insert proper OAUTH tokens for GitHub releases.