### PR TITLE
[Fix] Find compound by ID when loading mzroll

### DIFF
--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -226,6 +226,17 @@ vector<Compound*> Database::findSpeciesByName(string name, string dbname) {
 		return set;
 }
 
+vector<Compound*> Database::findSpeciesById(string id, string dbName) {
+    vector<Compound*> matches;
+    for (auto compound : compoundsDB) {
+        if (compound->id == id && compound->db == dbName) {
+            matches.push_back(compound);
+        }
+    }
+
+    return matches;
+}
+
 void Database::loadReactions(string db) {
 
 		map<string, Reaction*> seenReactions;

--- a/src/gui/mzroll/database.h
+++ b/src/gui/mzroll/database.h
@@ -92,6 +92,7 @@ class Database {
 	deque<Compound*> getCompoundsDB(){ 	return compoundsDB;}
 	set<Compound*> findSpeciesByMass(float mz, MassCutoff *massCutoff);
 	vector<Compound*> findSpeciesByName(string name, string dbname);
+	vector<Compound*> findSpeciesById(string id, string dbName);
 
 	void loadRetentionTimes(QString method);
 	void saveRetentionTime(Compound* c, float rt, QString method);

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -1175,9 +1175,18 @@ PeakGroup* mzFileIO::readGroupXML(QXmlStreamReader& xml, PeakGroup* parent)
         if (matches.size() > 0)
             group->compound = matches[0];
     } else if (!compoundId.empty()) {
-        Compound* c = DB.findSpeciesByIdAndName(compoundId,
-                                                group->compound->name,
-                                                DB.ANYDATABASE);
+        Compound* c = nullptr;
+
+        if (group->compound && !group->compound->name.empty()) {
+            c = DB.findSpeciesByIdAndName(compoundId,
+                                          group->compound->name,
+                                          DB.ANYDATABASE);
+        } else if (!compoundDB.empty()) {
+            vector<Compound*> matches = DB.findSpeciesById(compoundId, compoundDB);
+            if (matches.size())
+                c = matches[0];
+        }
+        
         if (c)
             group->compound = c;
     }


### PR DESCRIPTION
The .mzroll files have a compound name, id and db name attached to every
group. In case the name is not available, El-MAVEN should search for
compounds using the compound ID and DB, instead of trying to access
group's compound name