### PR TITLE
Fix progress bar update during peak detection

### DIFF
--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -30,8 +30,8 @@ BackgroundPeakUpdate::BackgroundPeakUpdate(QWidget*) {
         _stopped = true;
         setTerminationEnabled(true);
         runFunction = "computeKnowsPeaks";
-        peakDetector = new PeakDetector();
-        peakDetector->boostSignal.connect(boost::bind(&BackgroundPeakUpdate::qtSlot, this, _1, _2, _3));
+        peakDetector = nullptr;
+        setPeakDetector(new PeakDetector());
 }
 
 QString BackgroundPeakUpdate::printSettings() {
@@ -384,6 +384,19 @@ void BackgroundPeakUpdate::writeCSVRep(string setName)
                 csvreports = NULL;
         }
         Q_EMIT(updateProgressBar("Done", 1, 1));
+}
+
+void BackgroundPeakUpdate::setPeakDetector(PeakDetector *pd)
+{
+    if (peakDetector != nullptr)
+        delete peakDetector;
+
+    peakDetector = pd;
+    peakDetector->boostSignal.connect(boost::bind(&BackgroundPeakUpdate::qtSlot,
+                                                  this,
+                                                  _1,
+                                                  _2,
+                                                  _3));
 }
 
 void BackgroundPeakUpdate::processSlices() {

--- a/src/gui/mzroll/background_peaks_update.h
+++ b/src/gui/mzroll/background_peaks_update.h
@@ -49,9 +49,7 @@ public:
 	 * [set Peak Detector]
 	 * @param pd [pointer to peakDetector]
 	 */
-	void setPeakDetector(PeakDetector* pd) {
-                peakDetector = pd;
-	}
+        void setPeakDetector(PeakDetector* pd);
 
 	/**
 	 * [get Peak Detector]


### PR DESCRIPTION
Whenever `BackgroundPeakUpdate` thread has its `PeakDetector` object changed, there was no connection being made between the detector and the thread (`BackgroundPeakUpdate`) object, and all update messages were being lost. This connection will now be made everytime the detector object is changed for `BackgroundPeakUpdate`.