### PR TITLE
Activate and populate EPI elements after failure

### DIFF
--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -361,6 +361,7 @@ void PollyElmavenInterfaceDialog::showEPIError(QString errorMessage)
 {
     _resetUiElements();
     _showErrorMessage("Polly Error", errorMessage, QMessageBox::NoIcon);
+    _performPostUploadTasks(false);
     _populateProjects();
     _populateTables();
     _hideFormIfNotLicensed();
@@ -986,7 +987,11 @@ void PollyElmavenInterfaceDialog::_performPostUploadTasks(bool uploadSuccessful)
     projectOptions->setEnabled(true);
     workflowMenu->setEnabled(true);
     statusUpdate->setEnabled(true);
-    statusUpdate->setStyleSheet("QLabel { color : green;}");
+    if (uploadSuccessful) {
+        statusUpdate->setStyleSheet("QLabel { color : green; }");
+    } else {
+        statusUpdate->setStyleSheet("QLabel { color : red; }");
+    }
     statusUpdate->clear();
 }
 


### PR DESCRIPTION
After an EPI request failure, the elements of the Polly interface dialog remained inactive and the user will not be able to continue with the same dialog instance (closing and reopening the dialog,
once the internet returns is the only option). This behaviour has been fixed: UI elements are reactivated once the error message is accepted.

Issue: #1109