### PR TITLE
[Fix] Run the correct alignment algorithm

### DIFF
--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -183,7 +183,7 @@ void AlignmentDialog::showAdvanceParameters(bool checked)
 
 void AlignmentDialog::algoChanged()
 {
-    bool obiWarp = (alignAlgo->currentIndex() == 1);
+    bool obiWarp = (alignAlgo->currentIndex() == 0);
     showAdvanceParameters(showAdvanceParams->isChecked());
 
     auto samples = _mw->getSamples();

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -432,7 +432,7 @@ void BackgroundPeakUpdate::align() {
                 Aligner aligner;
                 int alignAlgo = mainwindow->alignmentDialog->alignAlgo->currentIndex();
 
-                if (alignAlgo == 0) {
+                if (alignAlgo == 1) {
                         mainwindow->getAnalytics()->hitEvent("Alignment", "PolyFit");
                         aligner.setMaxIterations(mainwindow->alignmentDialog->maxIterations->value());
                         aligner.setPolymialDegree(mainwindow->alignmentDialog->polynomialDegree->value());

--- a/src/gui/mzroll/forms/alignmentdialog.ui
+++ b/src/gui/mzroll/forms/alignmentdialog.ui
@@ -1084,9 +1084,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>530</y>
+     <y>510</y>
      <width>461</width>
-     <height>91</height>
+     <height>111</height>
     </rect>
    </property>
    <property name="title">
@@ -1096,9 +1096,9 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>20</y>
+      <y>30</y>
       <width>441</width>
-      <height>31</height>
+      <height>41</height>
      </rect>
     </property>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -1135,7 +1135,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>50</y>
+      <y>70</y>
       <width>441</width>
       <height>32</height>
      </rect>

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3430,7 +3430,7 @@ void MainWindow::Align()
 
     BackgroundPeakUpdate* workerThread;
 
-    if (alignmentDialog->alignAlgo->currentIndex() == 1) {
+    if (alignmentDialog->alignAlgo->currentIndex() == 0) {
         analytics->hitEvent("Alignment", "Obi-Warp");
         workerThread = newWorkerThread("alignWithObiWarp");
         workerThread->setMavenParameters(mavenParameters);

--- a/src/gui/mzroll/samplertwidget.cpp
+++ b/src/gui/mzroll/samplertwidget.cpp
@@ -119,10 +119,10 @@ void SampleRtWidget::plotIndividualGraph(mzSample* sample)
 
     int alignAlgo = _mw->alignmentDialog->alignAlgo->currentIndex();
 
-    if(alignAlgo == 0)
+    if(alignAlgo == 1)
         prepareGraphDataPolyFit(xAxis, yAxis, sample);
 
-    if(alignAlgo == 1)
+    if(alignAlgo == 0)
         prepareGraphDataObiWarp(xAxis, yAxis, sample);
 
     if(!xAxis.isEmpty() && !yAxis.isEmpty()){


### PR DESCRIPTION
There was an indexing issue due to which El-MAVEN was
not running the user-selected algorithm for alignment.

The tabs in alignment dialog were recently switched for the two algos, but the corresponding change was not done in the code.