### PR TITLE
Fix and optimize OBI-Warp alignment

### DIFF
--- a/3rdparty/obiwarp/dynprog.cpp
+++ b/3rdparty/obiwarp/dynprog.cpp
@@ -165,18 +165,24 @@ void DynProg::bijective_anchors(VecI &mCoords, VecI &nCoords, VecF &scores, VecI
     //puts("equivs:"); mCoords.print(); nCoords.print(); scores.print();
     int lengthEquiv = mCoords.dim();
 
-    int *nC_arr = new int[lengthEquiv];  // Max length...
-    int *mC_arr = new int[lengthEquiv];  // Max length...
-    float *sC_arr = new float[lengthEquiv];  // Max length...
+    std::vector<int> nC_arr;
+    nC_arr.resize(lengthEquiv);  // Max length...
+    std::vector<int> mC_arr;
+    mC_arr.resize(lengthEquiv);  // Max length...
+    std::vector<float> sC_arr;
+    sC_arr.resize(lengthEquiv);  // Max length...
 
     // monoMaps do NOT include the first and last equivalents!
 
     // find the length of the equivalents for MONOTONIC pairs (gaps collapse)
 
     // Eliminate the equivalents that have the same m or n as the two corners
-    int *mCoordsS_arr = new int[lengthEquiv-2];
-    int *nCoordsS_arr = new int[lengthEquiv-2];
-    float *scoresS_arr = new float[lengthEquiv-2];
+    std::vector<int> mCoordsS_arr;
+    mCoordsS_arr.resize(lengthEquiv-2);
+    std::vector<int> nCoordsS_arr;
+    nCoordsS_arr.resize(lengthEquiv-2);
+    std::vector<float> scoresS_arr;
+    scoresS_arr.resize(lengthEquiv-2);
     int last_index = lengthEquiv - 1;
     int startm = mCoords[0];
     int startn = nCoords[0];
@@ -377,17 +383,20 @@ void _traceback(MatI &tb, MatF &smat, int m, int n, MatI &tbpath, VecI &mCoord, 
         cnt++;
     }
 
-    int *tmpEquiv_m = new int[cnt];
-    int *tmpEquiv_n = new int[cnt];
-    float *tmpScores = new float[cnt];
+    std::vector<int> tmpEquiv_m;
+    tmpEquiv_m.reserve(cnt);
+    std::vector<int> tmpEquiv_n;
+    tmpEquiv_n.reserve(cnt);
+    std::vector<float> tmpScores;
+    tmpScores.reserve(cnt);
 
     // Reverse the arrays
     int rev = cnt - 1;
     // This could be made a little faster...
     for (i = 0; i < cnt; ++i) {
-        tmpEquiv_m[i] = m_eqr[rev];
-        tmpEquiv_n[i] = n_eqr[rev];
-        tmpScores[i] = score_pathr[rev];
+        tmpEquiv_m.push_back(m_eqr[rev]);
+        tmpEquiv_n.push_back(n_eqr[rev]);
+        tmpScores.push_back(score_pathr[rev]);
         rev--;
     }
     delete[] n_eqr;
@@ -1053,8 +1062,8 @@ float entropy(MatF &mat, int rowNum, int numBins, float minVal, float scaleFacto
 
 //Subtract a value
 void _subtract(MatF &mat, int rowNum, float val, MatF &minused) {
-    float *matptr = mat.pointer(rowNum);
-    float *minusedptr = minused.pointer(rowNum);
+    std::vector<float> matptr = mat.pointer(rowNum);
+    std::vector<float> minusedptr = minused.pointer(rowNum);
     for (int i = 0; i < mat.cols(); ++i) {
         minusedptr[i] = matptr[i] - val;
     }
@@ -1062,8 +1071,8 @@ void _subtract(MatF &mat, int rowNum, float val, MatF &minused) {
 
 //Sum of the products (i.e. the dot product at that row)
 float sumOfProducts(MatF &mat1, int rowNum1, MatF &mat2, int rowNum2) {
-    float *mat1ptr = mat1.pointer(rowNum1);
-    float *mat2ptr = mat2.pointer(rowNum2);
+    std::vector<float> mat1ptr = mat1.pointer(rowNum1);
+    std::vector<float> mat2ptr = mat2.pointer(rowNum2);
     float sum = 0;
     for (int i = 0; i < mat1.cols(); ++i) {
         sum += mat1ptr[i] * mat2ptr[i]; 
@@ -1075,7 +1084,7 @@ float sumOfProducts(MatF &mat1, int rowNum1, MatF &mat2, int rowNum2) {
 // could increase the speed here by getting the oneD version and doing pointer
 // math(?)
 float sumXSquared(MatF &mat, int rowNum) {
-    float *matptr = mat.pointer(rowNum);
+    std::vector<float> matptr = mat.pointer(rowNum);
     float sum = 0;
     for (int i = 0; i < mat.cols(); ++i) {
         sum += matptr[i] * matptr[i]; 
@@ -1098,20 +1107,20 @@ void DynProg::less_before(VecF &arr) {
 // linear function given in terms of mx + b where m is slope and b is y
 // intercept
 void DynProg::linear(float m, float b, int len,  VecF &arr) {
-    float *tmparr = new float[len];
-    int ind = 0;
-    while (ind < len) { 
-        tmparr[ind] = m*ind + b;
-        ++ind;
+    std::vector<float> tmparr;
+    tmparr.reserve(len);
+    for (int i = 1; i < len; ++i) {
+        tmparr.push_back(m*i + b);
     }
     arr.take(len, tmparr);
 }
 
 void DynProg::linear_less_before(float m, float b, int veclen, VecF &lessbefore) {
-    float *tmparr = new float[veclen];
+    std::vector<float> tmparr;
+    tmparr.reserve(veclen);
     tmparr[0] = b;
     for (int i = 1; i < veclen; ++i) {
-        tmparr[i] = m;
+        tmparr.push_back(m*i + b);
     }
     lessbefore.take(veclen, tmparr);
 }

--- a/3rdparty/obiwarp/dynprog.cpp
+++ b/3rdparty/obiwarp/dynprog.cpp
@@ -799,13 +799,16 @@ void DynProg::score_pearsons_r(MatF &mCoords, MatF &nCoords, MatF &scores) {
     // CALCULATE ALL PAIR calculations
     for (int n = 0; n < s_nlen; ++n) {
         for (int m = 0; m < s_mlen; ++m) {
-            //        sum(X * Y) -    
-            double top = sumOfProducts(mCoords, m, nCoords, n) -
-                ((sum_x[n] * sum_y[m])/cols);
-            //  (sum(x)      * sum(y))/num_elements
             double bot = sqrt(bot_x[n] * bot_y[m]);
-            if (bot == 0) { tmp(m,n) = 0; }  // no undefined 
-            else { tmp(m,n) = (float)(top/bot); }
+            if (bot == 0) {
+                // no undefined
+                tmp(m, n) = 0;
+            } else {
+                // sum(X * Y) - (sum(x) * sum(y))/num_elements
+                double top = sumOfProducts(mCoords, m, nCoords, n)
+                             - ((sum_x[n] * sum_y[m]) / cols);
+                tmp(m, n) = static_cast<float>(top / bot);
+            }
         }
     }
     delete[] bot_x; delete[] bot_y; delete[] sum_x; delete[] sum_y;

--- a/3rdparty/obiwarp/dynprog.cpp
+++ b/3rdparty/obiwarp/dynprog.cpp
@@ -1062,20 +1062,20 @@ float entropy(MatF &mat, int rowNum, int numBins, float minVal, float scaleFacto
 
 //Subtract a value
 void _subtract(MatF &mat, int rowNum, float val, MatF &minused) {
-    std::vector<float> matptr = mat.pointer(rowNum);
-    std::vector<float> minusedptr = minused.pointer(rowNum);
+    float* matPtr = mat.rowData(rowNum);
+    float* minusedptr = minused.rowData(rowNum);
     for (int i = 0; i < mat.cols(); ++i) {
-        minusedptr[i] = matptr[i] - val;
+        minusedptr[i] = matPtr[i] - val;
     }
 }
 
 //Sum of the products (i.e. the dot product at that row)
 float sumOfProducts(MatF &mat1, int rowNum1, MatF &mat2, int rowNum2) {
-    std::vector<float> mat1ptr = mat1.pointer(rowNum1);
-    std::vector<float> mat2ptr = mat2.pointer(rowNum2);
+    float* mat1ptr = mat1.rowData(rowNum1);
+    float* mat2ptr = mat2.rowData(rowNum2);
     float sum = 0;
     for (int i = 0; i < mat1.cols(); ++i) {
-        sum += mat1ptr[i] * mat2ptr[i]; 
+        sum += mat1ptr[i] * mat2ptr[i];
     }
     return sum;
 }
@@ -1084,10 +1084,10 @@ float sumOfProducts(MatF &mat1, int rowNum1, MatF &mat2, int rowNum2) {
 // could increase the speed here by getting the oneD version and doing pointer
 // math(?)
 float sumXSquared(MatF &mat, int rowNum) {
-    std::vector<float> matptr = mat.pointer(rowNum);
+    float* ptr = mat.rowData(rowNum);
     float sum = 0;
     for (int i = 0; i < mat.cols(); ++i) {
-        sum += matptr[i] * matptr[i]; 
+        sum += ptr[i] * ptr[i];
     }
     return sum;
 }

--- a/3rdparty/obiwarp/mat.cpp
+++ b/3rdparty/obiwarp/mat.cpp
@@ -613,7 +613,7 @@ void MatD::mask_as_vec(double return_val, MatI &mask, VecD &out) {
 
 double MatD::sum(int m) {
     auto iters = rowIters(m);
-    double sum = std::accumulate(iters.first, iters.second, 0.0f);
+    double sum = std::accumulate(iters.first, iters.second, 0.0);
     return sum;
 }
 
@@ -914,7 +914,7 @@ void MatI::mask_as_vec(int return_val, MatI &mask, VecI &out) {
 
 int MatI::sum(int m) {
     auto iters = rowIters(m);
-    int sum = std::accumulate(iters.first, iters.second, 0.0f);
+    int sum = std::accumulate(iters.first, iters.second, 0);
     return sum;
 }
 

--- a/3rdparty/obiwarp/mat.cpp
+++ b/3rdparty/obiwarp/mat.cpp
@@ -41,7 +41,7 @@ MatF::MatF(int m, int n, const float &val) : _m(m), _n(n), _dat(m*n, val) {
 #endif
 }
 
-MatF::MatF(int m, int n, std::vector<float> arr) : _m(m), _n(n), _dat(m*n,arr) {
+MatF::MatF(int m, int n, std::vector<float>& arr) : _m(m), _n(n), _dat(m*n,arr) {
 #ifdef JTP_DEBUG
     printf("CONSTRUCTOR MatF(m,n,*arr,shallow) shallow=%d!\n", this->shallow());
 #endif
@@ -342,7 +342,7 @@ MatD::MatD(int m, int n, const double &val) : _m(m), _n(n), _dat(m*n, val) {
 #endif
 }
 
-MatD::MatD(int m, int n, std::vector<double> arr) : _m(m), _n(n), _dat(m*n,arr) {
+MatD::MatD(int m, int n, std::vector<double>& arr) : _m(m), _n(n), _dat(m*n,arr) {
 #ifdef JTP_DEBUG
     printf("CONSTRUCTOR MatD(m,n,*arr,shallow) shallow=%d!\n", this->shallow());
 #endif
@@ -643,7 +643,7 @@ MatI::MatI(int m, int n, const int &val) : _m(m), _n(n), _dat(m*n, val) {
 #endif
 }
 
-MatI::MatI(int m, int n, std::vector<int> arr) : _m(m), _n(n), _dat(m*n,arr) {
+MatI::MatI(int m, int n, std::vector<int>& arr) : _m(m), _n(n), _dat(m*n,arr) {
 #ifdef JTP_DEBUG
     printf("CONSTRUCTOR MatI(m,n,*arr,shallow) shallow=%d!\n", this->shallow());
 #endif

--- a/3rdparty/obiwarp/mat.cpp
+++ b/3rdparty/obiwarp/mat.cpp
@@ -1,16 +1,3 @@
-#include <utility>
-
-#include <utility>
-
-#include <utility>
-
-#include <utility>
-
-#include <utility>
-
-#include <utility>
-
-
 #include <stdio.h>
 #include <iostream>
 #include <fstream>

--- a/3rdparty/obiwarp/mat.cpp
+++ b/3rdparty/obiwarp/mat.cpp
@@ -240,7 +240,7 @@ else {
     MatF *C = new MatF(_n);
     MatF tmp = *C;
     tmp._to_pass_up = C;
-        printf("TMPENEW %d\n", tmp.shallow());
+    printf("TMPENEW %d\n", tmp.shallow());
     for (int i = 0; i < _n; ++i) {
         tmp[i] = _dat[i] + A[i];
     }
@@ -316,7 +316,6 @@ float MatF::sum(int m) {
     return sum;
 }
 
-
 /****************************************************************
  * MatD
  ***************************************************************/
@@ -355,9 +354,24 @@ MatD::MatD(const MatD &A) : _m(A._m), _n(A._n), _dat(A._dat) {
 #endif
 }
 
-std::vector<double> MatD::pointer(int m)
+std::vector<double> MatD::row(int m)
 {
     return _dat.slice((m * _n), (m * _n) + _n);
+}
+
+std::pair<std::vector<double>::iterator, std::vector<double>::iterator> MatD::rowIters(int m)
+{
+    return _dat.slice2((m * _n), (m * _n) + _n);
+}
+
+double* MatD::rowData(int m)
+{
+    return (_dat.data() + (m * _n));
+}
+
+std::vector<double>::iterator MatD::rowIter(int m)
+{
+    return _dat.slice2((m * _n), (m * _n) + _n).first;
 }
 
 void MatD::to_vec(VecD &outvec) {
@@ -400,7 +414,7 @@ void MatD::row_vecs(int &cnt, VecD *vecs) {
     cnt = rows();
     int _cols = cols();
     for (int i = 0; i < cnt; ++i) {
-        std::vector<double> ptr = this->pointer(i);
+        std::vector<double> ptr = this->row(i);
         vecs[i].set(_cols, ptr);  // shallow allocation
     }
 }
@@ -527,7 +541,7 @@ else {
     MatD *C = new MatD(_n);
     MatD tmp = *C;
     tmp._to_pass_up = C;
-        printf("TMPENEW %d\n", tmp.shallow());
+    printf("TMPENEW %d\n", tmp.shallow());
     for (int i = 0; i < _n; ++i) {
         tmp[i] = _dat[i] + A[i];
     }
@@ -598,8 +612,8 @@ void MatD::mask_as_vec(double return_val, MatI &mask, VecD &out) {
 
 
 double MatD::sum(int m) {
-    std::vector<double> ptr = pointer(m);
-    double sum = std::accumulate(ptr.begin(), ptr.end(), 0.0);
+    auto iters = rowIters(m);
+    double sum = std::accumulate(iters.first, iters.second, 0.0f);
     return sum;
 }
 
@@ -641,9 +655,24 @@ MatI::MatI(const MatI &A) : _m(A._m), _n(A._n), _dat(A._dat) {
 #endif
 }
 
-std::vector<int> MatI::pointer(int m)
+std::vector<int> MatI::row(int m)
 {
     return _dat.slice((m * _n), (m * _n) + _n);
+}
+
+std::pair<std::vector<int>::iterator, std::vector<int>::iterator> MatI::rowIters(int m)
+{
+    return _dat.slice2((m * _n), (m * _n) + _n);
+}
+
+int* MatI::rowData(int m)
+{
+    return (_dat.data() + (m * _n));
+}
+
+std::vector<int>::iterator MatI::rowIter(int m)
+{
+    return _dat.slice2((m * _n), (m * _n) + _n).first;
 }
 
 void MatI::to_vec(VecI &outvec) {
@@ -686,7 +715,7 @@ void MatI::row_vecs(int &cnt, VecI *vecs) {
     cnt = rows();
     int _cols = cols();
     for (int i = 0; i < cnt; ++i) {
-        std::vector<int> ptr = this->pointer(i);
+        std::vector<int> ptr = this->row(i);
         vecs[i].set(_cols, ptr);  // shallow allocation
     }
 }
@@ -813,7 +842,7 @@ else {
     MatI *C = new MatI(_n);
     MatI tmp = *C;
     tmp._to_pass_up = C;
-        printf("TMPENEW %d\n", tmp.shallow());
+    printf("TMPENEW %d\n", tmp.shallow());
     for (int i = 0; i < _n; ++i) {
         tmp[i] = _dat[i] + A[i];
     }
@@ -884,8 +913,8 @@ void MatI::mask_as_vec(int return_val, MatI &mask, VecI &out) {
 
 
 int MatI::sum(int m) {
-    std::vector<int> ptr = pointer(m);
-    int sum = std::accumulate(ptr.begin(), ptr.end(), 0);
+    auto iters = rowIters(m);
+    int sum = std::accumulate(iters.first, iters.second, 0.0f);
     return sum;
 }
 

--- a/3rdparty/obiwarp/mat.cpp
+++ b/3rdparty/obiwarp/mat.cpp
@@ -53,9 +53,24 @@ MatF::MatF(const MatF &A) : _m(A._m), _n(A._n), _dat(A._dat) {
 #endif
 }
 
-std::vector<float> MatF::pointer(int m)
+std::vector<float> MatF::row(int m)
 {
     return _dat.slice((m * _n), (m * _n) + _n);
+}
+
+std::pair<std::vector<float>::iterator, std::vector<float>::iterator> MatF::rowIters(int m)
+{
+    return _dat.slice2((m * _n), (m * _n) + _n);
+}
+
+float* MatF::rowData(int m)
+{
+    return (_dat.data() + (m * _n));
+}
+
+std::vector<float>::iterator MatF::rowIter(int m)
+{
+    return _dat.slice2((m * _n), (m * _n) + _n).first;
 }
 
 void MatF::to_vec(VecF &outvec) {
@@ -98,7 +113,7 @@ void MatF::row_vecs(int &cnt, VecF *vecs) {
     cnt = rows();
     int _cols = cols();
     for (int i = 0; i < cnt; ++i) {
-        std::vector<float> ptr = this->pointer(i);
+        std::vector<float> ptr = this->row(i);
         vecs[i].set(_cols, ptr);  // shallow allocation
     }
 }
@@ -296,8 +311,8 @@ void MatF::mask_as_vec(float return_val, MatI &mask, VecF &out) {
 
 
 float MatF::sum(int m) {
-    std::vector<float> ptr = pointer(m);
-    float sum = std::accumulate(ptr.begin(), ptr.end(), 0.0f);
+    auto iters = rowIters(m);
+    float sum = std::accumulate(iters.first, iters.second, 0.0f);
     return sum;
 }
 

--- a/3rdparty/obiwarp/mat.cpp
+++ b/3rdparty/obiwarp/mat.cpp
@@ -1,3 +1,15 @@
+#include <utility>
+
+#include <utility>
+
+#include <utility>
+
+#include <utility>
+
+#include <utility>
+
+#include <utility>
+
 
 #include <stdio.h>
 #include <iostream>
@@ -78,7 +90,7 @@ void MatF::to_vec(VecF &outvec) {
 }
 
 void MatF::set(int m, int n, std::vector<float> arr) {
-    _dat.set(m*n,arr);
+    _dat.set(m*n,std::move(arr));
     _m = m;
     _n = n;
 }
@@ -94,7 +106,7 @@ void MatF::set(MatF &A) {
 
 
 void MatF::take(int m, int n, std::vector<float> arr) {
-    _dat.take(m*n,arr);
+    _dat.take(m*n,std::move(arr));
     _m = m;
     _n = n;
 }
@@ -379,7 +391,7 @@ void MatD::to_vec(VecD &outvec) {
 }
 
 void MatD::set(int m, int n, std::vector<double> arr) {
-    _dat.set(m*n,arr);
+    _dat.set(m*n,std::move(arr));
     _m = m;
     _n = n;
 }
@@ -395,7 +407,7 @@ void MatD::set(MatD &A) {
 
 
 void MatD::take(int m, int n, std::vector<double> arr) {
-    _dat.take(m*n,arr);
+    _dat.take(m*n,std::move(arr));
     _m = m;
     _n = n;
 }
@@ -680,7 +692,7 @@ void MatI::to_vec(VecI &outvec) {
 }
 
 void MatI::set(int m, int n, std::vector<int> arr) {
-    _dat.set(m*n,arr);
+    _dat.set(m*n,std::move(arr));
     _m = m;
     _n = n;
 }
@@ -696,7 +708,7 @@ void MatI::set(MatI &A) {
 
 
 void MatI::take(int m, int n, std::vector<int> arr) {
-    _dat.take(m*n,arr);
+    _dat.take(m*n,std::move(arr));
     _m = m;
     _n = n;
 }

--- a/3rdparty/obiwarp/mat.cpp
+++ b/3rdparty/obiwarp/mat.cpp
@@ -80,11 +80,6 @@ float* MatF::rowData(int m)
     return (_dat.data() + (m * _n));
 }
 
-std::vector<float>::iterator MatF::rowIter(int m)
-{
-    return _dat.slice2((m * _n), (m * _n) + _n).first;
-}
-
 void MatF::to_vec(VecF &outvec) {
     _dat.copy(outvec);
 }

--- a/3rdparty/obiwarp/mat.h
+++ b/3rdparty/obiwarp/mat.h
@@ -22,458 +22,396 @@ class MatD;
 class MatF {
 
     public:
-        // length
-        int _m;
-        int _n;
-        VecF _dat;
-        // Constructors:
-        MatF();
-        MatF(int m, int n);
-        MatF(int m, int n, const float &val);
-       
+    // length
+    int _m;
+    int _n;
+    VecF _dat;
+    // Constructors:
+    MatF();
+    MatF(int m, int n);
+    MatF(int m, int n, const float &val);
 
-        // (copied from vec.h)
-        // if (shallow == 1 (true)) then no memory is deleted upon destruction
-        // if (shallow == 0 (false)) then delete[] is called
-        // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-        MatF(int m, int n, float *arr, bool shallow=0);
 
-        // (copied from vec.h)
-        // if (shallow == 0 (false)) a DEEP copy is made of the data
-        // if (shallow == 1 (true)) a copy of the pointer is made
-        // if (shallow) then no memory is released upon destruction
-        // shallow is used for a quick copy with which to work 
-        MatF(const MatF &A, bool shallow=0);
+    // (copied from vec.h)
+    // if (shallow == 1 (true)) then no memory is deleted upon destruction
+    // if (shallow == 0 (false)) then delete[] is called
+    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
+    MatF(int m, int n, std::vector<float> arr);
 
-        operator float*() { return (float*)_dat; }
-        operator const float*() { return (float*)_dat; }
-        float* pointer() { return (float*)_dat; }
-        float* pointer(int m) { return &_dat[m*_n]; }
-        // creates vec objects 
+    // (copied from vec.h)
+    // if (shallow == 0 (false)) a DEEP copy is made of the data
+    // if (shallow == 1 (true)) a copy of the pointer is made
+    // if (shallow) then no memory is released upon destruction
+    // shallow is used for a quick copy with which to work
+        MatF(const MatF &A);
+
+    std::vector<float> pointer(int m);
+    // creates vec objects
         // caller must have allocated the array for the vec objects
-        // the data is a shallow copy!
-        // transpose and call row_vecs for col_vecs!
-        void row_vecs(int &cnt, VecF *vecs);
+    // the data is a shallow copy!
+    // transpose and call row_vecs for col_vecs!
+    void row_vecs(int &cnt, VecF *vecs);
 
-        MatF & operator=(const float &val);
-        // DEEP
-        MatF & operator=(MatF &A);
-        ~MatF();
-        // Deep copy unless shallow == true
-        void copy(MatF &receiver, bool shallow=0) const;
+    MatF & operator=(const float &val);
+    // DEEP
+    MatF & operator=(MatF &A);
+    ~MatF();
+    // Deep copy unless shallow == true
+    void copy(MatF &receiver) const;
 
-        void set_from_ascii(std::ifstream &stream, int m, int n, MatF &out);
-        void set_from_ascii(std::ifstream &stream, MatF &out);
-        void set_from_ascii(const char *file, bool without_axes=0);
-        void set_from_binary(const char *file);
-        void file_rows_cols(std::ifstream &stream, int &rows, int &cols);
-        // tnt_array2d_utils.h has a good example (use ifstream)
+    // shallow copy and no ownership of memory
+    void set(int m, int n, std::vector<float> arr);
+    // shallow copy and no ownership of memory
+    void set(MatF &A);
 
-        // shallow copy and no ownership of memory
-        void set(int m, int n, float *arr);
-        // shallow copy and no ownership of memory
-        void set(MatF &A);
+    bool all_equal() {
+        return _dat.all_equal();
+    }
 
-        bool all_equal() {
-            return _dat.all_equal();
-        }
+    // Deletes the object's memory (if not shallow) and takes ownership
+    // of the array memory (we will call delete[])
+    void take(int m, int n, std::vector<float> arr);
+    // Deletes previous memory (if not shallow) and takes ownership
+    // of the other's memory.
+    void take(MatF &A);
 
-        // Deletes the object's memory (if not shallow) and takes ownership
-        // of the array memory (we will call delete[])
-        void take(int m, int n, float *arr);
-        // Deletes previous memory (if not shallow) and takes ownership
-        // of the other's memory.
-        void take(MatF &A);
+    // flattens the matrix and returns a vector
+    void to_vec(VecF &outvec);
 
-        // flattens the matrix and returns a vector
-        void to_vec(VecF &outvec, bool shallow=0);
+    bool operator==(const MatF &A);
 
-        bool operator==(const MatF &A);
-        
-        bool shallow() { return _dat.shallow(); }
-        int dim1() const { return _m; }
-        int dim2() const { return _n; }
-        int mlen() const { return _m; }
-        int nlen() const { return _n; }
-        int rows() const { return _m; }
-        int cols() const { return _n; }
+    bool shallow() { return _dat.shallow(); }
+    int dim1() const { return _m; }
+    int dim2() const { return _n; }
+    int mlen() const { return _m; }
+    int nlen() const { return _n; }
+    int rows() const { return _m; }
+    int cols() const { return _n; }
 
-        float& operator()(int m, int n) {
+    float& operator()(int m, int n) {
 #ifdef JTP_BOUNDS_CHECK
-            if (n < 0) { puts("n < 0"); exit(1); }
-            if (n >= _n) { puts("n >= _n"); exit(1); }
-            if (m < 0) { puts("m < 0"); exit(1); }
-            if (m >= _m) { puts("m >= _m"); exit(1); }
+        if (n < 0) { puts("n < 0"); exit(1); }
+        if (n >= _n) { puts("n >= _n"); exit(1); }
+        if (m < 0) { puts("m < 0"); exit(1); }
+        if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
-            return _dat[m*_n + n]; 
+        return _dat[m*_n + n];
         }
-        const float& operator()(int m, int n) const {
+    const float& operator()(int m, int n) const {
 #ifdef JTP_BOUNDS_CHECK
-            if (n < 0) { puts("n < 0"); exit(1); }
-            if (n >= _n) { puts("n >= _n"); exit(1); }
-            if (m < 0) { puts("m < 0"); exit(1); }
-            if (m >= _m) { puts("m >= _m"); exit(1); }
+        if (n < 0) { puts("n < 0"); exit(1); }
+        if (n >= _n) { puts("n >= _n"); exit(1); }
+        if (m < 0) { puts("m < 0"); exit(1); }
+        if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
-            return _dat[m*_n + n]; 
+        return _dat[m*_n + n];
         }
 
-        // NOTE: All assignment operators act on the caller!
-        void operator+=(const MatF &A);
-        void operator-=(const MatF &A);
-        void operator*=(const MatF &A);
-        void operator/=(const MatF &A);
-        void operator+=(const float val) { _dat += val; }
-        void operator-=(const float val) { _dat -= val; }
-        void operator*=(const float val) { _dat *= val; }
-        void operator/=(const float val) { _dat /= val; }
+    // NOTE: All assignment operators act on the caller!
+    void operator+=(const MatF &A);
+    void operator-=(const MatF &A);
+    void operator*=(const MatF &A);
+    void operator/=(const MatF &A);
+    void operator+=(const float val) { _dat += val; }
+    void operator-=(const float val) { _dat -= val; }
+    void operator*=(const float val) { _dat *= val; }
+    void operator/=(const float val) { _dat /= val; }
 
-    
-        void add(const MatF &toadd, MatF &out);
-        void sub(const MatF &tosub, MatF &out);
-        void mul(const MatF &tomul, MatF &out);
-        void div(const MatF &todiv, MatF &out);
 
-        // returns the transpose in out
-        void transpose(MatF &out);
+    void add(const MatF &toadd, MatF &out);
+    void sub(const MatF &tosub, MatF &out);
+    void mul(const MatF &tomul, MatF &out);
+    void div(const MatF &todiv, MatF &out);
 
-        void std_normal() { _dat.std_normal(); }
-        void logarithm(double base) { _dat.logarithm(base); }
-        void expand(MatF &result, float match, int expand_x_lt, int expand_x_rt, int expand_y_up, int expand_y_dn, int expand_diag_lt_up, int expand_diag_rt_up, int expand_diag_lt_dn, int expand_diag_rt_dn );
+    // returns the transpose in out
+    void transpose(MatF &out);
 
-        void min_max(float &_min, float &_max) { _dat.min_max(_min,_max); }
-        double avg() { return _dat.avg(); }
-        //void operator++();
-        //void operator--();
-        
-        float sum() { return _dat.sum(); } // return the sum of the entire matrix
-        float sum(int m);  // return the sum of a given row
-        // Returns in a vector all the values matching mask value
-        void mask_as_vec(float return_val, MatI &mask, VecF &out);
+    void std_normal() { _dat.std_normal(); }
+    void logarithm(double base) { _dat.logarithm(base); }
+    void expand(MatF &result, float match, int expand_x_lt, int expand_x_rt, int expand_y_up, int expand_y_dn, int expand_diag_lt_up, int expand_diag_rt_up, int expand_diag_lt_dn, int expand_diag_rt_dn );
 
-        // prints the bare matrix as ascii
-        void print(bool without_axes=0);
-        void print(const char *file, bool without_axes=0);
-        void print(std::ostream &fout, bool without_axes=0);
+    void min_max(float &_min, float &_max) { _dat.min_max(_min,_max); }
+    double avg() { return _dat.avg(); }
+    //void operator++();
+    //void operator--();
 
-        // writes the matrix as binary (includes # rows first and # cols as
-        // ints)
-        void write(const char *file=NULL);
+    float sum() { return _dat.sum(); } // return the sum of the entire matrix
+    float sum(int m);  // return the sum of a given row
+    // Returns in a vector all the values matching mask value
+    void mask_as_vec(float return_val, MatI &mask, VecF &out);
 
-        
-        // @TODO need to write these guys:
-        // prints the matrix in binary format:
-        // (int) num cols (int) num rows (float) data
-//        void write(const char *file);
-//        void write(std::ofstream &fout);
+    // @TODO need to write these guys:
+    // prints the matrix in binary format:
+    // (int) num cols (int) num rows (float) data
+    //        void write(const char *file);
+    //        void write(std::ofstream &fout);
 
     private:
-        void _copy(float *p1, const float *p2, int len) const;
+    void _copy(float *p1, const float *p2, int len) const;
 
 }; // End class MatF
-
 
 class MatD {
 
     public:
-        // length
-        int _m;
-        int _n;
-        VecD _dat;
-        // Constructors:
-        MatD();
-        MatD(int m, int n);
-        MatD(int m, int n, const double &val);
-       
+    // length
+    int _m;
+    int _n;
+    VecD _dat;
+    // Constructors:
+    MatD();
+    MatD(int m, int n);
+    MatD(int m, int n, const double &val);
 
-        // (copied from vec.h)
-        // if (shallow == 1 (true)) then no memory is deleted upon destruction
-        // if (shallow == 0 (false)) then delete[] is called
-        // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-        MatD(int m, int n, double *arr, bool shallow=0);
 
-        // (copied from vec.h)
-        // if (shallow == 0 (false)) a DEEP copy is made of the data
-        // if (shallow == 1 (true)) a copy of the pointer is made
-        // if (shallow) then no memory is released upon destruction
-        // shallow is used for a quick copy with which to work 
-        MatD(const MatD &A, bool shallow=0);
+    // (copied from vec.h)
+    // if (shallow == 1 (true)) then no memory is deleted upon destruction
+    // if (shallow == 0 (false)) then delete[] is called
+    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
+    MatD(int m, int n, std::vector<double> arr);
 
-        operator double*() { return (double*)_dat; }
-        operator const double*() { return (double*)_dat; }
-        double* pointer() { return (double*)_dat; }
-        double* pointer(int m) { return &_dat[m*_n]; }
-        // creates vec objects 
+    // (copied from vec.h)
+    // if (shallow == 0 (false)) a DEEP copy is made of the data
+    // if (shallow == 1 (true)) a copy of the pointer is made
+    // if (shallow) then no memory is released upon destruction
+    // shallow is used for a quick copy with which to work
+        MatD(const MatD &A);
+
+    std::vector<double> pointer(int m);
+    // creates vec objects
         // caller must have allocated the array for the vec objects
-        // the data is a shallow copy!
-        // transpose and call row_vecs for col_vecs!
-        void row_vecs(int &cnt, VecD *vecs);
+    // the data is a shallow copy!
+    // transpose and call row_vecs for col_vecs!
+    void row_vecs(int &cnt, VecD *vecs);
 
-        MatD & operator=(const double &val);
-        // DEEP
-        MatD & operator=(MatD &A);
-        ~MatD();
-        // Deep copy unless shallow == true
-        void copy(MatD &receiver, bool shallow=0) const;
+    MatD & operator=(const double &val);
+    // DEEP
+    MatD & operator=(MatD &A);
+    ~MatD();
+    // Deep copy unless shallow == true
+    void copy(MatD &receiver) const;
 
-        void set_from_ascii(std::ifstream &stream, int m, int n, MatD &out);
-        void set_from_ascii(std::ifstream &stream, MatD &out);
-        void set_from_ascii(const char *file, bool without_axes=0);
-        void set_from_binary(const char *file);
-        void file_rows_cols(std::ifstream &stream, int &rows, int &cols);
-        // tnt_array2d_utils.h has a good example (use ifstream)
+    // shallow copy and no ownership of memory
+    void set(int m, int n, std::vector<double> arr);
+    // shallow copy and no ownership of memory
+    void set(MatD &A);
 
-        // shallow copy and no ownership of memory
-        void set(int m, int n, double *arr);
-        // shallow copy and no ownership of memory
-        void set(MatD &A);
+    bool all_equal() {
+        return _dat.all_equal();
+    }
 
-        bool all_equal() {
-            return _dat.all_equal();
-        }
+    // Deletes the object's memory (if not shallow) and takes ownership
+    // of the array memory (we will call delete[])
+    void take(int m, int n, std::vector<double> arr);
+    // Deletes previous memory (if not shallow) and takes ownership
+    // of the other's memory.
+    void take(MatD &A);
 
-        // Deletes the object's memory (if not shallow) and takes ownership
-        // of the array memory (we will call delete[])
-        void take(int m, int n, double *arr);
-        // Deletes previous memory (if not shallow) and takes ownership
-        // of the other's memory.
-        void take(MatD &A);
+    // flattens the matrix and returns a vector
+    void to_vec(VecD &outvec);
 
-        // flattens the matrix and returns a vector
-        void to_vec(VecD &outvec, bool shallow=0);
+    bool operator==(const MatD &A);
 
-        bool operator==(const MatD &A);
-        
-        bool shallow() { return _dat.shallow(); }
-        int dim1() const { return _m; }
-        int dim2() const { return _n; }
-        int mlen() const { return _m; }
-        int nlen() const { return _n; }
-        int rows() const { return _m; }
-        int cols() const { return _n; }
+    bool shallow() { return _dat.shallow(); }
+    int dim1() const { return _m; }
+    int dim2() const { return _n; }
+    int mlen() const { return _m; }
+    int nlen() const { return _n; }
+    int rows() const { return _m; }
+    int cols() const { return _n; }
 
-        double& operator()(int m, int n) {
+    double& operator()(int m, int n) {
 #ifdef JTP_BOUNDS_CHECK
-            if (n < 0) { puts("n < 0"); exit(1); }
-            if (n >= _n) { puts("n >= _n"); exit(1); }
-            if (m < 0) { puts("m < 0"); exit(1); }
-            if (m >= _m) { puts("m >= _m"); exit(1); }
+        if (n < 0) { puts("n < 0"); exit(1); }
+        if (n >= _n) { puts("n >= _n"); exit(1); }
+        if (m < 0) { puts("m < 0"); exit(1); }
+        if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
-            return _dat[m*_n + n]; 
+        return _dat[m*_n + n];
         }
-        const double& operator()(int m, int n) const {
+    const double& operator()(int m, int n) const {
 #ifdef JTP_BOUNDS_CHECK
-            if (n < 0) { puts("n < 0"); exit(1); }
-            if (n >= _n) { puts("n >= _n"); exit(1); }
-            if (m < 0) { puts("m < 0"); exit(1); }
-            if (m >= _m) { puts("m >= _m"); exit(1); }
+        if (n < 0) { puts("n < 0"); exit(1); }
+        if (n >= _n) { puts("n >= _n"); exit(1); }
+        if (m < 0) { puts("m < 0"); exit(1); }
+        if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
-            return _dat[m*_n + n]; 
+        return _dat[m*_n + n];
         }
 
-        // NOTE: All assignment operators act on the caller!
-        void operator+=(const MatD &A);
-        void operator-=(const MatD &A);
-        void operator*=(const MatD &A);
-        void operator/=(const MatD &A);
-        void operator+=(const double val) { _dat += val; }
-        void operator-=(const double val) { _dat -= val; }
-        void operator*=(const double val) { _dat *= val; }
-        void operator/=(const double val) { _dat /= val; }
+    // NOTE: All assignment operators act on the caller!
+    void operator+=(const MatD &A);
+    void operator-=(const MatD &A);
+    void operator*=(const MatD &A);
+    void operator/=(const MatD &A);
+    void operator+=(const double val) { _dat += val; }
+    void operator-=(const double val) { _dat -= val; }
+    void operator*=(const double val) { _dat *= val; }
+    void operator/=(const double val) { _dat /= val; }
 
-    
-        void add(const MatD &toadd, MatD &out);
-        void sub(const MatD &tosub, MatD &out);
-        void mul(const MatD &tomul, MatD &out);
-        void div(const MatD &todiv, MatD &out);
 
-        // returns the transpose in out
-        void transpose(MatD &out);
+    void add(const MatD &toadd, MatD &out);
+    void sub(const MatD &tosub, MatD &out);
+    void mul(const MatD &tomul, MatD &out);
+    void div(const MatD &todiv, MatD &out);
 
-        void std_normal() { _dat.std_normal(); }
-        void logarithm(double base) { _dat.logarithm(base); }
-        void expand(MatD &result, double match, int expand_x_lt, int expand_x_rt, int expand_y_up, int expand_y_dn, int expand_diag_lt_up, int expand_diag_rt_up, int expand_diag_lt_dn, int expand_diag_rt_dn );
+    // returns the transpose in out
+    void transpose(MatD &out);
 
-        void min_max(double &_min, double &_max) { _dat.min_max(_min,_max); }
-        double avg() { return _dat.avg(); }
-        //void operator++();
-        //void operator--();
-        
-        double sum() { return _dat.sum(); } // return the sum of the entire matrix
-        double sum(int m);  // return the sum of a given row
-        // Returns in a vector all the values matching mask value
-        void mask_as_vec(double return_val, MatI &mask, VecD &out);
+    void std_normal() { _dat.std_normal(); }
+    void logarithm(double base) { _dat.logarithm(base); }
+    void expand(MatD &result, double match, int expand_x_lt, int expand_x_rt, int expand_y_up, int expand_y_dn, int expand_diag_lt_up, int expand_diag_rt_up, int expand_diag_lt_dn, int expand_diag_rt_dn );
 
-        // prints the bare matrix as ascii
-        void print(bool without_axes=0);
-        void print(const char *file, bool without_axes=0);
-        void print(std::ostream &fout, bool without_axes=0);
+    void min_max(double &_min, double &_max) { _dat.min_max(_min,_max); }
+    double avg() { return _dat.avg(); }
+    //void operator++();
+    //void operator--();
 
-        // writes the matrix as binary (includes # rows first and # cols as
-        // ints)
-        void write(const char *file=NULL);
+    double sum() { return _dat.sum(); } // return the sum of the entire matrix
+    double sum(int m);  // return the sum of a given row
+    // Returns in a vector all the values matching mask value
+    void mask_as_vec(double return_val, MatI &mask, VecD &out);
 
-        
-        // @TODO need to write these guys:
-        // prints the matrix in binary format:
-        // (int) num cols (int) num rows (double) data
-//        void write(const char *file);
-//        void write(std::ofstream &fout);
+    // @TODO need to write these guys:
+    // prints the matrix in binary format:
+    // (int) num cols (int) num rows (double) data
+    //        void write(const char *file);
+    //        void write(std::ofstream &fout);
 
     private:
-        void _copy(double *p1, const double *p2, int len) const;
+    void _copy(double *p1, const double *p2, int len) const;
 
 }; // End class MatD
-
 
 class MatI {
 
     public:
-        // length
-        int _m;
-        int _n;
-        VecI _dat;
-        // Constructors:
-        MatI();
-        MatI(int m, int n);
-        MatI(int m, int n, const int &val);
-       
+    // length
+    int _m;
+    int _n;
+    VecI _dat;
+    // Constructors:
+    MatI();
+    MatI(int m, int n);
+    MatI(int m, int n, const int &val);
 
-        // (copied from vec.h)
-        // if (shallow == 1 (true)) then no memory is deleted upon destruction
-        // if (shallow == 0 (false)) then delete[] is called
-        // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-        MatI(int m, int n, int *arr, bool shallow=0);
 
-        // (copied from vec.h)
-        // if (shallow == 0 (false)) a DEEP copy is made of the data
-        // if (shallow == 1 (true)) a copy of the pointer is made
-        // if (shallow) then no memory is released upon destruction
-        // shallow is used for a quick copy with which to work 
-        MatI(const MatI &A, bool shallow=0);
+    // (copied from vec.h)
+    // if (shallow == 1 (true)) then no memory is deleted upon destruction
+    // if (shallow == 0 (false)) then delete[] is called
+    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
+    MatI(int m, int n, std::vector<int> arr);
 
-        operator int*() { return (int*)_dat; }
-        operator const int*() { return (int*)_dat; }
-        int* pointer() { return (int*)_dat; }
-        int* pointer(int m) { return &_dat[m*_n]; }
-        // creates vec objects 
+    // (copied from vec.h)
+    // if (shallow == 0 (false)) a DEEP copy is made of the data
+    // if (shallow == 1 (true)) a copy of the pointer is made
+    // if (shallow) then no memory is released upon destruction
+    // shallow is used for a quick copy with which to work
+        MatI(const MatI &A);
+
+    std::vector<int> pointer(int m);
+    // creates vec objects
         // caller must have allocated the array for the vec objects
-        // the data is a shallow copy!
-        // transpose and call row_vecs for col_vecs!
-        void row_vecs(int &cnt, VecI *vecs);
+    // the data is a shallow copy!
+    // transpose and call row_vecs for col_vecs!
+    void row_vecs(int &cnt, VecI *vecs);
 
-        MatI & operator=(const int &val);
-        // DEEP
-        MatI & operator=(MatI &A);
-        ~MatI();
-        // Deep copy unless shallow == true
-        void copy(MatI &receiver, bool shallow=0) const;
+    MatI & operator=(const int &val);
+    // DEEP
+    MatI & operator=(MatI &A);
+    ~MatI();
+    // Deep copy unless shallow == true
+    void copy(MatI &receiver) const;
 
-        void set_from_ascii(std::ifstream &stream, int m, int n, MatI &out);
-        void set_from_ascii(std::ifstream &stream, MatI &out);
-        void set_from_ascii(const char *file, bool without_axes=0);
-        void set_from_binary(const char *file);
-        void file_rows_cols(std::ifstream &stream, int &rows, int &cols);
-        // tnt_array2d_utils.h has a good example (use ifstream)
+    // shallow copy and no ownership of memory
+    void set(int m, int n, std::vector<int> arr);
+    // shallow copy and no ownership of memory
+    void set(MatI &A);
 
-        // shallow copy and no ownership of memory
-        void set(int m, int n, int *arr);
-        // shallow copy and no ownership of memory
-        void set(MatI &A);
+    bool all_equal() {
+        return _dat.all_equal();
+    }
 
-        bool all_equal() {
-            return _dat.all_equal();
-        }
+    // Deletes the object's memory (if not shallow) and takes ownership
+    // of the array memory (we will call delete[])
+    void take(int m, int n, std::vector<int> arr);
+    // Deletes previous memory (if not shallow) and takes ownership
+    // of the other's memory.
+    void take(MatI &A);
 
-        // Deletes the object's memory (if not shallow) and takes ownership
-        // of the array memory (we will call delete[])
-        void take(int m, int n, int *arr);
-        // Deletes previous memory (if not shallow) and takes ownership
-        // of the other's memory.
-        void take(MatI &A);
+    // flattens the matrix and returns a vector
+    void to_vec(VecI &outvec);
 
-        // flattens the matrix and returns a vector
-        void to_vec(VecI &outvec, bool shallow=0);
+    bool operator==(const MatI &A);
 
-        bool operator==(const MatI &A);
-        
-        bool shallow() { return _dat.shallow(); }
-        int dim1() const { return _m; }
-        int dim2() const { return _n; }
-        int mlen() const { return _m; }
-        int nlen() const { return _n; }
-        int rows() const { return _m; }
-        int cols() const { return _n; }
+    bool shallow() { return _dat.shallow(); }
+    int dim1() const { return _m; }
+    int dim2() const { return _n; }
+    int mlen() const { return _m; }
+    int nlen() const { return _n; }
+    int rows() const { return _m; }
+    int cols() const { return _n; }
 
-        int& operator()(int m, int n) {
+    int& operator()(int m, int n) {
 #ifdef JTP_BOUNDS_CHECK
-            if (n < 0) { puts("n < 0"); exit(1); }
-            if (n >= _n) { puts("n >= _n"); exit(1); }
-            if (m < 0) { puts("m < 0"); exit(1); }
-            if (m >= _m) { puts("m >= _m"); exit(1); }
+        if (n < 0) { puts("n < 0"); exit(1); }
+        if (n >= _n) { puts("n >= _n"); exit(1); }
+        if (m < 0) { puts("m < 0"); exit(1); }
+        if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
-            return _dat[m*_n + n]; 
+        return _dat[m*_n + n];
         }
-        const int& operator()(int m, int n) const {
+    const int& operator()(int m, int n) const {
 #ifdef JTP_BOUNDS_CHECK
-            if (n < 0) { puts("n < 0"); exit(1); }
-            if (n >= _n) { puts("n >= _n"); exit(1); }
-            if (m < 0) { puts("m < 0"); exit(1); }
-            if (m >= _m) { puts("m >= _m"); exit(1); }
+        if (n < 0) { puts("n < 0"); exit(1); }
+        if (n >= _n) { puts("n >= _n"); exit(1); }
+        if (m < 0) { puts("m < 0"); exit(1); }
+        if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
-            return _dat[m*_n + n]; 
+        return _dat[m*_n + n];
         }
 
-        // NOTE: All assignment operators act on the caller!
-        void operator+=(const MatI &A);
-        void operator-=(const MatI &A);
-        void operator*=(const MatI &A);
-        void operator/=(const MatI &A);
-        void operator+=(const int val) { _dat += val; }
-        void operator-=(const int val) { _dat -= val; }
-        void operator*=(const int val) { _dat *= val; }
-        void operator/=(const int val) { _dat /= val; }
+    // NOTE: All assignment operators act on the caller!
+    void operator+=(const MatI &A);
+    void operator-=(const MatI &A);
+    void operator*=(const MatI &A);
+    void operator/=(const MatI &A);
+    void operator+=(const int val) { _dat += val; }
+    void operator-=(const int val) { _dat -= val; }
+    void operator*=(const int val) { _dat *= val; }
+    void operator/=(const int val) { _dat /= val; }
 
-    
-        void add(const MatI &toadd, MatI &out);
-        void sub(const MatI &tosub, MatI &out);
-        void mul(const MatI &tomul, MatI &out);
-        void div(const MatI &todiv, MatI &out);
 
-        // returns the transpose in out
-        void transpose(MatI &out);
+    void add(const MatI &toadd, MatI &out);
+    void sub(const MatI &tosub, MatI &out);
+    void mul(const MatI &tomul, MatI &out);
+    void div(const MatI &todiv, MatI &out);
 
-        void std_normal() { _dat.std_normal(); }
-        void logarithm(double base) { _dat.logarithm(base); }
-        void expand(MatI &result, int match, int expand_x_lt, int expand_x_rt, int expand_y_up, int expand_y_dn, int expand_diag_lt_up, int expand_diag_rt_up, int expand_diag_lt_dn, int expand_diag_rt_dn );
+    // returns the transpose in out
+    void transpose(MatI &out);
 
-        void min_max(int &_min, int &_max) { _dat.min_max(_min,_max); }
-        double avg() { return _dat.avg(); }
-        //void operator++();
-        //void operator--();
-        
-        int sum() { return _dat.sum(); } // return the sum of the entire matrix
-        int sum(int m);  // return the sum of a given row
-        // Returns in a vector all the values matching mask value
-        void mask_as_vec(int return_val, MatI &mask, VecI &out);
+    void std_normal() { _dat.std_normal(); }
+    void logarithm(double base) { _dat.logarithm(base); }
+    void expand(MatI &result, int match, int expand_x_lt, int expand_x_rt, int expand_y_up, int expand_y_dn, int expand_diag_lt_up, int expand_diag_rt_up, int expand_diag_lt_dn, int expand_diag_rt_dn );
 
-        // prints the bare matrix as ascii
-        void print(bool without_axes=0);
-        void print(const char *file, bool without_axes=0);
-        void print(std::ostream &fout, bool without_axes=0);
+    void min_max(int &_min, int &_max) { _dat.min_max(_min,_max); }
+    double avg() { return _dat.avg(); }
+    //void operator++();
+    //void operator--();
 
-        // writes the matrix as binary (includes # rows first and # cols as
-        // ints)
-        void write(const char *file=NULL);
+    int sum() { return _dat.sum(); } // return the sum of the entire matrix
+    int sum(int m);  // return the sum of a given row
+    // Returns in a vector all the values matching mask value
+    void mask_as_vec(int return_val, MatI &mask, VecI &out);
 
-        
-        // @TODO need to write these guys:
-        // prints the matrix in binary format:
-        // (int) num cols (int) num rows (int) data
-//        void write(const char *file);
-//        void write(std::ofstream &fout);
+    // @TODO need to write these guys:
+    // prints the matrix in binary format:
+    // (int) num cols (int) num rows (int) data
+    //        void write(const char *file);
+    //        void write(std::ofstream &fout);
 
     private:
-        void _copy(int *p1, const int *p2, int len) const;
+    void _copy(int *p1, const int *p2, int len) const;
 
 }; // End class MatI
 

--- a/3rdparty/obiwarp/mat.h
+++ b/3rdparty/obiwarp/mat.h
@@ -43,14 +43,14 @@ class MatF {
     // if (shallow == 1 (true)) a copy of the pointer is made
     // if (shallow) then no memory is released upon destruction
     // shallow is used for a quick copy with which to work
-        MatF(const MatF &A);
+    MatF(const MatF &A);
 
     std::vector<float> row(int m);
     std::pair<std::vector<float>::iterator, std::vector<float>::iterator> rowIters(int m);
     float* rowData(int m);
     std::vector<float>::iterator rowIter(int m);
     // creates vec objects
-        // caller must have allocated the array for the vec objects
+    // caller must have allocated the array for the vec objects
     // the data is a shallow copy!
     // transpose and call row_vecs for col_vecs!
     void row_vecs(int &cnt, VecF *vecs);
@@ -99,7 +99,7 @@ class MatF {
         if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
         return _dat[m*_n + n];
-        }
+    }
     const float& operator()(int m, int n) const {
 #ifdef JTP_BOUNDS_CHECK
         if (n < 0) { puts("n < 0"); exit(1); }
@@ -108,7 +108,7 @@ class MatF {
         if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
         return _dat[m*_n + n];
-        }
+    }
 
     // NOTE: All assignment operators act on the caller!
     void operator+=(const MatF &A);
@@ -178,11 +178,14 @@ class MatD {
     // if (shallow == 1 (true)) a copy of the pointer is made
     // if (shallow) then no memory is released upon destruction
     // shallow is used for a quick copy with which to work
-        MatD(const MatD &A);
+    MatD(const MatD &A);
 
-    std::vector<double> pointer(int m);
+    std::vector<double> row(int m);
+    std::pair<std::vector<double>::iterator, std::vector<double>::iterator> rowIters(int m);
+    double* rowData(int m);
+    std::vector<double>::iterator rowIter(int m);
     // creates vec objects
-        // caller must have allocated the array for the vec objects
+    // caller must have allocated the array for the vec objects
     // the data is a shallow copy!
     // transpose and call row_vecs for col_vecs!
     void row_vecs(int &cnt, VecD *vecs);
@@ -231,7 +234,7 @@ class MatD {
         if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
         return _dat[m*_n + n];
-        }
+    }
     const double& operator()(int m, int n) const {
 #ifdef JTP_BOUNDS_CHECK
         if (n < 0) { puts("n < 0"); exit(1); }
@@ -240,7 +243,7 @@ class MatD {
         if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
         return _dat[m*_n + n];
-        }
+    }
 
     // NOTE: All assignment operators act on the caller!
     void operator+=(const MatD &A);
@@ -310,11 +313,14 @@ class MatI {
     // if (shallow == 1 (true)) a copy of the pointer is made
     // if (shallow) then no memory is released upon destruction
     // shallow is used for a quick copy with which to work
-        MatI(const MatI &A);
+    MatI(const MatI &A);
 
-    std::vector<int> pointer(int m);
+    std::vector<int> row(int m);
+    std::pair<std::vector<int>::iterator, std::vector<int>::iterator> rowIters(int m);
+    int* rowData(int m);
+    std::vector<int>::iterator rowIter(int m);
     // creates vec objects
-        // caller must have allocated the array for the vec objects
+    // caller must have allocated the array for the vec objects
     // the data is a shallow copy!
     // transpose and call row_vecs for col_vecs!
     void row_vecs(int &cnt, VecI *vecs);
@@ -363,7 +369,7 @@ class MatI {
         if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
         return _dat[m*_n + n];
-        }
+    }
     const int& operator()(int m, int n) const {
 #ifdef JTP_BOUNDS_CHECK
         if (n < 0) { puts("n < 0"); exit(1); }
@@ -372,7 +378,7 @@ class MatI {
         if (m >= _m) { puts("m >= _m"); exit(1); }
 #endif
         return _dat[m*_n + n];
-        }
+    }
 
     // NOTE: All assignment operators act on the caller!
     void operator+=(const MatI &A);

--- a/3rdparty/obiwarp/mat.h
+++ b/3rdparty/obiwarp/mat.h
@@ -42,7 +42,6 @@ class MatF {
     std::vector<float> row(int m);
     std::pair<std::vector<float>::iterator, std::vector<float>::iterator> rowIters(int m);
     float* rowData(int m);
-    std::vector<float>::iterator rowIter(int m);
 
     // creates vec objects
     // transpose and call row_vecs for col_vecs!

--- a/3rdparty/obiwarp/mat.h
+++ b/3rdparty/obiwarp/mat.h
@@ -3,14 +3,6 @@
 
 #include "vec.h"
 
-/*************************************************************
- * Creation from existing object/array is always shallow!.  
- * Will delete any memory allocated.
- * Will NOT delete any memory not allocated.
- * If you want deep then use copy function!
- ************************************************************/ 
-
-
 namespace VEC {
 
 class MatI;
@@ -22,60 +14,63 @@ class MatD;
 class MatF {
 
     public:
+
     // length
     int _m;
     int _n;
     VecF _dat;
+
     // Constructors:
+
+    // Creates an empty matrix.
     MatF();
+
+    // Creates a matrix with given row and column size but does not initialize
+    // the data.
     MatF(int m, int n);
+
+    // Creates a matrix with given row and column size and initialize elements
+    // with the given value.
     MatF(int m, int n, const float &val);
 
+    // Creates a matrix with the given STL vector.
+    MatF(int m, int n, std::vector<float>& arr);
 
-    // (copied from vec.h)
-    // if (shallow == 1 (true)) then no memory is deleted upon destruction
-    // if (shallow == 0 (false)) then delete[] is called
-    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-    MatF(int m, int n, std::vector<float> arr);
-
-    // (copied from vec.h)
-    // if (shallow == 0 (false)) a DEEP copy is made of the data
-    // if (shallow == 1 (true)) a copy of the pointer is made
-    // if (shallow) then no memory is released upon destruction
-    // shallow is used for a quick copy with which to work
+    // Creates a matrix by copying the data from the given matrix.
     MatF(const MatF &A);
 
     std::vector<float> row(int m);
     std::pair<std::vector<float>::iterator, std::vector<float>::iterator> rowIters(int m);
     float* rowData(int m);
     std::vector<float>::iterator rowIter(int m);
+
     // creates vec objects
-    // caller must have allocated the array for the vec objects
-    // the data is a shallow copy!
     // transpose and call row_vecs for col_vecs!
     void row_vecs(int &cnt, VecF *vecs);
 
     MatF & operator=(const float &val);
-    // DEEP
     MatF & operator=(MatF &A);
     ~MatF();
-    // Deep copy unless shallow == true
+
+    // Overwrite receiver's internals to be the same as this matrix.
     void copy(MatF &receiver) const;
 
-    // shallow copy and no ownership of memory
+    // Set the row, columns and internal vector to the given values.
     void set(int m, int n, std::vector<float> arr);
-    // shallow copy and no ownership of memory
+
+    // Set the row, columns and internal vector from the given matrix.
     void set(MatF &A);
 
     bool all_equal() {
         return _dat.all_equal();
     }
 
-    // Deletes the object's memory (if not shallow) and takes ownership
-    // of the array memory (we will call delete[])
+    // Same as its `MatF::set` equivalent now, but allowed to remain for legacy
+    // semantics.
     void take(int m, int n, std::vector<float> arr);
-    // Deletes previous memory (if not shallow) and takes ownership
-    // of the other's memory.
+
+    // Same as its `MatF::set` equivalent now, but allowed to remain for legacy
+    // semantics.
     void take(MatF &A);
 
     // flattens the matrix and returns a vector
@@ -157,60 +152,63 @@ class MatF {
 class MatD {
 
     public:
+
     // length
     int _m;
     int _n;
     VecD _dat;
+
     // Constructors:
+
+    // Creates an empty matrix.
     MatD();
+
+    // Creates a matrix with given row and column size but does not initialize
+    // the data.
     MatD(int m, int n);
+
+    // Creates a matrix with given row and column size and initialize elements
+    // with the given value.
     MatD(int m, int n, const double &val);
 
+    // Creates a matrix with the given STL vector.
+    MatD(int m, int n, std::vector<double>& arr);
 
-    // (copied from vec.h)
-    // if (shallow == 1 (true)) then no memory is deleted upon destruction
-    // if (shallow == 0 (false)) then delete[] is called
-    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-    MatD(int m, int n, std::vector<double> arr);
-
-    // (copied from vec.h)
-    // if (shallow == 0 (false)) a DEEP copy is made of the data
-    // if (shallow == 1 (true)) a copy of the pointer is made
-    // if (shallow) then no memory is released upon destruction
-    // shallow is used for a quick copy with which to work
+    // Creates a matrix by copying the data from the given matrix.
     MatD(const MatD &A);
 
     std::vector<double> row(int m);
     std::pair<std::vector<double>::iterator, std::vector<double>::iterator> rowIters(int m);
     double* rowData(int m);
     std::vector<double>::iterator rowIter(int m);
+
     // creates vec objects
-    // caller must have allocated the array for the vec objects
-    // the data is a shallow copy!
     // transpose and call row_vecs for col_vecs!
     void row_vecs(int &cnt, VecD *vecs);
 
     MatD & operator=(const double &val);
-    // DEEP
     MatD & operator=(MatD &A);
     ~MatD();
-    // Deep copy unless shallow == true
+
+    // Overwrite receiver's internals to be the same as this matrix.
     void copy(MatD &receiver) const;
 
-    // shallow copy and no ownership of memory
+    // Set the row, columns and internal vector to the given values.
     void set(int m, int n, std::vector<double> arr);
-    // shallow copy and no ownership of memory
+
+    // Set the row, columns and internal vector from the given matrix.
     void set(MatD &A);
 
     bool all_equal() {
         return _dat.all_equal();
     }
 
-    // Deletes the object's memory (if not shallow) and takes ownership
-    // of the array memory (we will call delete[])
+    // Same as its `MatD::set` equivalent now, but allowed to remain for legacy
+    // semantics.
     void take(int m, int n, std::vector<double> arr);
-    // Deletes previous memory (if not shallow) and takes ownership
-    // of the other's memory.
+
+    // Same as its `MatD::set` equivalent now, but allowed to remain for legacy
+    // semantics.
     void take(MatD &A);
 
     // flattens the matrix and returns a vector
@@ -289,63 +287,67 @@ class MatD {
 
 }; // End class MatD
 
+
 class MatI {
 
     public:
+
     // length
     int _m;
     int _n;
     VecI _dat;
+
     // Constructors:
+
+    // Creates an empty matrix.
     MatI();
+
+    // Creates a matrix with given row and column size but does not initialize
+    // the data.
     MatI(int m, int n);
+
+    // Creates a matrix with given row and column size and initialize elements
+    // with the given value.
     MatI(int m, int n, const int &val);
 
+    // Creates a matrix with the given STL vector.
+    MatI(int m, int n, std::vector<int>& arr);
 
-    // (copied from vec.h)
-    // if (shallow == 1 (true)) then no memory is deleted upon destruction
-    // if (shallow == 0 (false)) then delete[] is called
-    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-    MatI(int m, int n, std::vector<int> arr);
-
-    // (copied from vec.h)
-    // if (shallow == 0 (false)) a DEEP copy is made of the data
-    // if (shallow == 1 (true)) a copy of the pointer is made
-    // if (shallow) then no memory is released upon destruction
-    // shallow is used for a quick copy with which to work
+    // Creates a matrix by copying the data from the given matrix.
     MatI(const MatI &A);
 
     std::vector<int> row(int m);
     std::pair<std::vector<int>::iterator, std::vector<int>::iterator> rowIters(int m);
     int* rowData(int m);
     std::vector<int>::iterator rowIter(int m);
+
     // creates vec objects
-    // caller must have allocated the array for the vec objects
-    // the data is a shallow copy!
     // transpose and call row_vecs for col_vecs!
     void row_vecs(int &cnt, VecI *vecs);
 
     MatI & operator=(const int &val);
-    // DEEP
     MatI & operator=(MatI &A);
     ~MatI();
-    // Deep copy unless shallow == true
+
+    // Overwrite receiver's internals to be the same as this matrix.
     void copy(MatI &receiver) const;
 
-    // shallow copy and no ownership of memory
+    // Set the row, columns and internal vector to the given values.
     void set(int m, int n, std::vector<int> arr);
-    // shallow copy and no ownership of memory
+
+    // Set the row, columns and internal vector from the given matrix.
     void set(MatI &A);
 
     bool all_equal() {
         return _dat.all_equal();
     }
 
-    // Deletes the object's memory (if not shallow) and takes ownership
-    // of the array memory (we will call delete[])
+    // Same as its `MatI::set` equivalent now, but allowed to remain for legacy
+    // semantics.
     void take(int m, int n, std::vector<int> arr);
-    // Deletes previous memory (if not shallow) and takes ownership
-    // of the other's memory.
+
+    // Same as its `MatI::set` equivalent now, but allowed to remain for legacy
+    // semantics.
     void take(MatI &A);
 
     // flattens the matrix and returns a vector

--- a/3rdparty/obiwarp/mat.h
+++ b/3rdparty/obiwarp/mat.h
@@ -45,7 +45,10 @@ class MatF {
     // shallow is used for a quick copy with which to work
         MatF(const MatF &A);
 
-    std::vector<float> pointer(int m);
+    std::vector<float> row(int m);
+    std::pair<std::vector<float>::iterator, std::vector<float>::iterator> rowIters(int m);
+    float* rowData(int m);
+    std::vector<float>::iterator rowIter(int m);
     // creates vec objects
         // caller must have allocated the array for the vec objects
     // the data is a shallow copy!

--- a/3rdparty/obiwarp/obiwarp.cpp
+++ b/3rdparty/obiwarp/obiwarp.cpp
@@ -26,26 +26,19 @@ ObiWarp::ObiWarp(ObiParams *obiParams){
     this->init_penalty = obiParams->init_penalty;
     this->response = obiParams->response;
     this->nostdnrm = obiParams->nostdnrm;
-    
-    tmPoint = NULL;
-    mzPoint = NULL;
-
 }
+
 ObiWarp::~ObiWarp(){
 
 }
 
 void ObiWarp::setReferenceData(vector<float> &rtPoints, vector<float> &mzPoints, vector<vector<float> >& intMat){
-    _tm_vals = rtPoints.size();
-    tmPoint = new float[_tm_vals];
-    for(int i=0; i < _tm_vals ; ++i)
-        tmPoint[i] = rtPoints[i];
+    tmPoint = rtPoints;
+    _tm_vals = tmPoint.size();
     _tm.take(_tm_vals, tmPoint);
 
-    _mz_vals = mzPoints.size();
-    mzPoint = new float[_mz_vals];
-    for(int i = 0; i < _mz_vals; ++i)
-        mzPoint[i] = mzPoints[i];
+    mzPoint = mzPoints;
+    _mz_vals = mzPoint.size();
     _mz.take(_mz_vals, mzPoint);
 
     assert(_tm_vals == intMat.size());
@@ -62,17 +55,13 @@ void ObiWarp::setReferenceData(vector<float> &rtPoints, vector<float> &mzPoints,
 vector<float> ObiWarp::align(vector<float> &rtPoints, vector<float> &mzPoints, vector<vector<float> >& intMat){
     
     VecF tm;
-    int tm_vals = rtPoints.size();
-    float* tmPoint = new float[tm_vals];
-    for(int i = 0; i < tm_vals; ++i)
-        tmPoint[i] = rtPoints[i];
+    vector<float> tmPoint(rtPoints);
+    int tm_vals = tmPoint.size();
     tm.take(tm_vals, tmPoint);
 
     VecF mz;
-    int mz_vals = mzPoints.size();
-    float* mzPoint = new float[mz_vals];
-    for(int i = 0; i < mz_vals; ++i)
-        mzPoint[i] = mzPoints[i];
+    vector<float> mzPoint(mzPoints);
+    int mz_vals = mzPoint.size();
     mz.take(mz_vals, mzPoint);
 
     assert(tm_vals = intMat.size());
@@ -111,10 +100,9 @@ vector<float> ObiWarp::align(vector<float> &rtPoints, vector<float> &mzPoints, v
         !tm_axis_vals(nOut, nOutF, tm,tm_vals))
         return alignedRts;
     warp_tm(nOutF, mOutF, tm);
-    
-    float* rts = tm.pointer();
+
     for(int i = 0; i < tm_vals; ++i)
-        alignedRts.push_back(rts[i]);
+        alignedRts.push_back(tm[i]);
     
     // delete[] tmPoint;
     // delete[] mzPoint;

--- a/3rdparty/obiwarp/obiwarp.h
+++ b/3rdparty/obiwarp/obiwarp.h
@@ -41,8 +41,8 @@ private:
     MatF _mat;
     int _tm_vals;
     int _mz_vals;
-    float* tmPoint;
-    float* mzPoint;
+    std::vector<float> tmPoint;
+    std::vector<float> mzPoint;
     DynProg dyn;
 
     char* score;

--- a/3rdparty/obiwarp/obiwarp.pro
+++ b/3rdparty/obiwarp/obiwarp.pro
@@ -15,7 +15,9 @@ QMAKE_CXXFLAGS += -DOMP_PARALLEL
 
 TARGET = obiwarp
 
-
+linux: QMAKE_CXXFLAGS += -Ofast -ffast-math
+win32: QMAKE_CXXFLAGS += -Ofast -ffast-math
+macx: QMAKE_CXXFLAGS += -O3
 
 macx{
     INCLUDEPATH += /usr/local/include/

--- a/3rdparty/obiwarp/vec.cpp
+++ b/3rdparty/obiwarp/vec.cpp
@@ -83,12 +83,12 @@ void VecF::to_i(VecI &out) {
 
 
 void VecF::set(int n, std::vector<float> arr) {
-    _dat = arr;
+    _dat = std::move(arr);
     _n = n;
 }
 
 void VecF::take(int n, std::vector<float> arr) {
-    _dat = arr;
+    _dat = std::move(arr);
     _n = n;
 }
 
@@ -991,12 +991,12 @@ void VecD::to_i(VecI &out) {
 
 
 void VecD::set(int n, std::vector<double> arr) {
-    _dat = arr;
+    _dat = std::move(arr);
     _n = n;
 }
 
 void VecD::take(int n, std::vector<double> arr) {
-    _dat = arr;
+    _dat = std::move(arr);
     _n = n;
 }
 
@@ -1899,12 +1899,12 @@ void VecI::to_d(VecD &out) {
 
 
 void VecI::set(int n, std::vector<int> arr) {
-    _dat = arr;
+    _dat = std::move(arr);
     _n = n;
 }
 
 void VecI::take(int n, std::vector<int> arr) {
-    _dat = arr;
+    _dat = std::move(arr);
     _n = n;
 }
 

--- a/3rdparty/obiwarp/vec.cpp
+++ b/3rdparty/obiwarp/vec.cpp
@@ -742,7 +742,6 @@ double VecF::covariance(VecF &x, VecF &y) {
 }
 
 double VecF::euclidean(VecF &x, VecF &y) {
-    VecF diff(x.size());
     double sum_of_diffs = 0;
     for (int i = 0; i < x.size(); ++i) {
         sum_of_diffs += (x[i] - y[i]) * (x[i] - y[i]);
@@ -1651,7 +1650,6 @@ double VecD::covariance(VecD &x, VecD &y) {
 }
 
 double VecD::euclidean(VecD &x, VecD &y) {
-    VecD diff(x.size());
     double sum_of_diffs = 0;
     for (int i = 0; i < x.size(); ++i) {
         sum_of_diffs += (x[i] - y[i]) * (x[i] - y[i]);
@@ -2560,7 +2558,6 @@ double VecI::covariance(VecI &x, VecI &y) {
 }
 
 double VecI::euclidean(VecI &x, VecI &y) {
-    VecI diff(x.size());
     double sum_of_diffs = 0;
     for (int i = 0; i < x.size(); ++i) {
         sum_of_diffs += (x[i] - y[i]) * (x[i] - y[i]);

--- a/3rdparty/obiwarp/vec.cpp
+++ b/3rdparty/obiwarp/vec.cpp
@@ -52,7 +52,7 @@ VecF::VecF(int n, const float &val) : _n(n) {
 #endif
 }
 
-VecF::VecF(int n, std::vector<float> arr) : _n(n), _dat(arr) {
+VecF::VecF(int n, std::vector<float>& arr) : _n(n), _dat(arr) {
 #ifdef JTP_DEBUG
     puts("SHALLOW, (N,*ARR)");
 #endif
@@ -65,20 +65,20 @@ VecF::VecF(const VecF &A) : _n(A._n) {
 #endif
 }
 
-void VecF::to_f(VecF &out) {
-    VecF _tmp(_n);
+void VecF::to_d(VecD &out) {
+    std::vector<double> dat(_n);
     for (int i = 0; i < _n; ++i) {
-        _tmp[i] = static_cast<float>(_dat[i]);
+        dat.push_back(static_cast<double>(_dat[i]));
     }
-    out.take(_tmp);
+    out.set(_n, dat);
 }
 
 void VecF::to_i(VecI &out) {
-    VecI _tmp(_n);
+    std::vector<int> dat(_n);
     for (int i = 0; i < _n; ++i) {
-        _tmp[i] = static_cast<int>(_dat[i]);
+        dat.push_back(static_cast<int>(_dat[i]));
     }
-    out.take(_tmp);
+    out.set(_n, dat);
 }
 
 
@@ -961,7 +961,7 @@ VecD::VecD(int n, const double &val) : _n(n) {
 #endif
 }
 
-VecD::VecD(int n, std::vector<double> arr) : _n(n), _dat(arr) {
+VecD::VecD(int n, std::vector<double>& arr) : _n(n), _dat(arr) {
 #ifdef JTP_DEBUG
     puts("SHALLOW, (N,*ARR)");
 #endif
@@ -974,20 +974,20 @@ VecD::VecD(const VecD &A) : _n(A._n) {
 #endif
 }
 
-void VecD::to_f(VecD &out) {
-    VecD _tmp(_n);
+void VecD::to_f(VecF &out) {
+    std::vector<float> dat(_n);
     for (int i = 0; i < _n; ++i) {
-        _tmp[i] = static_cast<double>(_dat[i]);
+        dat.push_back(static_cast<float>(_dat[i]));
     }
-    out.take(_tmp);
+    out.set(_n, dat);
 }
 
 void VecD::to_i(VecI &out) {
-    VecI _tmp(_n);
+    std::vector<int> dat(_n);
     for (int i = 0; i < _n; ++i) {
-        _tmp[i] = static_cast<int>(_dat[i]);
+        dat.push_back(static_cast<int>(_dat[i]));
     }
-    out.take(_tmp);
+    out.set(_n, dat);
 }
 
 
@@ -1870,7 +1870,7 @@ VecI::VecI(int n, const int &val) : _n(n) {
 #endif
 }
 
-VecI::VecI(int n, std::vector<int> arr) : _n(n), _dat(arr) {
+VecI::VecI(int n, std::vector<int>& arr) : _n(n), _dat(arr) {
 #ifdef JTP_DEBUG
     puts("SHALLOW, (N,*ARR)");
 #endif
@@ -1883,20 +1883,20 @@ VecI::VecI(const VecI &A) : _n(A._n) {
 #endif
 }
 
-void VecI::to_f(VecI &out) {
-    VecI _tmp(_n);
+void VecI::to_f(VecF &out) {
+    std::vector<float> dat(_n);
     for (int i = 0; i < _n; ++i) {
-        _tmp[i] = static_cast<int>(_dat[i]);
+        dat.push_back(static_cast<float>(_dat[i]));
     }
-    out.take(_tmp);
+    out.set(_n, dat);
 }
 
-void VecI::to_i(VecI &out) {
-    VecI _tmp(_n);
+void VecI::to_d(VecD &out) {
+    std::vector<double> dat(_n);
     for (int i = 0; i < _n; ++i) {
-        _tmp[i] = static_cast<int>(_dat[i]);
+        dat.push_back(static_cast<double>(_dat[i]));
     }
-    out.take(_tmp);
+    out.set(_n, dat);
 }
 
 

--- a/3rdparty/obiwarp/vec.cpp
+++ b/3rdparty/obiwarp/vec.cpp
@@ -1207,7 +1207,7 @@ else {
 */
 
     double VecD::sum() {
-    return std::accumulate(_dat.begin(), _dat.end(), 0.0f);
+    return std::accumulate(_dat.begin(), _dat.end(), 0.0);
 }
 
 char * VecD::class_name() {
@@ -1306,8 +1306,8 @@ void VecD::mask_as_vec(double return_val, VecI &mask, VecD &out) {
 
 void VecD::hist(int num_bins, VecD &bins, VecI &freqs) {
     // Create the scaling factor
-    double _min = 0.0f;
-    double _max = 0.0f;
+    double _min = 0.0;
+    double _max = 0.0;
     min_max(_min, _max);
     double dmin = static_cast<double>(_min);
     double conv = static_cast<double>(num_bins)/static_cast<double>(_max - _min);
@@ -1384,7 +1384,7 @@ void VecD::chim(VecD &x, VecD &y, VecD &out_derivs) {
     double w2;
     double dmax;
     double dmin;
-    double three = 3.0f;
+    double three = 3.0;
     double dsave;
     double drat1;
     double drat2;
@@ -1437,7 +1437,7 @@ void VecD::chim(VecD &x, VecD &y, VecD &out_derivs) {
     w2 = -h1/hsum;
     tmp_derivs[0] = (w1*del1) + (w2*del2);
     if ( pchst(tmp_derivs[0],del1) <= 0 ) {
-        tmp_derivs[0] = 0.0f;
+        tmp_derivs[0] = 0.0;
     }
     else if ( pchst(del1,del2) < 0 ) {
         // need to do this check only if monotonicity switches
@@ -1459,7 +1459,7 @@ void VecD::chim(VecD &x, VecD &y, VecD &out_derivs) {
             del2 = (y[ind+1] - y[ind])/h2;
         }
         // 40
-        tmp_derivs[ind] = 0.0f;
+        tmp_derivs[ind] = 0.0;
 
         pchstval = pchst(del1,del2);
 
@@ -1482,7 +1482,7 @@ void VecD::chim(VecD &x, VecD &y, VecD &out_derivs) {
         }
         // 41
         else {  // equal to zero
-            if (del2 == 0.0f) { continue; }
+            if (del2 == 0.0) { continue; }
             if (VecD::pchst(dsave,del2) < 0) { ierr = ierr + 1; }
             dsave = del2;
             continue;
@@ -1494,7 +1494,7 @@ void VecD::chim(VecD &x, VecD &y, VecD &out_derivs) {
     w2 = (h2 + hsum)/hsum;
     tmp_derivs[ind] = w1*del1 + w2*del2;
     if ( VecD::pchst(tmp_derivs[ind],del2) <= 0 ) {
-        tmp_derivs[ind] = 0.0f;
+        tmp_derivs[ind] = 0.0;
     }
     else if ( VecD::pchst(del1, del2) < 0) {
         // NEED DO THIS CHECK ONLY IF MONOTONICITY SWITCHES.
@@ -2114,8 +2114,8 @@ else {
 }
 */
 
-    int VecI::sum() {
-    return std::accumulate(_dat.begin(), _dat.end(), 0.0f);
+int VecI::sum() {
+    return std::accumulate(_dat.begin(), _dat.end(), 0);
 }
 
 char * VecI::class_name() {
@@ -2214,8 +2214,8 @@ void VecI::mask_as_vec(int return_val, VecI &mask, VecI &out) {
 
 void VecI::hist(int num_bins, VecD &bins, VecI &freqs) {
     // Create the scaling factor
-    int _min = 0.0f;
-    int _max = 0.0f;
+    int _min = 0;
+    int _max = 0;
     min_max(_min, _max);
     double dmin = static_cast<double>(_min);
     double conv = static_cast<double>(num_bins)/static_cast<double>(_max - _min);
@@ -2292,7 +2292,7 @@ void VecI::chim(VecI &x, VecI &y, VecI &out_derivs) {
     int w2;
     int dmax;
     int dmin;
-    int three = 3.0f;
+    int three = 3;
     int dsave;
     int drat1;
     int drat2;
@@ -2345,7 +2345,7 @@ void VecI::chim(VecI &x, VecI &y, VecI &out_derivs) {
     w2 = -h1/hsum;
     tmp_derivs[0] = (w1*del1) + (w2*del2);
     if ( pchst(tmp_derivs[0],del1) <= 0 ) {
-        tmp_derivs[0] = 0.0f;
+        tmp_derivs[0] = 0;
     }
     else if ( pchst(del1,del2) < 0 ) {
         // need to do this check only if monotonicity switches
@@ -2367,7 +2367,7 @@ void VecI::chim(VecI &x, VecI &y, VecI &out_derivs) {
             del2 = (y[ind+1] - y[ind])/h2;
         }
         // 40
-        tmp_derivs[ind] = 0.0f;
+        tmp_derivs[ind] = 0;
 
         pchstval = pchst(del1,del2);
 
@@ -2390,7 +2390,7 @@ void VecI::chim(VecI &x, VecI &y, VecI &out_derivs) {
         }
         // 41
         else {  // equal to zero
-            if (del2 == 0.0f) { continue; }
+            if (del2 == 0) { continue; }
             if (VecI::pchst(dsave,del2) < 0) { ierr = ierr + 1; }
             dsave = del2;
             continue;
@@ -2402,7 +2402,7 @@ void VecI::chim(VecI &x, VecI &y, VecI &out_derivs) {
     w2 = (h2 + hsum)/hsum;
     tmp_derivs[ind] = w1*del1 + w2*del2;
     if ( VecI::pchst(tmp_derivs[ind],del2) <= 0 ) {
-        tmp_derivs[ind] = 0.0f;
+        tmp_derivs[ind] = 0;
     }
     else if ( VecI::pchst(del1, del2) < 0) {
         // NEED DO THIS CHECK ONLY IF MONOTONICITY SWITCHES.

--- a/3rdparty/obiwarp/vec.cpp
+++ b/3rdparty/obiwarp/vec.cpp
@@ -45,10 +45,8 @@ VecF::VecF(int n) : _n(n) {
 }
 
 VecF::VecF(int n, const float &val) : _n(n) {
-    _dat.reserve(_n);
-    for (int i = 0; i < _n; ++i) {
-        _dat.push_back(val);
-    }
+    _dat.resize(_n);
+    fill(_dat.begin(), _dat.end(), val);
 #ifdef JTP_DEBUG
     puts("Creating DATA(N,float)");
 #endif
@@ -121,9 +119,7 @@ void VecF::copy(VecF &receiver) const {
 }
 
 VecF & VecF::operator=(const float &val) {
-    for (int i = 0; i < _n; ++i) {
-        _dat[i] = val;
-    }
+    std::fill(_dat.begin(), _dat.end(), val);
     return *this;
 }
 
@@ -151,6 +147,18 @@ std::vector<float> VecF::slice(int start, int end)
 {
     std::vector<float> out(&_dat[start], &_dat[end]);
     return out;
+}
+
+std::pair<std::vector<float>::iterator, std::vector<float>::iterator>
+VecF::slice2(int start, int end)
+{
+    return std::make_pair(_dat.begin() + start, _dat.begin() + end);
+}
+
+float* VecF::data() {
+    if (_dat.size() == 0)
+        return nullptr;
+    return _dat.data();
 }
 
 /*************************

--- a/3rdparty/obiwarp/vec.cpp
+++ b/3rdparty/obiwarp/vec.cpp
@@ -289,7 +289,7 @@ else {
     VecF *C = new VecF(_n);
     VecF tmp = *C;
     tmp._to_pass_up = C;
-        printf("TMPENEW %d\n", tmp.shallow());
+    printf("TMPENEW %d\n", tmp.shallow());
     for (int i = 0; i < _n; ++i) {
         tmp[i] = _dat[i] + A[i];
     }
@@ -298,7 +298,7 @@ else {
 }
 */
 
-float VecF::sum() {
+    float VecF::sum() {
     return std::accumulate(_dat.begin(), _dat.end(), 0.0f);
 }
 
@@ -499,7 +499,7 @@ void VecF::chim(VecF &x, VecF &y, VecF &out_derivs) {
     //    // Check monotonicity
     //    for (int i = 2; i < length; i++) {
     //        if (x[i] <= x[i-1]) {
-//            return 2;
+    //            return 2;
     //        }
     //    }
 
@@ -954,10 +954,8 @@ VecD::VecD(int n) : _n(n) {
 }
 
 VecD::VecD(int n, const double &val) : _n(n) {
-    _dat.reserve(_n);
-    for (int i = 0; i < _n; ++i) {
-        _dat.push_back(val);
-    }
+    _dat.resize(_n);
+    fill(_dat.begin(), _dat.end(), val);
 #ifdef JTP_DEBUG
     puts("Creating DATA(N,double)");
 #endif
@@ -1030,9 +1028,7 @@ void VecD::copy(VecD &receiver) const {
 }
 
 VecD & VecD::operator=(const double &val) {
-    for (int i = 0; i < _n; ++i) {
-        _dat[i] = val;
-    }
+    std::fill(_dat.begin(), _dat.end(), val);
     return *this;
 }
 
@@ -1060,6 +1056,18 @@ std::vector<double> VecD::slice(int start, int end)
 {
     std::vector<double> out(&_dat[start], &_dat[end]);
     return out;
+}
+
+std::pair<std::vector<double>::iterator, std::vector<double>::iterator>
+VecD::slice2(int start, int end)
+{
+    return std::make_pair(_dat.begin() + start, _dat.begin() + end);
+}
+
+double* VecD::data() {
+    if (_dat.size() == 0)
+        return nullptr;
+    return _dat.data();
 }
 
 /*************************
@@ -1190,7 +1198,7 @@ else {
     VecD *C = new VecD(_n);
     VecD tmp = *C;
     tmp._to_pass_up = C;
-        printf("TMPENEW %d\n", tmp.shallow());
+    printf("TMPENEW %d\n", tmp.shallow());
     for (int i = 0; i < _n; ++i) {
         tmp[i] = _dat[i] + A[i];
     }
@@ -1199,7 +1207,7 @@ else {
 }
 */
 
-double VecD::sum() {
+    double VecD::sum() {
     return std::accumulate(_dat.begin(), _dat.end(), 0.0f);
 }
 
@@ -1334,7 +1342,7 @@ void VecD::logarithm(double base) {
     for (int i = 0; i < _n; ++i) {
         //printf("ME: %f\n", me[i]);
         _dat[i] = static_cast<double>(log(static_cast<double>(_dat[i]))
-                                     / log(base));
+                                      / log(base));
         //printf("MELOGGED: %f\n", me[i]);
     }
 }
@@ -1400,7 +1408,7 @@ void VecD::chim(VecD &x, VecD &y, VecD &out_derivs) {
     //    // Check monotonicity
     //    for (int i = 2; i < length; i++) {
     //        if (x[i] <= x[i-1]) {
-//            return 2;
+    //            return 2;
     //        }
     //    }
 
@@ -1855,10 +1863,8 @@ VecI::VecI(int n) : _n(n) {
 }
 
 VecI::VecI(int n, const int &val) : _n(n) {
-    _dat.reserve(_n);
-    for (int i = 0; i < _n; ++i) {
-        _dat.push_back(val);
-    }
+    _dat.resize(_n);
+    fill(_dat.begin(), _dat.end(), val);
 #ifdef JTP_DEBUG
     puts("Creating DATA(N,int)");
 #endif
@@ -1931,9 +1937,7 @@ void VecI::copy(VecI &receiver) const {
 }
 
 VecI & VecI::operator=(const int &val) {
-    for (int i = 0; i < _n; ++i) {
-        _dat[i] = val;
-    }
+    std::fill(_dat.begin(), _dat.end(), val);
     return *this;
 }
 
@@ -1961,6 +1965,18 @@ std::vector<int> VecI::slice(int start, int end)
 {
     std::vector<int> out(&_dat[start], &_dat[end]);
     return out;
+}
+
+std::pair<std::vector<int>::iterator, std::vector<int>::iterator>
+VecI::slice2(int start, int end)
+{
+    return std::make_pair(_dat.begin() + start, _dat.begin() + end);
+}
+
+int* VecI::data() {
+    if (_dat.size() == 0)
+        return nullptr;
+    return _dat.data();
 }
 
 /*************************
@@ -2091,7 +2107,7 @@ else {
     VecI *C = new VecI(_n);
     VecI tmp = *C;
     tmp._to_pass_up = C;
-        printf("TMPENEW %d\n", tmp.shallow());
+    printf("TMPENEW %d\n", tmp.shallow());
     for (int i = 0; i < _n; ++i) {
         tmp[i] = _dat[i] + A[i];
     }
@@ -2100,7 +2116,7 @@ else {
 }
 */
 
-int VecI::sum() {
+    int VecI::sum() {
     return std::accumulate(_dat.begin(), _dat.end(), 0.0f);
 }
 
@@ -2235,7 +2251,7 @@ void VecI::logarithm(double base) {
     for (int i = 0; i < _n; ++i) {
         //printf("ME: %f\n", me[i]);
         _dat[i] = static_cast<int>(log(static_cast<double>(_dat[i]))
-                                     / log(base));
+                                   / log(base));
         //printf("MELOGGED: %f\n", me[i]);
     }
 }
@@ -2301,7 +2317,7 @@ void VecI::chim(VecI &x, VecI &y, VecI &out_derivs) {
     //    // Check monotonicity
     //    for (int i = 2; i < length; i++) {
     //        if (x[i] <= x[i-1]) {
-//            return 2;
+    //            return 2;
     //        }
     //    }
 

--- a/3rdparty/obiwarp/vec.h
+++ b/3rdparty/obiwarp/vec.h
@@ -2,6 +2,7 @@
 #define _VEC_H
 
 #include <fstream>
+#include <vector>
 
 /*************************************************************
  * Creation from existing object/array is always deep!.  
@@ -20,791 +21,699 @@ class VecI;
 class VecF {
 
     protected:
-        // length
-        int _n;
-        float *_dat;
-        bool _shallow;
+    // length
+    int _n;
+    std::vector<float> _dat;
 
     public:
-        // Constructors:
-        VecF();
-        // Data values are NOT set by default
-        explicit VecF(int n);
-        VecF(int n, const float &val);
+    // Constructors:
+    VecF();
+    // Data values are NOT set by default
+    explicit VecF(int n);
+    VecF(int n, const float &val);
 
-        // if (shallow == 1 (true)) then no memory is deleted upon destruction
-        // if (shallow == 0 (false)) then delete[] is called
-        // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-        VecF(int n, float *arr, bool shallow=0);
+    // if (shallow == 1 (true)) then no memory is deleted upon destruction
+    // if (shallow == 0 (false)) then delete[] is called
+    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
+    VecF(int n, std::vector<float> arr);
 
-        // if (shallow == 0 (false)) a DEEP copy is made of the data
-        // if (shallow == 1 (true)) a copy of the pointer is made
-        // if (shallow) then no memory is released upon destruction
-        // shallow is used for a quick copy with which to work 
-        VecF(const VecF &A, bool shallow=0);
+    // if (shallow == 0 (false)) a DEEP copy is made of the data
+    // if (shallow == 1 (true)) a copy of the pointer is made
+    // if (shallow) then no memory is released upon destruction
+    // shallow is used for a quick copy with which to work
+        VecF(const VecF &A);
 
-        operator float*() {
-            if (_n > 0) {
-                return &(_dat[0]);
-            }
-            else {
-                return 0;
-            }
-        }
-        operator const float*() {
-            if (_n > 0) {
-                return &(_dat[0]);
-            }
-            else {
-                return 0;
-            }
-        }
+    float first() { return _dat[0]; }
+    float last() { return _dat[_n-1]; }
 
-        float first() { return _dat[0]; }
-        float last() { return _dat[_n-1]; }
+    // Returns the name of the class
+    // del needs to be called
+    char * class_name();
+    // shallow ownership
+    void set(int n, std::vector<float> arr);
+    // Deletes the object's previous memory (if not shallow) and takes
+    // ownership of the array (destructor call delete[])
+    // shallow in this context only refers to calling delete
+    // no data is copied
+    // deep ownership (no copy is performed)
+    void take(int n, std::vector<float> arr);
 
-        float* pointer() { return &(_dat[0]); }
+    void to_f(VecF &out);
+    void to_i(VecI &out);
 
-        // Returns the name of the class
-        // del needs to be called
-        char * class_name();
-        // shallow ownership
-        void set(int n, float *arr);
-        // Deletes the object's previous memory (if not shallow) and takes
-        // ownership of the array (destructor call delete[])
-        // shallow in this context only refers to calling delete
-        // no data is copied
-        // deep ownership (no copy is performed)
-        void take(int n, float *arr);
+    // returns the first index at the value, else -1
+    int index(float val);
 
-        void to_f(VecF &out);
-        void to_i(VecI &out);
+    // shallow ownership
+    void set(VecF &A);
+    // Deletes previous memory (if not shallow) and takes ownership
+    // of the other's memory.
+    void take(VecF &A);
+    VecF & operator=(const float &val);
+    VecF & operator=(VecF &A);
+    ~VecF();
+    // A deep copy unless shallow is set
+    void copy(VecF &receiver) const;
 
-        // returns the first index at the value, else -1
-        int index(float val);
+    bool operator==(const VecF &A);
 
-        // shallow ownership
-        void set(VecF &A);
-        // Deletes previous memory (if not shallow) and takes ownership
-        // of the other's memory.
-        void take(VecF &A);
-        VecF & operator=(const float &val);
-        VecF & operator=(VecF &A);
-        ~VecF();
-        // A deep copy unless shallow is set
-        void copy(VecF &receiver, bool shallow=0) const;
+    int length() const { return _n; }
+    int len() const { return _n; }
+    int size() const { return _n; }
+    int dim() const { return _n; }
+    int dim1() const { return _n; }
+    // Returns in a vector all the values matching mask value
+    void mask_as_vec(float return_val, VecI &mask, VecF &vec);
 
-        bool operator==(const VecF &A);
-        
-        int length() const { return _n; }
-        int len() const { return _n; }
-        int size() const { return _n; }
-        int dim() const { return _n; }
-        int dim1() const { return _n; }
-        // Returns in a vector all the values matching mask value
-        void mask_as_vec(float return_val, VecI &mask, VecF &vec);
-
-        // Returns true if all values are the same, false otherwise
-        bool all_equal() { 
+    // Returns true if all values are the same, false otherwise
+    bool all_equal() {
             float _min, _max; min_max(_min, _max);
-            if (_min == _max) { return 1; } 
+        if (_min == _max) { return 1; }
             else { return 0; }
-        }
+    }
 
-        float& operator[](int i) {
+    float& operator[](int i) {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
-        const float& operator[](int i) const {
+    const float& operator[](int i) const {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
 
-        float& at(int i) {
+    float& at(int i) {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
-        const float& at(int i) const {
+    const float& at(int i) const {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
 
-        bool shallow() {
-            return _shallow;
-        }
+    bool shallow() {
+        return false;
+    }
 
-        // NOTE: All operators act on the caller!
-        // Operators
-        void operator+=(const VecF &A);
-        void operator-=(const VecF &A);
-        void operator*=(const VecF &A);
-        void operator/=(const VecF &A);
-        void operator+=(float val);
-        void operator-=(float val);
-        void operator*=(float val);
-        void operator/=(float val);
-    
-        void add(const VecF &toadd, VecF &out);
-        void sub(const VecF &tosub, VecF &out);
-        void mul(const VecF &tomul, VecF &out);
-        void div(const VecF &todiv, VecF &out);
-        // This may be slow because we cast every value to double regardless
-        void square_root();
+    std::vector<float> slice(int start, int end);
 
-        void logarithm(double base);
-        void min_max(float &mn, float &mx);
-        // alias for min_max
-        void mn_mx(float &mn, float &mx) {min_max(mn,mx);}
-        double avg() const;
-        void hist(int num_bins, VecD &bins, VecI &freqs);
-        void sample_stats(double &mean, double &std_dev);
-        double prob_one_side_right(double x);
-        float sum();
-        float sum_of_sq();
+    // NOTE: All operators act on the caller!
+    // Operators
+    void operator+=(const VecF &A);
+    void operator-=(const VecF &A);
+    void operator*=(const VecF &A);
+    void operator/=(const VecF &A);
+    void operator+=(float val);
+    void operator-=(float val);
+    void operator*=(float val);
+    void operator/=(float val);
 
-        void abs_val();
-        // converts the distribution of values into standard normal
-        // Only for floating points right now!
-        void std_normal();
+    void add(const VecF &toadd, VecF &out);
+    void sub(const VecF &tosub, VecF &out);
+    void mul(const VecF &tomul, VecF &out);
+    void div(const VecF &todiv, VecF &out);
+    // This may be slow because we cast every value to double regardless
+    void square_root();
 
-        // uses quicksort to sort the values
-        void sort();
-        static int floatCompare( const void *a, const void *b );
+    void logarithm(double base);
+    void min_max(float &mn, float &mx);
+    // alias for min_max
+    void mn_mx(float &mn, float &mx) {min_max(mn,mx);}
+    double avg() const;
+    void hist(int num_bins, VecD &bins, VecI &freqs);
+    void sample_stats(double &mean, double &std_dev);
+    double prob_one_side_right(double x);
+    float sum();
+    float sum_of_sq();
 
-        // Removes the value at index and shortens the array by one
-        // not shallow anymore regardless of previous state 
+    void abs_val();
+    // converts the distribution of values into standard normal
+    // Only for floating points right now!
+    void std_normal();
+
+    // uses quicksort to sort the values
+    void sort();
+
+    // Removes the value at index and shortens the array by one
+    // not shallow anymore regardless of previous state
         void remove(int index);
-        
-        //VecF operator+(const VecF &A);
-        //void operator++();
-        //void operator--();
-        
-        // prints the vector (space delimited on one line without any length
-        // header)
-        void print(bool without_length=0);
-        // prints the vector to the file with the length written on the line
-        // before, unless without_length == true
-        void print(const char *, bool without_length=0);
-        // prints the vector to the filehandle with the length written on the
-        // line before, unless without_length == true
-        void print(std::ostream &fout, bool without_length=0);
 
-        // CLASS FUNCTIONS:
-        static int pchst(float arg1, float arg2) {
-            if      (arg1*arg2 > 0) { return  1; }
-            else if (arg1*arg2 < 0) { return -1; } 
+    //VecF operator+(const VecF &A);
+    //void operator++();
+    //void operator--();
+
+    // CLASS FUNCTIONS:
+    static int pchst(float arg1, float arg2) {
+        if      (arg1*arg2 > 0) { return  1; }
+        else if (arg1*arg2 < 0) { return -1; }
             else                    { return  0; }
-        }
+    }
 
-        static double pearsons_r(VecF &x, VecF &y);
-        static double covariance(VecF &x, VecF &y);
-        static double euclidean(VecF &x, VecF &y);
-        static float dot_product(VecF &x, VecF &y);
+    static double pearsons_r(VecF &x, VecF &y);
+    static double covariance(VecF &x, VecF &y);
+    static double euclidean(VecF &x, VecF &y);
+    static float dot_product(VecF &x, VecF &y);
 
-        static void xy_to_x(VecF &x, VecF &y);
-        static void x_to_xy(VecF &x, VecF &y);
-        static void chim(VecF &x, VecF &y, VecF &out_derivs);
+    static void xy_to_x(VecF &x, VecF &y);
+    static void x_to_xy(VecF &x, VecF &y);
+    static void chim(VecF &x, VecF &y, VecF &out_derivs);
 
-        static void calc_cubic_coeff(VecF &x, VecF &y, VecF &derivs, VecF &c2, VecF &c3);
-        static void chfe(VecF &xin, VecF &yin, VecF &xe, VecF &out_ye, int sorted=0);
-        //static void pchfe(VecF &xin, VecF &yin, VecF &XE, VecF &out_newy);
-        // interpolates so that linearity is encouraged along x axis
-        // if out_new_y.length() == 0 then new memory is allocated
-        // otherwise, uses whatever memory is allocated in out_new_y
-        static inline void chfev(float X1, float F1, float D1, float C2, float C3, float XE, float &FE);
-        static inline void chfev_all(float X1, float X2, float F1, float F2, float D1, float D2, float XE, float &FE);
-       // static void chfev(float X1, float X2, float F1, float F2, float D1, float D2, int NE, float *XE, float *FE, int *nlr, int &ierr);
+    static void calc_cubic_coeff(VecF &x, VecF &y, VecF &derivs, VecF &c2, VecF &c3);
+    static void chfe(VecF &xin, VecF &yin, VecF &xe, VecF &out_ye, int sorted=0);
+    //static void pchfe(VecF &xin, VecF &yin, VecF &XE, VecF &out_newy);
+    // interpolates so that linearity is encouraged along x axis
+    // if out_new_y.length() == 0 then new memory is allocated
+    // otherwise, uses whatever memory is allocated in out_new_y
+    static inline void chfev(float X1, float F1, float D1, float C2, float C3, float XE, float &FE);
+    static inline void chfev_all(float X1, float X2, float F1, float F2, float D1, float D2, float XE, float &FE);
+    // static void chfev(float X1, float X2, float F1, float F2, float D1, float D2, int NE, float *XE, float *FE, int *nlr, int &ierr);
 
-        // interpolates so that linearity is encouraged along the xy line
-        // if out_new_y.length() == 0 then new memory is allocated
-        // otherwise, uses whatever memory is allocated in out_new_y
-        static void chfe_xy(VecF &x, VecF &y, VecF &new_x, VecF &out_new_y, int sorted=0);
+    // interpolates so that linearity is encouraged along the xy line
+    // if out_new_y.length() == 0 then new memory is allocated
+    // otherwise, uses whatever memory is allocated in out_new_y
+    static void chfe_xy(VecF &x, VecF &y, VecF &new_x, VecF &out_new_y, int sorted=0);
 
-        static void linear_derivs(VecF &x, VecF &y, VecF &out_derivs);
-        static void linear_interp(VecF &xin, VecF &yin, VecF &xe, VecF &out_ye, int sorted=0);
-        //##### FOR ANY FUNCTION:
-        //                B 
-        //               /|
-        //              / |
-        //             /  |
-        //          c /   |a
-        //           /    |
-        //          /     |
-        //       A --------C
-        //             b
-        //  
+    static void linear_derivs(VecF &x, VecF &y, VecF &out_derivs);
+    static void linear_interp(VecF &xin, VecF &yin, VecF &xe, VecF &out_ye, int sorted=0);
+    //##### FOR ANY FUNCTION:
+    //                B
+    //               /|
+    //              / |
+    //             /  |
+    //          c /   |a
+    //           /    |
+    //          /     |
+    //       A --------C
+    //             b
+    //
         //  cPerp = Perpendicular from C to c
-        //  (sin A)/a = (sin C)/c
-        //  sin C = 1
-        //  c = sqrt(a^2 + b^2)
-        //  sin A = a/c
-        //  cPerp = (a/c)*b      note:   = sin A * b
-        //  cPerp^2 = (ab)^2/(a^2 + b^2)
+    //  (sin A)/a = (sin C)/c
+    //  sin C = 1
+    //  c = sqrt(a^2 + b^2)
+    //  sin A = a/c
+    //  cPerp = (a/c)*b      note:   = sin A * b
+    //  cPerp^2 = (ab)^2/(a^2 + b^2)
 
-        // g(x):  y = x
-        // h(y):  x = y
-        //  a = y - g(x)
+    // g(x):  y = x
+    // h(y):  x = y
+    //  a = y - g(x)
 
-        // b = actual x - (x = actual y)
-        // a = actual y - (y = actual x)
-        // avg residual = SUM(cPerp^2)/N
-        // 
+    // b = actual x - (x = actual y)
+    // a = actual y - (y = actual x)
+    // avg residual = SUM(cPerp^2)/N
+    //
 
-        //###### FOR X=Y
-        // residual^2 = 1/2((Y-X)^2)        note: [or X-Y]
-        static double sum_sq_res_yeqx(VecF &x, VecF &y);
-        // divides the sum of square of residuals by the length of the vector
-        static double avg_sq_res_yeqx(VecF &x, VecF &y);
+    //###### FOR X=Y
+    // residual^2 = 1/2((Y-X)^2)        note: [or X-Y]
+    static double sum_sq_res_yeqx(VecF &x, VecF &y);
+    // divides the sum of square of residuals by the length of the vector
+    static double avg_sq_res_yeqx(VecF &x, VecF &y);
 
-        // returns the average of the absolute values of the differences at
-        // each index
-        static double avg_abs_diff(VecF &x, VecF &y);
-        static void rsq_slope_intercept(VecF &x, VecF &y, double &rsq, double &slope, double &y_intercept);
+    // returns the average of the absolute values of the differences at
+    // each index
+    static double avg_abs_diff(VecF &x, VecF &y);
+    static void rsq_slope_intercept(VecF &x, VecF &y, double &rsq, double &slope, double &y_intercept);
 
     private:
-        void _copy(float *p1, const float *p2, int len) const;
-        static void outliers_from_regression_line(VecF &x, VecF &y, VecI &indices_out);
-        double _zScore(double mean, double sigma, double x);
+    static void outliers_from_regression_line(VecF &x, VecF &y, VecI &indices_out);
+    double _zScore(double mean, double sigma, double x);
 
 }; // End class VecF
-
 
 class VecD {
 
     protected:
-        // length
-        int _n;
-        double *_dat;
-        bool _shallow;
+    // length
+    int _n;
+    std::vector<double> _dat;
 
     public:
-        // Constructors:
-        VecD();
-        // Data values are NOT set by default
-        explicit VecD(int n);
-        VecD(int n, const double &val);
+    // Constructors:
+    VecD();
+    // Data values are NOT set by default
+    explicit VecD(int n);
+    VecD(int n, const double &val);
 
-        // if (shallow == 1 (true)) then no memory is deleted upon destruction
-        // if (shallow == 0 (false)) then delete[] is called
-        // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-        VecD(int n, double *arr, bool shallow=0);
+    // if (shallow == 1 (true)) then no memory is deleted upon destruction
+    // if (shallow == 0 (false)) then delete[] is called
+    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
+    VecD(int n, std::vector<double> arr);
 
-        // if (shallow == 0 (false)) a DEEP copy is made of the data
-        // if (shallow == 1 (true)) a copy of the pointer is made
-        // if (shallow) then no memory is released upon destruction
-        // shallow is used for a quick copy with which to work 
-        VecD(const VecD &A, bool shallow=0);
+    // if (shallow == 0 (false)) a DEEP copy is made of the data
+    // if (shallow == 1 (true)) a copy of the pointer is made
+    // if (shallow) then no memory is released upon destruction
+    // shallow is used for a quick copy with which to work
+        VecD(const VecD &A);
 
-        operator double*() {
-            if (_n > 0) {
-                return &(_dat[0]);
-            }
-            else {
-                return 0;
-            }
-        }
-        operator const double*() {
-            if (_n > 0) {
-                return &(_dat[0]);
-            }
-            else {
-                return 0;
-            }
-        }
+    double first() { return _dat[0]; }
+    double last() { return _dat[_n-1]; }
 
-        double first() { return _dat[0]; }
-        double last() { return _dat[_n-1]; }
+    // Returns the name of the class
+    // del needs to be called
+    char * class_name();
+    // shallow ownership
+    void set(int n, std::vector<double> arr);
+    // Deletes the object's previous memory (if not shallow) and takes
+    // ownership of the array (destructor call delete[])
+    // shallow in this context only refers to calling delete
+    // no data is copied
+    // deep ownership (no copy is performed)
+    void take(int n, std::vector<double> arr);
 
-        double* pointer() { return &(_dat[0]); }
+    void to_f(VecD &out);
+    void to_i(VecI &out);
 
-        // Returns the name of the class
-        // del needs to be called
-        char * class_name();
-        // shallow ownership
-        void set(int n, double *arr);
-        // Deletes the object's previous memory (if not shallow) and takes
-        // ownership of the array (destructor call delete[])
-        // shallow in this context only refers to calling delete
-        // no data is copied
-        // deep ownership (no copy is performed)
-        void take(int n, double *arr);
+    // returns the first index at the value, else -1
+    int index(double val);
 
-        void to_f(VecF &out);
-        void to_i(VecI &out);
+    // shallow ownership
+    void set(VecD &A);
+    // Deletes previous memory (if not shallow) and takes ownership
+    // of the other's memory.
+    void take(VecD &A);
+    VecD & operator=(const double &val);
+    VecD & operator=(VecD &A);
+    ~VecD();
+    // A deep copy unless shallow is set
+    void copy(VecD &receiver) const;
 
-        // returns the first index at the value, else -1
-        int index(double val);
+    bool operator==(const VecD &A);
 
-        // shallow ownership
-        void set(VecD &A);
-        // Deletes previous memory (if not shallow) and takes ownership
-        // of the other's memory.
-        void take(VecD &A);
-        VecD & operator=(const double &val);
-        VecD & operator=(VecD &A);
-        ~VecD();
-        // A deep copy unless shallow is set
-        void copy(VecD &receiver, bool shallow=0) const;
+    int length() const { return _n; }
+    int len() const { return _n; }
+    int size() const { return _n; }
+    int dim() const { return _n; }
+    int dim1() const { return _n; }
+    // Returns in a vector all the values matching mask value
+    void mask_as_vec(double return_val, VecI &mask, VecD &vec);
 
-        bool operator==(const VecD &A);
-        
-        int length() const { return _n; }
-        int len() const { return _n; }
-        int size() const { return _n; }
-        int dim() const { return _n; }
-        int dim1() const { return _n; }
-        // Returns in a vector all the values matching mask value
-        void mask_as_vec(double return_val, VecI &mask, VecD &vec);
-
-        // Returns true if all values are the same, false otherwise
-        bool all_equal() { 
+    // Returns true if all values are the same, false otherwise
+    bool all_equal() {
             double _min, _max; min_max(_min, _max);
-            if (_min == _max) { return 1; } 
+        if (_min == _max) { return 1; }
             else { return 0; }
-        }
+    }
 
-        double& operator[](int i) {
+    double& operator[](int i) {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
-        const double& operator[](int i) const {
+    const double& operator[](int i) const {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
 
-        double& at(int i) {
+    double& at(int i) {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
-        const double& at(int i) const {
+    const double& at(int i) const {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
 
-        bool shallow() {
-            return _shallow;
-        }
+    bool shallow() {
+        return false;
+    }
 
-        // NOTE: All operators act on the caller!
-        // Operators
-        void operator+=(const VecD &A);
-        void operator-=(const VecD &A);
-        void operator*=(const VecD &A);
-        void operator/=(const VecD &A);
-        void operator+=(double val);
-        void operator-=(double val);
-        void operator*=(double val);
-        void operator/=(double val);
-    
-        void add(const VecD &toadd, VecD &out);
-        void sub(const VecD &tosub, VecD &out);
-        void mul(const VecD &tomul, VecD &out);
-        void div(const VecD &todiv, VecD &out);
-        // This may be slow because we cast every value to double regardless
-        void square_root();
+    std::vector<double> slice(int start, int end);
 
-        void logarithm(double base);
-        void min_max(double &mn, double &mx);
-        // alias for min_max
-        void mn_mx(double &mn, double &mx) {min_max(mn,mx);}
-        double avg() const;
-        void hist(int num_bins, VecD &bins, VecI &freqs);
-        void sample_stats(double &mean, double &std_dev);
-        double prob_one_side_right(double x);
-        double sum();
-        double sum_of_sq();
+    // NOTE: All operators act on the caller!
+    // Operators
+    void operator+=(const VecD &A);
+    void operator-=(const VecD &A);
+    void operator*=(const VecD &A);
+    void operator/=(const VecD &A);
+    void operator+=(double val);
+    void operator-=(double val);
+    void operator*=(double val);
+    void operator/=(double val);
 
-        void abs_val();
-        // converts the distribution of values into standard normal
-        // Only for floating points right now!
-        void std_normal();
+    void add(const VecD &toadd, VecD &out);
+    void sub(const VecD &tosub, VecD &out);
+    void mul(const VecD &tomul, VecD &out);
+    void div(const VecD &todiv, VecD &out);
+    // This may be slow because we cast every value to double regardless
+    void square_root();
 
-        // uses quicksort to sort the values
-        void sort();
-        static int doubleCompare( const void *a, const void *b );
+    void logarithm(double base);
+    void min_max(double &mn, double &mx);
+    // alias for min_max
+    void mn_mx(double &mn, double &mx) {min_max(mn,mx);}
+    double avg() const;
+    void hist(int num_bins, VecD &bins, VecI &freqs);
+    void sample_stats(double &mean, double &std_dev);
+    double prob_one_side_right(double x);
+    double sum();
+    double sum_of_sq();
 
-        // Removes the value at index and shortens the array by one
-        // not shallow anymore regardless of previous state 
+    void abs_val();
+    // converts the distribution of values into standard normal
+    // Only for doubleing points right now!
+    void std_normal();
+
+    // uses quicksort to sort the values
+    void sort();
+
+    // Removes the value at index and shortens the array by one
+    // not shallow anymore regardless of previous state
         void remove(int index);
-        
-        //VecD operator+(const VecD &A);
-        //void operator++();
-        //void operator--();
-        
-        // prints the vector (space delimited on one line without any length
-        // header)
-        void print(bool without_length=0);
-        // prints the vector to the file with the length written on the line
-        // before, unless without_length == true
-        void print(const char *, bool without_length=0);
-        // prints the vector to the filehandle with the length written on the
-        // line before, unless without_length == true
-        void print(std::ostream &fout, bool without_length=0);
 
-        // CLASS FUNCTIONS:
-        static int pchst(double arg1, double arg2) {
-            if      (arg1*arg2 > 0) { return  1; }
-            else if (arg1*arg2 < 0) { return -1; } 
+    //VecD operator+(const VecD &A);
+    //void operator++();
+    //void operator--();
+
+    // CLASS FUNCTIONS:
+    static int pchst(double arg1, double arg2) {
+        if      (arg1*arg2 > 0) { return  1; }
+        else if (arg1*arg2 < 0) { return -1; }
             else                    { return  0; }
-        }
+    }
 
-        static double pearsons_r(VecD &x, VecD &y);
-        static double covariance(VecD &x, VecD &y);
-        static double euclidean(VecD &x, VecD &y);
-        static double dot_product(VecD &x, VecD &y);
+    static double pearsons_r(VecD &x, VecD &y);
+    static double covariance(VecD &x, VecD &y);
+    static double euclidean(VecD &x, VecD &y);
+    static double dot_product(VecD &x, VecD &y);
 
-        static void xy_to_x(VecD &x, VecD &y);
-        static void x_to_xy(VecD &x, VecD &y);
-        static void chim(VecD &x, VecD &y, VecD &out_derivs);
+    static void xy_to_x(VecD &x, VecD &y);
+    static void x_to_xy(VecD &x, VecD &y);
+    static void chim(VecD &x, VecD &y, VecD &out_derivs);
 
-        static void calc_cubic_coeff(VecD &x, VecD &y, VecD &derivs, VecD &c2, VecD &c3);
-        static void chfe(VecD &xin, VecD &yin, VecD &xe, VecD &out_ye, int sorted=0);
-        //static void pchfe(VecD &xin, VecD &yin, VecD &XE, VecD &out_newy);
-        // interpolates so that linearity is encouraged along x axis
-        // if out_new_y.length() == 0 then new memory is allocated
-        // otherwise, uses whatever memory is allocated in out_new_y
-        static inline void chfev(double X1, double F1, double D1, double C2, double C3, double XE, double &FE);
-        static inline void chfev_all(double X1, double X2, double F1, double F2, double D1, double D2, double XE, double &FE);
-       // static void chfev(double X1, double X2, double F1, double F2, double D1, double D2, int NE, double *XE, double *FE, int *nlr, int &ierr);
+    static void calc_cubic_coeff(VecD &x, VecD &y, VecD &derivs, VecD &c2, VecD &c3);
+    static void chfe(VecD &xin, VecD &yin, VecD &xe, VecD &out_ye, int sorted=0);
+    //static void pchfe(VecD &xin, VecD &yin, VecD &XE, VecD &out_newy);
+    // interpolates so that linearity is encouraged along x axis
+    // if out_new_y.length() == 0 then new memory is allocated
+    // otherwise, uses whatever memory is allocated in out_new_y
+    static inline void chfev(double X1, double F1, double D1, double C2, double C3, double XE, double &FE);
+    static inline void chfev_all(double X1, double X2, double F1, double F2, double D1, double D2, double XE, double &FE);
+    // static void chfev(double X1, double X2, double F1, double F2, double D1, double D2, int NE, double *XE, double *FE, int *nlr, int &ierr);
 
-        // interpolates so that linearity is encouraged along the xy line
-        // if out_new_y.length() == 0 then new memory is allocated
-        // otherwise, uses whatever memory is allocated in out_new_y
-        static void chfe_xy(VecD &x, VecD &y, VecD &new_x, VecD &out_new_y, int sorted=0);
+    // interpolates so that linearity is encouraged along the xy line
+    // if out_new_y.length() == 0 then new memory is allocated
+    // otherwise, uses whatever memory is allocated in out_new_y
+    static void chfe_xy(VecD &x, VecD &y, VecD &new_x, VecD &out_new_y, int sorted=0);
 
-        static void linear_derivs(VecD &x, VecD &y, VecD &out_derivs);
-        static void linear_interp(VecD &xin, VecD &yin, VecD &xe, VecD &out_ye, int sorted=0);
-        //##### FOR ANY FUNCTION:
-        //                B 
-        //               /|
-        //              / |
-        //             /  |
-        //          c /   |a
-        //           /    |
-        //          /     |
-        //       A --------C
-        //             b
-        //  
+    static void linear_derivs(VecD &x, VecD &y, VecD &out_derivs);
+    static void linear_interp(VecD &xin, VecD &yin, VecD &xe, VecD &out_ye, int sorted=0);
+    //##### FOR ANY FUNCTION:
+    //                B
+    //               /|
+    //              / |
+    //             /  |
+    //          c /   |a
+    //           /    |
+    //          /     |
+    //       A --------C
+    //             b
+    //
         //  cPerp = Perpendicular from C to c
-        //  (sin A)/a = (sin C)/c
-        //  sin C = 1
-        //  c = sqrt(a^2 + b^2)
-        //  sin A = a/c
-        //  cPerp = (a/c)*b      note:   = sin A * b
-        //  cPerp^2 = (ab)^2/(a^2 + b^2)
+    //  (sin A)/a = (sin C)/c
+    //  sin C = 1
+    //  c = sqrt(a^2 + b^2)
+    //  sin A = a/c
+    //  cPerp = (a/c)*b      note:   = sin A * b
+    //  cPerp^2 = (ab)^2/(a^2 + b^2)
 
-        // g(x):  y = x
-        // h(y):  x = y
-        //  a = y - g(x)
+    // g(x):  y = x
+    // h(y):  x = y
+    //  a = y - g(x)
 
-        // b = actual x - (x = actual y)
-        // a = actual y - (y = actual x)
-        // avg residual = SUM(cPerp^2)/N
-        // 
+    // b = actual x - (x = actual y)
+    // a = actual y - (y = actual x)
+    // avg residual = SUM(cPerp^2)/N
+    //
 
-        //###### FOR X=Y
-        // residual^2 = 1/2((Y-X)^2)        note: [or X-Y]
-        static double sum_sq_res_yeqx(VecD &x, VecD &y);
-        // divides the sum of square of residuals by the length of the vector
-        static double avg_sq_res_yeqx(VecD &x, VecD &y);
+    //###### FOR X=Y
+    // residual^2 = 1/2((Y-X)^2)        note: [or X-Y]
+    static double sum_sq_res_yeqx(VecD &x, VecD &y);
+    // divides the sum of square of residuals by the length of the vector
+    static double avg_sq_res_yeqx(VecD &x, VecD &y);
 
-        // returns the average of the absolute values of the differences at
-        // each index
-        static double avg_abs_diff(VecD &x, VecD &y);
-        static void rsq_slope_intercept(VecD &x, VecD &y, double &rsq, double &slope, double &y_intercept);
+    // returns the average of the absolute values of the differences at
+    // each index
+    static double avg_abs_diff(VecD &x, VecD &y);
+    static void rsq_slope_intercept(VecD &x, VecD &y, double &rsq, double &slope, double &y_intercept);
 
     private:
-        void _copy(double *p1, const double *p2, int len) const;
-        static void outliers_from_regression_line(VecD &x, VecD &y, VecI &indices_out);
-        double _zScore(double mean, double sigma, double x);
+    static void outliers_from_regression_line(VecD &x, VecD &y, VecI &indices_out);
+    double _zScore(double mean, double sigma, double x);
 
 }; // End class VecD
-
 
 class VecI {
 
     protected:
-        // length
-        int _n;
-        int *_dat;
-        bool _shallow;
+    // length
+    int _n;
+    std::vector<int> _dat;
 
     public:
-        // Constructors:
-        VecI();
-        // Data values are NOT set by default
-        explicit VecI(int n);
-        VecI(int n, const int &val);
+    // Constructors:
+    VecI();
+    // Data values are NOT set by default
+    explicit VecI(int n);
+    VecI(int n, const int &val);
 
-        // if (shallow == 1 (true)) then no memory is deleted upon destruction
-        // if (shallow == 0 (false)) then delete[] is called
-        // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-        VecI(int n, int *arr, bool shallow=0);
+    // if (shallow == 1 (true)) then no memory is deleted upon destruction
+    // if (shallow == 0 (false)) then delete[] is called
+    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
+    VecI(int n, std::vector<int> arr);
 
-        // if (shallow == 0 (false)) a DEEP copy is made of the data
-        // if (shallow == 1 (true)) a copy of the pointer is made
-        // if (shallow) then no memory is released upon destruction
-        // shallow is used for a quick copy with which to work 
-        VecI(const VecI &A, bool shallow=0);
+    // if (shallow == 0 (false)) a DEEP copy is made of the data
+    // if (shallow == 1 (true)) a copy of the pointer is made
+    // if (shallow) then no memory is released upon destruction
+    // shallow is used for a quick copy with which to work
+        VecI(const VecI &A);
 
-        operator int*() {
-            if (_n > 0) {
-                return &(_dat[0]);
-            }
-            else {
-                return 0;
-            }
-        }
-        operator const int*() {
-            if (_n > 0) {
-                return &(_dat[0]);
-            }
-            else {
-                return 0;
-            }
-        }
+    int first() { return _dat[0]; }
+    int last() { return _dat[_n-1]; }
 
-        int first() { return _dat[0]; }
-        int last() { return _dat[_n-1]; }
+    // Returns the name of the class
+    // del needs to be called
+    char * class_name();
+    // shallow ownership
+    void set(int n, std::vector<int> arr);
+    // Deletes the object's previous memory (if not shallow) and takes
+    // ownership of the array (destructor call delete[])
+    // shallow in this context only refers to calling delete
+    // no data is copied
+    // deep ownership (no copy is performed)
+    void take(int n, std::vector<int> arr);
 
-        int* pointer() { return &(_dat[0]); }
+    void to_f(VecI &out);
+    void to_i(VecI &out);
 
-        // Returns the name of the class
-        // del needs to be called
-        char * class_name();
-        // shallow ownership
-        void set(int n, int *arr);
-        // Deletes the object's previous memory (if not shallow) and takes
-        // ownership of the array (destructor call delete[])
-        // shallow in this context only refers to calling delete
-        // no data is copied
-        // deep ownership (no copy is performed)
-        void take(int n, int *arr);
+    // returns the first index at the value, else -1
+    int index(int val);
 
-        void to_f(VecF &out);
-        void to_i(VecI &out);
+    // shallow ownership
+    void set(VecI &A);
+    // Deletes previous memory (if not shallow) and takes ownership
+    // of the other's memory.
+    void take(VecI &A);
+    VecI & operator=(const int &val);
+    VecI & operator=(VecI &A);
+    ~VecI();
+    // A deep copy unless shallow is set
+    void copy(VecI &receiver) const;
 
-        // returns the first index at the value, else -1
-        int index(int val);
+    bool operator==(const VecI &A);
 
-        // shallow ownership
-        void set(VecI &A);
-        // Deletes previous memory (if not shallow) and takes ownership
-        // of the other's memory.
-        void take(VecI &A);
-        VecI & operator=(const int &val);
-        VecI & operator=(VecI &A);
-        ~VecI();
-        // A deep copy unless shallow is set
-        void copy(VecI &receiver, bool shallow=0) const;
+    int length() const { return _n; }
+    int len() const { return _n; }
+    int size() const { return _n; }
+    int dim() const { return _n; }
+    int dim1() const { return _n; }
+    // Returns in a vector all the values matching mask value
+    void mask_as_vec(int return_val, VecI &mask, VecI &vec);
 
-        bool operator==(const VecI &A);
-        
-        int length() const { return _n; }
-        int len() const { return _n; }
-        int size() const { return _n; }
-        int dim() const { return _n; }
-        int dim1() const { return _n; }
-        // Returns in a vector all the values matching mask value
-        void mask_as_vec(int return_val, VecI &mask, VecI &vec);
-
-        // Returns true if all values are the same, false otherwise
-        bool all_equal() { 
+    // Returns true if all values are the same, false otherwise
+    bool all_equal() {
             int _min, _max; min_max(_min, _max);
-            if (_min == _max) { return 1; } 
+        if (_min == _max) { return 1; }
             else { return 0; }
-        }
+    }
 
-        int& operator[](int i) {
+    int& operator[](int i) {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
-        const int& operator[](int i) const {
+    const int& operator[](int i) const {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
 
-        int& at(int i) {
+    int& at(int i) {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
-        const int& at(int i) const {
+    const int& at(int i) const {
 #ifdef JTP_BOUNDS_CHECK
-            if (i < 0) { puts("index < 0 !"); exit(1); }
-            if (i >= _n) { puts("i >= _n !"); exit(1); }
+        if (i < 0) { puts("index < 0 !"); exit(1); }
+        if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
-            return _dat[i]; 
+        return _dat[i];
         }
 
-        bool shallow() {
-            return _shallow;
-        }
+    bool shallow() {
+        return false;
+    }
 
-        // NOTE: All operators act on the caller!
-        // Operators
-        void operator+=(const VecI &A);
-        void operator-=(const VecI &A);
-        void operator*=(const VecI &A);
-        void operator/=(const VecI &A);
-        void operator+=(int val);
-        void operator-=(int val);
-        void operator*=(int val);
-        void operator/=(int val);
-    
-        void add(const VecI &toadd, VecI &out);
-        void sub(const VecI &tosub, VecI &out);
-        void mul(const VecI &tomul, VecI &out);
-        void div(const VecI &todiv, VecI &out);
-        // This may be slow because we cast every value to double regardless
-        void square_root();
+    std::vector<int> slice(int start, int end);
 
-        void logarithm(double base);
-        void min_max(int &mn, int &mx);
-        // alias for min_max
-        void mn_mx(int &mn, int &mx) {min_max(mn,mx);}
-        double avg() const;
-        void hist(int num_bins, VecD &bins, VecI &freqs);
-        void sample_stats(double &mean, double &std_dev);
-        double prob_one_side_right(double x);
-        int sum();
-        int sum_of_sq();
+    // NOTE: All operators act on the caller!
+    // Operators
+    void operator+=(const VecI &A);
+    void operator-=(const VecI &A);
+    void operator*=(const VecI &A);
+    void operator/=(const VecI &A);
+    void operator+=(int val);
+    void operator-=(int val);
+    void operator*=(int val);
+    void operator/=(int val);
 
-        void abs_val();
-        // converts the distribution of values into standard normal
-        // Only for floating points right now!
-        void std_normal();
+    void add(const VecI &toadd, VecI &out);
+    void sub(const VecI &tosub, VecI &out);
+    void mul(const VecI &tomul, VecI &out);
+    void div(const VecI &todiv, VecI &out);
+    // This may be slow because we cast every value to double regardless
+    void square_root();
 
-        // uses quicksort to sort the values
-        void sort();
-        static int intCompare( const void *a, const void *b );
+    void logarithm(double base);
+    void min_max(int &mn, int &mx);
+    // alias for min_max
+    void mn_mx(int &mn, int &mx) {min_max(mn,mx);}
+    double avg() const;
+    void hist(int num_bins, VecD &bins, VecI &freqs);
+    void sample_stats(double &mean, double &std_dev);
+    double prob_one_side_right(double x);
+    int sum();
+    int sum_of_sq();
 
-        // Removes the value at index and shortens the array by one
-        // not shallow anymore regardless of previous state 
+    void abs_val();
+    // converts the distribution of values into standard normal
+    // Only for inting points right now!
+    void std_normal();
+
+    // uses quicksort to sort the values
+    void sort();
+
+    // Removes the value at index and shortens the array by one
+    // not shallow anymore regardless of previous state
         void remove(int index);
-        
-        //VecI operator+(const VecI &A);
-        //void operator++();
-        //void operator--();
-        
-        // prints the vector (space delimited on one line without any length
-        // header)
-        void print(bool without_length=0);
-        // prints the vector to the file with the length written on the line
-        // before, unless without_length == true
-        void print(const char *, bool without_length=0);
-        // prints the vector to the filehandle with the length written on the
-        // line before, unless without_length == true
-        void print(std::ostream &fout, bool without_length=0);
 
-        // CLASS FUNCTIONS:
-        static int pchst(int arg1, int arg2) {
-            if      (arg1*arg2 > 0) { return  1; }
-            else if (arg1*arg2 < 0) { return -1; } 
+    //VecI operator+(const VecI &A);
+    //void operator++();
+    //void operator--();
+
+    // CLASS FUNCTIONS:
+    static int pchst(int arg1, int arg2) {
+        if      (arg1*arg2 > 0) { return  1; }
+        else if (arg1*arg2 < 0) { return -1; }
             else                    { return  0; }
-        }
+    }
 
-        static double pearsons_r(VecI &x, VecI &y);
-        static double covariance(VecI &x, VecI &y);
-        static double euclidean(VecI &x, VecI &y);
-        static int dot_product(VecI &x, VecI &y);
+    static double pearsons_r(VecI &x, VecI &y);
+    static double covariance(VecI &x, VecI &y);
+    static double euclidean(VecI &x, VecI &y);
+    static int dot_product(VecI &x, VecI &y);
 
-        static void xy_to_x(VecI &x, VecI &y);
-        static void x_to_xy(VecI &x, VecI &y);
-        static void chim(VecI &x, VecI &y, VecI &out_derivs);
+    static void xy_to_x(VecI &x, VecI &y);
+    static void x_to_xy(VecI &x, VecI &y);
+    static void chim(VecI &x, VecI &y, VecI &out_derivs);
 
-        static void calc_cubic_coeff(VecI &x, VecI &y, VecI &derivs, VecI &c2, VecI &c3);
-        static void chfe(VecI &xin, VecI &yin, VecI &xe, VecI &out_ye, int sorted=0);
-        //static void pchfe(VecI &xin, VecI &yin, VecI &XE, VecI &out_newy);
-        // interpolates so that linearity is encouraged along x axis
-        // if out_new_y.length() == 0 then new memory is allocated
-        // otherwise, uses whatever memory is allocated in out_new_y
-        static inline void chfev(int X1, int F1, int D1, int C2, int C3, int XE, int &FE);
-        static inline void chfev_all(int X1, int X2, int F1, int F2, int D1, int D2, int XE, int &FE);
-       // static void chfev(int X1, int X2, int F1, int F2, int D1, int D2, int NE, int *XE, int *FE, int *nlr, int &ierr);
+    static void calc_cubic_coeff(VecI &x, VecI &y, VecI &derivs, VecI &c2, VecI &c3);
+    static void chfe(VecI &xin, VecI &yin, VecI &xe, VecI &out_ye, int sorted=0);
+    //static void pchfe(VecI &xin, VecI &yin, VecI &XE, VecI &out_newy);
+    // interpolates so that linearity is encouraged along x axis
+    // if out_new_y.length() == 0 then new memory is allocated
+    // otherwise, uses whatever memory is allocated in out_new_y
+    static inline void chfev(int X1, int F1, int D1, int C2, int C3, int XE, int &FE);
+    static inline void chfev_all(int X1, int X2, int F1, int F2, int D1, int D2, int XE, int &FE);
+    // static void chfev(int X1, int X2, int F1, int F2, int D1, int D2, int NE, int *XE, int *FE, int *nlr, int &ierr);
 
-        // interpolates so that linearity is encouraged along the xy line
-        // if out_new_y.length() == 0 then new memory is allocated
-        // otherwise, uses whatever memory is allocated in out_new_y
-        static void chfe_xy(VecI &x, VecI &y, VecI &new_x, VecI &out_new_y, int sorted=0);
+    // interpolates so that linearity is encouraged along the xy line
+    // if out_new_y.length() == 0 then new memory is allocated
+    // otherwise, uses whatever memory is allocated in out_new_y
+    static void chfe_xy(VecI &x, VecI &y, VecI &new_x, VecI &out_new_y, int sorted=0);
 
-        static void linear_derivs(VecI &x, VecI &y, VecI &out_derivs);
-        static void linear_interp(VecI &xin, VecI &yin, VecI &xe, VecI &out_ye, int sorted=0);
-        //##### FOR ANY FUNCTION:
-        //                B 
-        //               /|
-        //              / |
-        //             /  |
-        //          c /   |a
-        //           /    |
-        //          /     |
-        //       A --------C
-        //             b
-        //  
+    static void linear_derivs(VecI &x, VecI &y, VecI &out_derivs);
+    static void linear_interp(VecI &xin, VecI &yin, VecI &xe, VecI &out_ye, int sorted=0);
+    //##### FOR ANY FUNCTION:
+    //                B
+    //               /|
+    //              / |
+    //             /  |
+    //          c /   |a
+    //           /    |
+    //          /     |
+    //       A --------C
+    //             b
+    //
         //  cPerp = Perpendicular from C to c
-        //  (sin A)/a = (sin C)/c
-        //  sin C = 1
-        //  c = sqrt(a^2 + b^2)
-        //  sin A = a/c
-        //  cPerp = (a/c)*b      note:   = sin A * b
-        //  cPerp^2 = (ab)^2/(a^2 + b^2)
+    //  (sin A)/a = (sin C)/c
+    //  sin C = 1
+    //  c = sqrt(a^2 + b^2)
+    //  sin A = a/c
+    //  cPerp = (a/c)*b      note:   = sin A * b
+    //  cPerp^2 = (ab)^2/(a^2 + b^2)
 
-        // g(x):  y = x
-        // h(y):  x = y
-        //  a = y - g(x)
+    // g(x):  y = x
+    // h(y):  x = y
+    //  a = y - g(x)
 
-        // b = actual x - (x = actual y)
-        // a = actual y - (y = actual x)
-        // avg residual = SUM(cPerp^2)/N
-        // 
+    // b = actual x - (x = actual y)
+    // a = actual y - (y = actual x)
+    // avg residual = SUM(cPerp^2)/N
+    //
 
-        //###### FOR X=Y
-        // residual^2 = 1/2((Y-X)^2)        note: [or X-Y]
-        static double sum_sq_res_yeqx(VecI &x, VecI &y);
-        // divides the sum of square of residuals by the length of the vector
-        static double avg_sq_res_yeqx(VecI &x, VecI &y);
+    //###### FOR X=Y
+    // residual^2 = 1/2((Y-X)^2)        note: [or X-Y]
+    static double sum_sq_res_yeqx(VecI &x, VecI &y);
+    // divides the sum of square of residuals by the length of the vector
+    static double avg_sq_res_yeqx(VecI &x, VecI &y);
 
-        // returns the average of the absolute values of the differences at
-        // each index
-        static double avg_abs_diff(VecI &x, VecI &y);
-        static void rsq_slope_intercept(VecI &x, VecI &y, double &rsq, double &slope, double &y_intercept);
+    // returns the average of the absolute values of the differences at
+    // each index
+    static double avg_abs_diff(VecI &x, VecI &y);
+    static void rsq_slope_intercept(VecI &x, VecI &y, double &rsq, double &slope, double &y_intercept);
 
     private:
-        void _copy(int *p1, const int *p2, int len) const;
-        static void outliers_from_regression_line(VecI &x, VecI &y, VecI &indices_out);
-        double _zScore(double mean, double sigma, double x);
+    static void outliers_from_regression_line(VecI &x, VecI &y, VecI &indices_out);
+    double _zScore(double mean, double sigma, double x);
 
 }; // End class VecI
 

--- a/3rdparty/obiwarp/vec.h
+++ b/3rdparty/obiwarp/vec.h
@@ -43,8 +43,8 @@ class VecF {
     // shallow is used for a quick copy with which to work
         VecF(const VecF &A);
 
-    float first() { return _dat[0]; }
-    float last() { return _dat[_n-1]; }
+    float first() { return _dat.front(); }
+    float last() { return _dat.back(); }
 
     // Returns the name of the class
     // del needs to be called
@@ -127,6 +127,8 @@ class VecF {
     }
 
     std::vector<float> slice(int start, int end);
+    std::pair<std::vector<float>::iterator, std::vector<float>::iterator> slice2(int start, int end);
+    float* data();
 
     // NOTE: All operators act on the caller!
     // Operators

--- a/3rdparty/obiwarp/vec.h
+++ b/3rdparty/obiwarp/vec.h
@@ -4,12 +4,6 @@
 #include <fstream>
 #include <vector>
 
-/*************************************************************
- * Creation from existing object/array is always deep!.  
- * If you want shallow, use a pointer!
- ************************************************************/ 
-
-
 namespace VEC {
 
 class VecF;
@@ -27,20 +21,21 @@ class VecF {
 
     public:
     // Constructors:
+
+    // Creates an empty VecF vector.
     VecF();
-    // Data values are NOT set by default
+
+    // Creates a VecF with given size but data values are NOT set by default.
     explicit VecF(int n);
+
+    // Creates a VecF with given size and initializes all elements to a given
+    // default value.
     VecF(int n, const float &val);
 
-    // if (shallow == 1 (true)) then no memory is deleted upon destruction
-    // if (shallow == 0 (false)) then delete[] is called
-    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-    VecF(int n, std::vector<float> arr);
+    // Construct using an STL vector.
+    VecF(int n, std::vector<float>& arr);
 
-    // if (shallow == 0 (false)) a DEEP copy is made of the data
-    // if (shallow == 1 (true)) a copy of the pointer is made
-    // if (shallow) then no memory is released upon destruction
-    // shallow is used for a quick copy with which to work
+    // Construct using another VecF.
     VecF(const VecF &A);
 
     float first() { return _dat.front(); }
@@ -49,30 +44,33 @@ class VecF {
     // Returns the name of the class
     // del needs to be called
     char * class_name();
-    // shallow ownership
+
+    // Set the size and internal vector to the given values.
     void set(int n, std::vector<float> arr);
-    // Deletes the object's previous memory (if not shallow) and takes
-    // ownership of the array (destructor call delete[])
-    // shallow in this context only refers to calling delete
-    // no data is copied
-    // deep ownership (no copy is performed)
+
+    // Same as `VecF::set` now, but allowed to remain for legacy semantics.
     void take(int n, std::vector<float> arr);
 
-    void to_f(VecF &out);
+    void to_d(VecD &out);
     void to_i(VecI &out);
 
     // returns the first index at the value, else -1
     int index(float val);
 
-    // shallow ownership
+    // Copies the data and length and essentially becoming a copy of the given
+    // VecF.
     void set(VecF &A);
-    // Deletes previous memory (if not shallow) and takes ownership
-    // of the other's memory.
+
+    // Same as its `VecF::set` equivalent now, but allowed to remain for legacy
+    // semantics.
     void take(VecF &A);
+
     VecF & operator=(const float &val);
     VecF & operator=(VecF &A);
     ~VecF();
-    // A deep copy unless shallow is set
+
+    // Changes the receiver's data and length to match its own, essentially
+    // making them both copies of each other.
     void copy(VecF &receiver) const;
 
     bool operator==(const VecF &A);
@@ -82,6 +80,7 @@ class VecF {
     int size() const { return _n; }
     int dim() const { return _n; }
     int dim1() const { return _n; }
+
     // Returns in a vector all the values matching mask value
     void mask_as_vec(float return_val, VecI &mask, VecF &vec);
 
@@ -145,13 +144,14 @@ class VecF {
     void sub(const VecF &tosub, VecF &out);
     void mul(const VecF &tomul, VecF &out);
     void div(const VecF &todiv, VecF &out);
-    // This may be slow because we cast every value to double regardless
-    void square_root();
 
+    void square_root();
     void logarithm(double base);
     void min_max(float &mn, float &mx);
+
     // alias for min_max
     void mn_mx(float &mn, float &mx) {min_max(mn,mx);}
+
     double avg() const;
     void hist(int num_bins, VecD &bins, VecI &freqs);
     void sample_stats(double &mean, double &std_dev);
@@ -160,6 +160,7 @@ class VecF {
     float sum_of_sq();
 
     void abs_val();
+
     // converts the distribution of values into standard normal
     // Only for floating points right now!
     void std_normal();
@@ -167,8 +168,7 @@ class VecF {
     // uses quicksort to sort the values
     void sort();
 
-    // Removes the value at index and shortens the array by one
-    // not shallow anymore regardless of previous state
+    // Removes the value at index and shortens the array by one.
     void remove(int index);
 
     //VecF operator+(const VecF &A);
@@ -262,20 +262,21 @@ class VecD {
 
     public:
     // Constructors:
+
+    // Creates an empty VecD vector.
     VecD();
-    // Data values are NOT set by default
+
+    // Creates a VecD with given size but data values are NOT set by default.
     explicit VecD(int n);
+
+    // Creates a VecD with given size and initializes all elements to a given
+    // default value.
     VecD(int n, const double &val);
 
-    // if (shallow == 1 (true)) then no memory is deleted upon destruction
-    // if (shallow == 0 (false)) then delete[] is called
-    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-    VecD(int n, std::vector<double> arr);
+    // Construct using an STL vector.
+    VecD(int n, std::vector<double>& arr);
 
-    // if (shallow == 0 (false)) a DEEP copy is made of the data
-    // if (shallow == 1 (true)) a copy of the pointer is made
-    // if (shallow) then no memory is released upon destruction
-    // shallow is used for a quick copy with which to work
+    // Construct using another VecD.
     VecD(const VecD &A);
 
     double first() { return _dat.front(); }
@@ -284,30 +285,33 @@ class VecD {
     // Returns the name of the class
     // del needs to be called
     char * class_name();
-    // shallow ownership
+
+    // Set the size and internal vector to the given values.
     void set(int n, std::vector<double> arr);
-    // Deletes the object's previous memory (if not shallow) and takes
-    // ownership of the array (destructor call delete[])
-    // shallow in this context only refers to calling delete
-    // no data is copied
-    // deep ownership (no copy is performed)
+
+    // Same as `VecD::set` now, but allowed to remain for legacy semantics.
     void take(int n, std::vector<double> arr);
 
-    void to_f(VecD &out);
+    void to_f(VecF &out);
     void to_i(VecI &out);
 
     // returns the first index at the value, else -1
     int index(double val);
 
-    // shallow ownership
+    // Copies the data and length and essentially becoming a copy of the given
+    // VecD.
     void set(VecD &A);
-    // Deletes previous memory (if not shallow) and takes ownership
-    // of the other's memory.
+
+    // Same as its `VecD::set` equivalent now, but allowed to remain for legacy
+    // semantics.
     void take(VecD &A);
+
     VecD & operator=(const double &val);
     VecD & operator=(VecD &A);
     ~VecD();
-    // A deep copy unless shallow is set
+
+    // Changes the receiver's data and length to match its own, essentially
+    // making them both copies of each other.
     void copy(VecD &receiver) const;
 
     bool operator==(const VecD &A);
@@ -317,6 +321,7 @@ class VecD {
     int size() const { return _n; }
     int dim() const { return _n; }
     int dim1() const { return _n; }
+
     // Returns in a vector all the values matching mask value
     void mask_as_vec(double return_val, VecI &mask, VecD &vec);
 
@@ -380,13 +385,14 @@ class VecD {
     void sub(const VecD &tosub, VecD &out);
     void mul(const VecD &tomul, VecD &out);
     void div(const VecD &todiv, VecD &out);
-    // This may be slow because we cast every value to double regardless
-    void square_root();
 
+    void square_root();
     void logarithm(double base);
     void min_max(double &mn, double &mx);
+
     // alias for min_max
     void mn_mx(double &mn, double &mx) {min_max(mn,mx);}
+
     double avg() const;
     void hist(int num_bins, VecD &bins, VecI &freqs);
     void sample_stats(double &mean, double &std_dev);
@@ -395,15 +401,14 @@ class VecD {
     double sum_of_sq();
 
     void abs_val();
+
     // converts the distribution of values into standard normal
-    // Only for doubleing points right now!
     void std_normal();
 
     // uses quicksort to sort the values
     void sort();
 
-    // Removes the value at index and shortens the array by one
-    // not shallow anymore regardless of previous state
+    // Removes the value at index and shortens the array by one.
     void remove(int index);
 
     //VecD operator+(const VecD &A);
@@ -497,20 +502,21 @@ class VecI {
 
     public:
     // Constructors:
+
+    // Creates an empty VecI vector.
     VecI();
-    // Data values are NOT set by default
+
+    // Creates a VecI with given size but data values are NOT set by default.
     explicit VecI(int n);
+
+    // Creates a VecI with given size and initializes all elements to a given
+    // default value.
     VecI(int n, const int &val);
 
-    // if (shallow == 1 (true)) then no memory is deleted upon destruction
-    // if (shallow == 0 (false)) then delete[] is called
-    // FOR THIS CONSTRUCTOR ONLY, there is no DEEP copying, EVER!
-    VecI(int n, std::vector<int> arr);
+    // Construct using an STL vector.
+    VecI(int n, std::vector<int>& arr);
 
-    // if (shallow == 0 (false)) a DEEP copy is made of the data
-    // if (shallow == 1 (true)) a copy of the pointer is made
-    // if (shallow) then no memory is released upon destruction
-    // shallow is used for a quick copy with which to work
+    // Construct using another VecI.
     VecI(const VecI &A);
 
     int first() { return _dat.front(); }
@@ -519,30 +525,33 @@ class VecI {
     // Returns the name of the class
     // del needs to be called
     char * class_name();
-    // shallow ownership
+
+    // Set the size and internal vector to the given values.
     void set(int n, std::vector<int> arr);
-    // Deletes the object's previous memory (if not shallow) and takes
-    // ownership of the array (destructor call delete[])
-    // shallow in this context only refers to calling delete
-    // no data is copied
-    // deep ownership (no copy is performed)
+
+    // Same as `VecI::set` now, but allowed to remain for legacy semantics.
     void take(int n, std::vector<int> arr);
 
-    void to_f(VecI &out);
-    void to_i(VecI &out);
+    void to_f(VecF &out);
+    void to_d(VecD &out);
 
     // returns the first index at the value, else -1
     int index(int val);
 
-    // shallow ownership
+    // Copies the data and length and essentially becoming a copy of the given
+    // VecI.
     void set(VecI &A);
-    // Deletes previous memory (if not shallow) and takes ownership
-    // of the other's memory.
+
+    // Same as its `VecI::set` equivalent now, but allowed to remain for legacy
+    // semantics.
     void take(VecI &A);
+
     VecI & operator=(const int &val);
     VecI & operator=(VecI &A);
     ~VecI();
-    // A deep copy unless shallow is set
+
+    // Changes the receiver's data and length to match its own, essentially
+    // making them both copies of each other.
     void copy(VecI &receiver) const;
 
     bool operator==(const VecI &A);
@@ -552,6 +561,7 @@ class VecI {
     int size() const { return _n; }
     int dim() const { return _n; }
     int dim1() const { return _n; }
+
     // Returns in a vector all the values matching mask value
     void mask_as_vec(int return_val, VecI &mask, VecI &vec);
 
@@ -615,13 +625,14 @@ class VecI {
     void sub(const VecI &tosub, VecI &out);
     void mul(const VecI &tomul, VecI &out);
     void div(const VecI &todiv, VecI &out);
-    // This may be slow because we cast every value to double regardless
-    void square_root();
 
+    void square_root();
     void logarithm(double base);
     void min_max(int &mn, int &mx);
+
     // alias for min_max
     void mn_mx(int &mn, int &mx) {min_max(mn,mx);}
+
     double avg() const;
     void hist(int num_bins, VecD &bins, VecI &freqs);
     void sample_stats(double &mean, double &std_dev);
@@ -630,15 +641,14 @@ class VecI {
     int sum_of_sq();
 
     void abs_val();
+
     // converts the distribution of values into standard normal
-    // Only for inting points right now!
     void std_normal();
 
     // uses quicksort to sort the values
     void sort();
 
-    // Removes the value at index and shortens the array by one
-    // not shallow anymore regardless of previous state
+    // Removes the value at index and shortens the array by one.
     void remove(int index);
 
     //VecI operator+(const VecI &A);

--- a/3rdparty/obiwarp/vec.h
+++ b/3rdparty/obiwarp/vec.h
@@ -41,7 +41,7 @@ class VecF {
     // if (shallow == 1 (true)) a copy of the pointer is made
     // if (shallow) then no memory is released upon destruction
     // shallow is used for a quick copy with which to work
-        VecF(const VecF &A);
+    VecF(const VecF &A);
 
     float first() { return _dat.front(); }
     float last() { return _dat.back(); }
@@ -87,9 +87,9 @@ class VecF {
 
     // Returns true if all values are the same, false otherwise
     bool all_equal() {
-            float _min, _max; min_max(_min, _max);
+        float _min, _max; min_max(_min, _max);
         if (_min == _max) { return 1; }
-            else { return 0; }
+        else { return 0; }
     }
 
     float& operator[](int i) {
@@ -98,14 +98,14 @@ class VecF {
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
     const float& operator[](int i) const {
 #ifdef JTP_BOUNDS_CHECK
         if (i < 0) { puts("index < 0 !"); exit(1); }
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
 
     float& at(int i) {
 #ifdef JTP_BOUNDS_CHECK
@@ -113,14 +113,14 @@ class VecF {
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
     const float& at(int i) const {
 #ifdef JTP_BOUNDS_CHECK
         if (i < 0) { puts("index < 0 !"); exit(1); }
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
 
     bool shallow() {
         return false;
@@ -169,7 +169,7 @@ class VecF {
 
     // Removes the value at index and shortens the array by one
     // not shallow anymore regardless of previous state
-        void remove(int index);
+    void remove(int index);
 
     //VecF operator+(const VecF &A);
     //void operator++();
@@ -179,7 +179,7 @@ class VecF {
     static int pchst(float arg1, float arg2) {
         if      (arg1*arg2 > 0) { return  1; }
         else if (arg1*arg2 < 0) { return -1; }
-            else                    { return  0; }
+        else                    { return  0; }
     }
 
     static double pearsons_r(VecF &x, VecF &y);
@@ -219,7 +219,7 @@ class VecF {
     //       A --------C
     //             b
     //
-        //  cPerp = Perpendicular from C to c
+    //  cPerp = Perpendicular from C to c
     //  (sin A)/a = (sin C)/c
     //  sin C = 1
     //  c = sqrt(a^2 + b^2)
@@ -276,10 +276,10 @@ class VecD {
     // if (shallow == 1 (true)) a copy of the pointer is made
     // if (shallow) then no memory is released upon destruction
     // shallow is used for a quick copy with which to work
-        VecD(const VecD &A);
+    VecD(const VecD &A);
 
-    double first() { return _dat[0]; }
-    double last() { return _dat[_n-1]; }
+    double first() { return _dat.front(); }
+    double last() { return _dat.back(); }
 
     // Returns the name of the class
     // del needs to be called
@@ -322,9 +322,9 @@ class VecD {
 
     // Returns true if all values are the same, false otherwise
     bool all_equal() {
-            double _min, _max; min_max(_min, _max);
+        double _min, _max; min_max(_min, _max);
         if (_min == _max) { return 1; }
-            else { return 0; }
+        else { return 0; }
     }
 
     double& operator[](int i) {
@@ -333,14 +333,14 @@ class VecD {
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
     const double& operator[](int i) const {
 #ifdef JTP_BOUNDS_CHECK
         if (i < 0) { puts("index < 0 !"); exit(1); }
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
 
     double& at(int i) {
 #ifdef JTP_BOUNDS_CHECK
@@ -348,20 +348,22 @@ class VecD {
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
     const double& at(int i) const {
 #ifdef JTP_BOUNDS_CHECK
         if (i < 0) { puts("index < 0 !"); exit(1); }
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
 
     bool shallow() {
         return false;
     }
 
     std::vector<double> slice(int start, int end);
+    std::pair<std::vector<double>::iterator, std::vector<double>::iterator> slice2(int start, int end);
+    double* data();
 
     // NOTE: All operators act on the caller!
     // Operators
@@ -402,7 +404,7 @@ class VecD {
 
     // Removes the value at index and shortens the array by one
     // not shallow anymore regardless of previous state
-        void remove(int index);
+    void remove(int index);
 
     //VecD operator+(const VecD &A);
     //void operator++();
@@ -412,7 +414,7 @@ class VecD {
     static int pchst(double arg1, double arg2) {
         if      (arg1*arg2 > 0) { return  1; }
         else if (arg1*arg2 < 0) { return -1; }
-            else                    { return  0; }
+        else                    { return  0; }
     }
 
     static double pearsons_r(VecD &x, VecD &y);
@@ -452,7 +454,7 @@ class VecD {
     //       A --------C
     //             b
     //
-        //  cPerp = Perpendicular from C to c
+    //  cPerp = Perpendicular from C to c
     //  (sin A)/a = (sin C)/c
     //  sin C = 1
     //  c = sqrt(a^2 + b^2)
@@ -509,10 +511,10 @@ class VecI {
     // if (shallow == 1 (true)) a copy of the pointer is made
     // if (shallow) then no memory is released upon destruction
     // shallow is used for a quick copy with which to work
-        VecI(const VecI &A);
+    VecI(const VecI &A);
 
-    int first() { return _dat[0]; }
-    int last() { return _dat[_n-1]; }
+    int first() { return _dat.front(); }
+    int last() { return _dat.back(); }
 
     // Returns the name of the class
     // del needs to be called
@@ -555,9 +557,9 @@ class VecI {
 
     // Returns true if all values are the same, false otherwise
     bool all_equal() {
-            int _min, _max; min_max(_min, _max);
+        int _min, _max; min_max(_min, _max);
         if (_min == _max) { return 1; }
-            else { return 0; }
+        else { return 0; }
     }
 
     int& operator[](int i) {
@@ -566,14 +568,14 @@ class VecI {
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
     const int& operator[](int i) const {
 #ifdef JTP_BOUNDS_CHECK
         if (i < 0) { puts("index < 0 !"); exit(1); }
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
 
     int& at(int i) {
 #ifdef JTP_BOUNDS_CHECK
@@ -581,20 +583,22 @@ class VecI {
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
     const int& at(int i) const {
 #ifdef JTP_BOUNDS_CHECK
         if (i < 0) { puts("index < 0 !"); exit(1); }
         if (i >= _n) { puts("i >= _n !"); exit(1); }
 #endif
         return _dat[i];
-        }
+    }
 
     bool shallow() {
         return false;
     }
 
     std::vector<int> slice(int start, int end);
+    std::pair<std::vector<int>::iterator, std::vector<int>::iterator> slice2(int start, int end);
+    int* data();
 
     // NOTE: All operators act on the caller!
     // Operators
@@ -635,7 +639,7 @@ class VecI {
 
     // Removes the value at index and shortens the array by one
     // not shallow anymore regardless of previous state
-        void remove(int index);
+    void remove(int index);
 
     //VecI operator+(const VecI &A);
     //void operator++();
@@ -645,7 +649,7 @@ class VecI {
     static int pchst(int arg1, int arg2) {
         if      (arg1*arg2 > 0) { return  1; }
         else if (arg1*arg2 < 0) { return -1; }
-            else                    { return  0; }
+        else                    { return  0; }
     }
 
     static double pearsons_r(VecI &x, VecI &y);
@@ -685,7 +689,7 @@ class VecI {
     //       A --------C
     //             b
     //
-        //  cPerp = Perpendicular from C to c
+    //  cPerp = Perpendicular from C to c
     //  (sin A)/a = (sin C)/c
     //  sin C = 1
     //  c = sqrt(a^2 + b^2)

--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -332,20 +332,33 @@ bool Aligner::alignSampleRts(mzSample* sample,
                              bool setAsReference,
                              const MavenParameters* mp)
 {
+    // we set the rt interval using the reference sample
+    int rtBinSize = 1;
+    if (setAsReference && sample != nullptr) {
+        rtBinSize = mzUtils::approximateResamplingFactor(sample->scanCount(),
+                                                         500);
+    } else if (refSample != nullptr) {
+        rtBinSize = mzUtils::approximateResamplingFactor(refSample->scanCount(),
+                                                         500);
+    }
+
     vector<float> rtPoints;
     vector<vector<float> > mxn;
 
-    int mxnCount = 0;
+    int intervalCounter = 0;
     for(auto scan: sample->scans) {
-        if(mp->stop) return (true);
-        if(scan->mslevel == 1 ) {
+        if (mp->stop) return (true);
+        if (scan->mslevel == 1 && (intervalCounter % rtBinSize == 0 || scan == sample->scans.back())) {
             rtPoints.push_back(scan->originalRt);
             mxn.push_back(vector<float> (mzPoints.size()));
         }
+        ++intervalCounter;
     }
 
+    intervalCounter = 0;
+    int mxnCount = 0;
     for(auto scan: sample->scans) {
-        if(scan->mslevel == 1) {
+        if (scan->mslevel == 1 && (intervalCounter % rtBinSize == 0 || scan == sample->scans.back())) {
             mxnCount++;
             for(int i = 0; i <  scan->mz.size(); i++) {
                 if (mp->stop) return (true);
@@ -355,22 +368,37 @@ bool Aligner::alignSampleRts(mzSample* sample,
                 mxn[mxnCount - 1][index] = max(mxn[mxnCount -1][index], scan->intensity.at(i));
             }
         }
+        ++intervalCounter;
     }
 
-    
     if (setAsReference) {
         if (mp->stop) return (true);
         obiWarp.setReferenceData(rtPoints, mzPoints, mxn);
     }
     else {
+        vector<float> updatedRtPoints = obiWarp.align(rtPoints, mzPoints, mxn);
+        if (updatedRtPoints.empty())
+            return(true);
 
-        rtPoints = obiWarp.align(rtPoints, mzPoints, mxn);
-        if (rtPoints.empty()) return(true);
-        for(int j = 0, i=0 ; j < rtPoints.size(); i++) {
-            if(sample->scans.at(i)->mslevel ==1) {
-                sample->scans.at(i)->rt = rtPoints.at(j);
-                j++;
+        // perform segmented alignment
+        AlignmentSegment* lastSegment = nullptr;
+        for (int i = 0; i < rtPoints.size(); ++i) {
+            auto originalRt = rtPoints.at(i);
+            auto updatedRt = updatedRtPoints.at(i);
+            AlignmentSegment* seg = new AlignmentSegment();
+            seg->sampleName = sample->sampleName;
+            seg->segStart = 0;
+            seg->segEnd = originalRt;
+            seg->newStart = 0;
+            seg->newEnd = updatedRt;
+
+            if (lastSegment and lastSegment->sampleName == seg->sampleName) {
+                seg->segStart = lastSegment->segEnd;
+                seg->newStart = lastSegment->newEnd;
             }
+
+            addSegment(sample->sampleName, seg);
+            lastSegment = seg;
         }
     }
     return (false);
@@ -431,6 +459,8 @@ bool Aligner::alignWithObiWarp(vector<mzSample*> samples,
         return (true);
     }
 
+    _alignmentSegments.clear();
+    setSamples(samples);
     int samplesAligned = 0;
     #pragma omp parallel for shared(samplesAligned)
     for (int i = 0; i < samples.size(); ++i) {
@@ -448,6 +478,8 @@ bool Aligner::alignWithObiWarp(vector<mzSample*> samples,
             setAlignmentProgress("Aligning samples", samplesAligned, samples.size()-1);
         }
     }
+    setAlignmentProgress("Performing post-alignment interpolation…", 1, 1);
+    performSegmentedAlignment();
 
     cerr << "Samples modified: " << samplesAligned << endl;
     delete obiWarp;

--- a/src/core/libmaven/mzAligner.cpp
+++ b/src/core/libmaven/mzAligner.cpp
@@ -335,10 +335,10 @@ bool Aligner::alignSampleRts(mzSample* sample,
     // we set the rt interval using the reference sample
     int rtBinSize = 1;
     if (setAsReference && sample != nullptr) {
-        rtBinSize = mzUtils::approximateResamplingFactor(sample->scanCount(),
+        rtBinSize = mzUtils::approximateResamplingFactor(sample->ms1ScanCount(),
                                                          500);
     } else if (refSample != nullptr) {
-        rtBinSize = mzUtils::approximateResamplingFactor(refSample->scanCount(),
+        rtBinSize = mzUtils::approximateResamplingFactor(refSample->ms1ScanCount(),
                                                          500);
     }
 

--- a/src/core/libmaven/mzUtils.cpp
+++ b/src/core/libmaven/mzUtils.cpp
@@ -1139,4 +1139,19 @@ Series:  Prentice-Hall Series in Automatic Computation
         return buf.vec;
     }
 
+    chrono::time_point<chrono::high_resolution_clock> startTimer()
+    {
+        return chrono::high_resolution_clock::now();
+    }
+
+    void stopTimer(chrono::time_point<chrono::high_resolution_clock>& clock,
+                   string name)
+    {
+        auto now = chrono::high_resolution_clock::now();
+        auto diff = now - clock;
+        cerr << "RUNTIME OF " << name << ": "
+             << chrono::duration_cast<chrono::milliseconds>(diff).count()
+             << " ms\n";
+    }
+
 } //namespace end

--- a/src/core/libmaven/mzUtils.cpp
+++ b/src/core/libmaven/mzUtils.cpp
@@ -1113,9 +1113,9 @@ Series:  Prentice-Hall Series in Automatic Computation
         return firDesignKaiser(numTaps, fc, beta, interpRate);
     }
 
-    int approximateResamplingFactor(const size_t dataSize)
+    int approximateResamplingFactor(const size_t dataSize, int lowerSizeLimit)
     {
-        int resamplingFactor = static_cast<int>(dataSize / 100) - 1;
+        int resamplingFactor = static_cast<int>(dataSize / lowerSizeLimit) - 1;
         if (resamplingFactor < 1)
             resamplingFactor = 1;
 

--- a/src/core/libmaven/mzUtils.h
+++ b/src/core/libmaven/mzUtils.h
@@ -642,9 +642,12 @@ namespace mzUtils {
          * estimate an optimal resampling factor, without losing information, it
          * would have to consider the nature of the signal itself.
          * @param dataSize Length of the digital signal.
+         * @param lowerSizeLimit Length which the returned resampling factor is
+         * guaranteed to not cross if used to resize data of given size.
          * @return A integer resampling factor (always ≥ 1).
          */
-        int approximateResamplingFactor(size_t dataSize);
+        int approximateResamplingFactor(size_t dataSize,
+                                        int lowerSizeLimit=100);
 
         /**
          * @brief Resample an input signal according to the given interpolation

--- a/src/core/libmaven/mzUtils.h
+++ b/src/core/libmaven/mzUtils.h
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <iostream>
+#include <chrono>
 
 #include "standardincludes.h"
 #include "statistics.h"
@@ -659,6 +661,28 @@ namespace mzUtils {
         std::vector<double> resample(const std::vector<double>& inputData,
                                      int interpRate,
                                      int decimRate);
+
+        /**
+         * @brief Create a clock that can be used to indicate the start of an
+         * operation which needs to be timed.
+         * @return A high resolution `time_point` value representing the current
+         * point in time.
+         */
+        chrono::time_point<chrono::high_resolution_clock> startTimer();
+
+        /**
+         * @brief Given a high resolution time point, prints the difference
+         * between the given time point and the current point in time.
+         * @details Despite its name, this function does not really stop
+         * anything but exists only to print a difference between given and
+         * current time points. Wrapping an operation with `startTimer` and
+         * `stopTimer` to record its runtime makes idiomatic sense.
+         * @param clock A high resolution time point object.
+         * @param name The name of the operation, which elapsed time will be
+         * attributed to.
+         */
+        void stopTimer(chrono::time_point<chrono::high_resolution_clock>& clock,
+                       string name);
 }
 
 template <typename T>


### PR DESCRIPTION
This PR primarily contains two changes that improve the overall user experience with OBI-Warp alignment using El-MAVEN:
 1. Make changes to the OBI-Warp library itself such that it uses safer (i.e., no manual allocation/deallocation or pointer based indexing) STL containers for its core vector (`VecF` `VecD` and `VecI`) and matrix (`matF`, `matD` and `matI`) data structures. These changes were made because, even after a [previous fix](https://github.com/ElucidataInc/ElMaven/pull/1085), we were observing certain crashes due to freeing of allocated memory associated with vectors and matrices at multiple different points in the library. While this whole change has had some effect on performance, the most often called methods have been optimized to keep the decline in performance to a minimal.
 2. Call OBI-Warp from `mzAligner` with only a sparse representation of the data set being aligned. This improves the runtime (since warping on less data points will obviously be faster) and we can interpolate the updated RT values for the remaining data points that were not sent to OBI-Warp for alignment. The interpolation logic is the same as the one that we use when restoring alignment values from emDB, using the segmented alignment technique (borrowed from MAVEN).
