### PR TITLE
Compile El-MAVEN with QtCreator

### DIFF
--- a/build.pro
+++ b/build.pro
@@ -1,6 +1,5 @@
 macx {
-
-    compiler_version = $$system( clang -v 2>&1 | head -n1 | ggrep -Po  "[0-9\.]+" | head -n1 | ggrep -Po "[0-9]+" | head -n1 )
+    compiler_version = $$system(clang -v 2>&1 | head -n1 | grep -o  "[0-9\.]" | head -n1)
     message("compiler major version $$compiler_version")
     if(greaterThan(compiler_version, 5):lessThan(compiler_version, 7)) {
         message("Clang Version : $$system( clang -v 2>&1 | head -n1 )")

--- a/src/cli/peakdetector/peakdetector.pro
+++ b/src/cli/peakdetector/peakdetector.pro
@@ -44,12 +44,12 @@ LIBS +=  -lmaven         \
 !macx: LIBS += -fopenmp
 
 macx {
-    DYLIBPATH = $$(LDFLAGS)
+    DYLIBPATH = $$system(source ~/.bash_profile ; echo $LDFLAGS)
     isEmpty(DYLIBPATH) {
         warning("LDFLAGS variable is not set. Linking operation might complain about missing OMP library")
         warning("Please follow the README to make sure you have correctly set the LDFLAGS variable")
     }
-    QMAKE_LFLAGS += $$(LDFLAGS)
+    QMAKE_LFLAGS += $$DYLIBPATH
     QMAKE_CXXFLAGS += -fopenmp
     LIBS += -lomp
     LIBS -= -lnetcdf -lcdfread

--- a/src/gui/mzroll/mzroll.pro
+++ b/src/gui/mzroll/mzroll.pro
@@ -53,12 +53,12 @@ win32 {
 mac {
     QMAKE_CXXFLAGS += -fopenmp
     INCLUDEPATH  += $$top_srcdir/3rdparty/google-breakpad/src/
-    DYLIBPATH = $$(LDFLAGS)
+    DYLIBPATH = $$system(source ~/.bash_profile ; echo $LDFLAGS)
     isEmpty(DYLIBPATH) {
         warning("LDFLAGS variable is not set. Linking operation might complain about missing OMP library")
         warning("Please follow the README to make sure you have correctly set the LDFLAGS variable")
     }
-    QMAKE_LFLAGS += $$(LDFLAGS)
+    QMAKE_LFLAGS += $$DYLIBPATH
     QMAKE_LFLAGS += -L$$top_builddir/libs/
     LIBS += /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
     LIBS += /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
@@ -128,8 +128,6 @@ unix {
 win32 {
     LIBS += -lboost_system-mt -lboost_filesystem-mt -lsqlite3
 }
-
-message($$LDFLAGS)
 
 INSTALLS += sources target
 

--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -24,12 +24,12 @@ INCLUDEPATH +=  $$top_srcdir/src/core/libmaven  $$top_srcdir/3rdparty/pugixml/sr
                 $$top_srcdir/3rdparty/Eigen $$top_srcdir/src/
 macx {
 
-    DYLIBPATH = $$(LDFLAGS)
+    DYLIBPATH = $$system(source ~/.bash_profile ; echo $LDFLAGS)
     isEmpty(DYLIBPATH) {
         warning("LDFLAGS variable is not set. Linking operation might complain about missing OMP library")
         warning("Please follow the README to make sure you have correctly set the LDFLAGS variable")
     }
-    QMAKE_LFLAGS += $$(LDFLAGS)
+    QMAKE_LFLAGS += $$DYLIBPATH
 }
 QMAKE_LFLAGS += -L$$top_builddir/libs/
 


### PR DESCRIPTION
The following changes were made to make El-MAVEN compile using QtCreator (tested only on MacOS for now).
 - Use native grep to extract clang version (stops QtCreator from complaining about compiler not found).
 - Obtain `LDFLAGS` environment variable from user's bash profile (to allow OpenMP library to be found for linking).

Note: these changes still assume that the user has already followed the instructions in our [README](https://github.com/ElucidataInc/ElMaven#mac), and exported the necessary variables as directed.