### PR TITLE
Compare distinct MS2 fragmentation spectra

### DIFF
--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -699,8 +699,12 @@ QList<Compound*> LigandWidget::parseXMLRemoteCompounds()
 
 Compound* LigandWidget::getSelectedCompound() { 
     //Merged with Maven776
-	//get current compound
-    QTreeWidgetItem* item = treeWidget->selectedItems().first();
+    //get current compound
+    auto selectedItems = treeWidget->selectedItems();
+    if (selectedItems.isEmpty())
+        return nullptr;
+
+    QTreeWidgetItem* item = selectedItems.first();
     if (!item) return NULL;
 
     QVariant v = item->data(0,Qt::UserRole);

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -316,7 +316,7 @@ using namespace mzUtils;
 	//set main dock widget
 	eicWidget = new EicWidget(this);
 	spectraWidget = new SpectraWidget(this);
-	fragSpectraWidget = new SpectraWidget(this);
+    fragSpectraWidget = new SpectraWidget(this, true);
 	customPlot = new QCustomPlot(this);
     groupRtVizPlot = new QCustomPlot(this);
     sampleRtVizPlot = new QCustomPlot(this);

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -209,6 +209,8 @@ void EicPoint::_updateWidgetsForScan(MainWindow* mw, Scan* scan)
         }
         if (mw->spectraWidget->isVisible())
             mw->spectraWidget->setScan(scan);
+        if (mw->fragSpectraWidget->isVisible())
+            mw->fragSpectraWidget->overlayScan(scan);
         if(scan->mslevel == 2)
             mw->spectralHitsDockWidget->limitPrecursorMz(scan->precursorMz);
     }

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -203,10 +203,14 @@ void EicPoint::_updateWidgetsForPeakGroup(MainWindow* mw,
 void EicPoint::_updateWidgetsForScan(MainWindow* mw, Scan* scan)
 {
     if(scan) {
-        if (mw->spectraWidget->isVisible())
+        if (mw->spectraWidget)
             mw->spectraWidget->setScan(scan);
-        if (mw->fragSpectraWidget->isVisible())
+        if (mw->fragSpectraWidget) {
+            mw->fragSpectraDockWidget->setVisible(true);
+            mw->fragSpectraDockWidget->raise();
             mw->fragSpectraWidget->overlayScan(scan);
+            mw->fragSpectraWidget->overlayCompoundFragmentation(mw->ligandWidget->getSelectedCompound());
+        }
         if(scan->mslevel == 2)
             mw->spectralHitsDockWidget->limitPrecursorMz(scan->precursorMz);
     }

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -203,10 +203,6 @@ void EicPoint::_updateWidgetsForPeakGroup(MainWindow* mw,
 void EicPoint::_updateWidgetsForScan(MainWindow* mw, Scan* scan)
 {
     if(scan) {
-        if (mw->spectraDockWidget) {
-            mw->spectraDockWidget->setVisible(true);
-            mw->spectraDockWidget->raise();
-        }
         if (mw->spectraWidget->isVisible())
             mw->spectraWidget->setScan(scan);
         if (mw->fragSpectraWidget->isVisible())

--- a/src/gui/mzroll/spectralhitstable.cpp
+++ b/src/gui/mzroll/spectralhitstable.cpp
@@ -378,9 +378,10 @@ void SpectralHitsDockWidget::showSelectedGroup() {
             _mainwindow->getEicWidget()->setMzSlice(hit->precursorMz);
         }
 
-        if(hit->scan)
+        if(hit->scan) {
             _mainwindow->getSpectraWidget()->setScan(hit->scan);
-
+            _mainwindow->fragSpectraWidget->overlayScan(hit->scan);
+        }
 }
 
 QList<SpectralHit*> SpectralHitsDockWidget::getSelectedHits() {

--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -115,7 +115,7 @@ void SpectraWidget::_placeLabels()
 
     QString upperLabelText = tr("<b>Group Spectra</b>");
     QString lowerLabelText = tr("<b>Reference Spectra</b>");
-    if (_overlayMode == OverlayMode::Individual)
+    if (_overlayMode == OverlayMode::Raw)
         upperLabelText = tr("<b>MS2 Spectra (Rt: %1)</b>")
                              .arg(QString::number(_currentScan->rt, 'f', 2));
 
@@ -357,7 +357,7 @@ void SpectraWidget::overlayScan(Scan *scan)
     if (_overlayMode == OverlayMode::None || scan->mslevel != 2)
         return;
 
-    _overlayMode = OverlayMode::Individual;
+    _overlayMode = OverlayMode::Raw;
     setScan(scan);
     if (_currentGroup.compound)
         overlayCompoundFragmentation(_currentGroup.compound);

--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -14,7 +14,7 @@
 #include "spectramatching.h"
 #include "spectrawidget.h"
 
-SpectraWidget::SpectraWidget(MainWindow* mw) { 
+SpectraWidget::SpectraWidget(MainWindow* mw, bool isFragSpectra) {
     this->mainwindow = mw;
     eicparameters = new EICLogic();
    _currentScan = nullptr;
@@ -23,7 +23,7 @@ SpectraWidget::SpectraWidget(MainWindow* mw) {
    _spectralHit = SpectralHit();
    _lowerLabel = nullptr;
    _upperLabel = nullptr;
-   _overlayMode = OverlayMode::Raw;
+   _overlayMode = isFragSpectra ? OverlayMode::Raw : OverlayMode::None;
 
     initPlot();
 
@@ -826,7 +826,12 @@ void SpectraWidget::showLastFullScan() { incrementScan(-1, 1); }
 
 void SpectraWidget::incrementScan(int increment, int msLevel=0 )
 {
-	if (_currentScan == NULL || _currentScan->sample == NULL) return;
+    // increment only for non-overlay spectra having a scan for a sample
+    if (_currentScan == NULL
+        || _currentScan->sample == NULL
+        || _overlayMode != OverlayMode::None) {
+        return;
+    }
 
 	mzSample* sample = _currentScan->getSample();
     if (sample == NULL) return;

--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -23,6 +23,7 @@ SpectraWidget::SpectraWidget(MainWindow* mw) {
    _spectralHit = SpectralHit();
    _lowerLabel = nullptr;
    _upperLabel = nullptr;
+   _overlayMode = OverlayMode::None;
 
     initPlot();
 
@@ -278,6 +279,7 @@ void SpectraWidget::overlayPeakGroup(PeakGroup* group)
         //if (!group->compound->smileString.empty()) overlayTheoreticalSpectra(group->compound);
     }
     delete(avgScan);
+    _overlayMode = OverlayMode::Consensus;
 }
 
 void SpectraWidget::overlayCompoundFragmentation(Compound* c)
@@ -341,6 +343,18 @@ void SpectraWidget::overlaySpectralHit(SpectralHit& hit)
             _focusCoord.setY(0.0f);
         }
         delete productMassCutoff;
+}
+
+void SpectraWidget::overlayScan(Scan *scan)
+{
+    if (_overlayMode == OverlayMode::None || scan->mslevel != 2)
+        return;
+
+    setScan(scan);
+    if (_currentGroup.compound)
+        overlayCompoundFragmentation(_currentGroup.compound);
+
+    _overlayMode = OverlayMode::Individual;
 }
 
 void SpectraWidget::showConsensusSpectra(PeakGroup* group)
@@ -432,6 +446,7 @@ void SpectraWidget::clearGraph() {
     }
     _items.clear();
     scene()->setSceneRect(10,10,this->width()-10, this->height()-10);
+    _overlayMode = OverlayMode::None;
 }
 
 void SpectraWidget::clearOverlay()

--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -23,7 +23,7 @@ SpectraWidget::SpectraWidget(MainWindow* mw) {
    _spectralHit = SpectralHit();
    _lowerLabel = nullptr;
    _upperLabel = nullptr;
-   _overlayMode = OverlayMode::None;
+   _overlayMode = OverlayMode::Raw;
 
     initPlot();
 
@@ -116,7 +116,7 @@ void SpectraWidget::_placeLabels()
     QString upperLabelText = tr("<b>Group Spectra</b>");
     QString lowerLabelText = tr("<b>Reference Spectra</b>");
     if (_overlayMode == OverlayMode::Raw)
-        upperLabelText = tr("<b>MS2 Spectra (Rt: %1)</b>")
+        upperLabelText = tr("<b>Raw Spectra (Rt: %1)</b>")
                              .arg(QString::number(_currentScan->rt, 'f', 2));
 
     QFont font = QApplication::font();

--- a/src/gui/mzroll/spectrawidget.h
+++ b/src/gui/mzroll/spectrawidget.h
@@ -24,7 +24,7 @@ public:
         Raw
     };
 
-    SpectraWidget(MainWindow* mw);
+    SpectraWidget(MainWindow* mw, bool isFragSpectra = false);
     static vector<mzLink> findLinks(float centerMz, Scan* scan, MassCutoff *massCutoff, int ionizationMode);
 
         public Q_SLOTS:

--- a/src/gui/mzroll/spectrawidget.h
+++ b/src/gui/mzroll/spectrawidget.h
@@ -18,6 +18,12 @@ class SpectraWidget : public QGraphicsView
 {
     Q_OBJECT
 public:
+    enum class OverlayMode {
+        None,
+        Consensus,
+        Individual
+    };
+
     SpectraWidget(MainWindow* mw);
     static vector<mzLink> findLinks(float centerMz, Scan* scan, MassCutoff *massCutoff, int ionizationMode);
 
@@ -41,6 +47,18 @@ public:
                     void overlayPeakGroup(PeakGroup* group);
                     void overlayPeptideFragmentation(QString proteinSeq,MassCutoff *productMassCutoff); //TODO: Sahil, Added while merging point
                     void overlayCompoundFragmentation(Compound* c);
+
+                    /**
+                     * @brief Draw an individual scan and compare it with the
+                     * current reference spectra.
+                     * @details This method should be called once a group's MS2
+                     * spectra has been set (using `overlayPeakGroup`) and there
+                     * exists a reference MS2 spectra to compare against.
+                     * @param scan The MS2 level scan that will be compared with
+                     * current reference spectra.
+                     */
+                    void overlayScan(Scan* scan);
+
                     void showConsensusSpectra(PeakGroup* group);
                     void overlaySpectralHit(SpectralHit& hit);
                     void drawSpectralHit(SpectralHit& hit); //TODO: Sahil, Added while merging spectrawidget
@@ -105,6 +123,7 @@ public:
                     vector<int> chargeStates;
                     vector<int> peakClusters;
 
+                    OverlayMode _overlayMode;
 
                     void initPlot();
                     void addAxes();

--- a/src/gui/mzroll/spectrawidget.h
+++ b/src/gui/mzroll/spectrawidget.h
@@ -21,7 +21,7 @@ public:
     enum class OverlayMode {
         None,
         Consensus,
-        Individual
+        Raw
     };
 
     SpectraWidget(MainWindow* mw);

--- a/src/gui/mzroll/treedockwidget.cpp
+++ b/src/gui/mzroll/treedockwidget.cpp
@@ -108,8 +108,10 @@ void TreeDockWidget::showInfo() {
                                         mainwindow->spectraDockWidget->raise();
                                     }
 
-                                    if (scan->mslevel == 2)
+                                    if (scan->mslevel == 2) {
                                         mainwindow->massCalcWidget->setFragmentationScan(scan);
+                                        mainwindow->fragSpectraWidget->overlayScan(scan);
+                                    }
 
                                     mainwindow->getSpectraWidget()->setScan(scan);
                                     mainwindow->getEicWidget()->setFocusLine(scan->rt);


### PR DESCRIPTION
This change enables comparison of MS2 spectra of individual MS2 events with reference spectra. This comparison can be done either by clicking on MS2 events in the EIC or by browsing MS2 events in the events list.

Additionally, group consensus spectra is differentiated from individual MS2 event spectra by appropriate labels as well as colors.
