### PR TITLE
Check if feature detection is checked instead of enabled

### DIFF
--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -320,20 +320,8 @@ void PeakDetectionDialog::show() {
 
     if (mainwindow == NULL) return;
 
-    auto samples = mainwindow->getVisibleSamples();
-    auto iter = find_if(begin(samples),
-                        end(samples),
-                        [](mzSample* s) {
-                           return ((s->ms1ScanCount() > 0)
-                                   && (s->ms2ScanCount() > 0));
-                        });
-    bool foundDda = iter != end(samples);
-    if (foundDda && featureOptions->isChecked()) {
-        mustHaveMs2->setEnabled(true);
-    } else {
-        mustHaveMs2->setEnabled(false);
-        mustHaveMs2->setChecked(false);
-    }
+    QString dbName = compoundDatabase->currentText();
+    toggleFragmentation(dbName);
 
 	mainwindow->getAnalytics()->hitScreenView("PeakDetectionDialog");
     // delete(peakupdater);
@@ -476,6 +464,21 @@ void PeakDetectionDialog::toggleFragmentation(QString selectedDbName)
     } else {
         matchFragmentationOptions->setChecked(false);
         matchFragmentationOptions->setEnabled(false);
+    }
+
+    auto samples = mainwindow->getVisibleSamples();
+    auto iter = find_if(begin(samples),
+                        end(samples),
+                        [](mzSample* s) {
+                           return ((s->ms1ScanCount() > 0)
+                                   && (s->ms2ScanCount() > 0));
+                        });
+    bool foundDda = iter != end(samples);
+    if (foundDda && featureOptions->isChecked()) {
+        mustHaveMs2->setEnabled(true);
+    } else {
+        mustHaveMs2->setEnabled(false);
+        mustHaveMs2->setChecked(false);
     }
 }
 

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -328,7 +328,7 @@ void PeakDetectionDialog::show() {
                                    && (s->ms2ScanCount() > 0));
                         });
     bool foundDda = iter != end(samples);
-    if (foundDda && featureOptions->isEnabled()) {
+    if (foundDda && featureOptions->isChecked()) {
         mustHaveMs2->setEnabled(true);
     } else {
         mustHaveMs2->setEnabled(false);


### PR DESCRIPTION
This is a hotfix for the feature introduced in #1094. The check for enabling "Exclude unfragmented groups", was not checking for the correct condition. This has been fixed.