### PR TITLE
Remove child from the children vector on delete

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -265,16 +265,21 @@ bool PeakGroup::deleteChild(unsigned int index) {
 }
 
 bool PeakGroup::deleteChild(PeakGroup* child ) {
-    if (!child) return false;
+    if (!child)
+        return false;
 
-    vector<PeakGroup>::iterator it;
-    it = find(children.begin(),children.end(),child);
-    if ( *it == child ) {
-        cerr << "deleteChild: setting child to empty";
+    auto preDeletionChildCount = children.size();
+    children.erase(remove_if(begin(children),
+                             end(children),
+                             [&](PeakGroup& group) {
+                                 return child == &group;
+                             }),
+                   children.end());
+
+    // child was found and removed
+    if (children.size() != preDeletionChildCount) {
         child->clear();
         return true;
-        //sort(children.begin(), children.end(),PeakGroup::compIntensity);
-        //for(int i=0; i < children.size(); i++ ) { cerr << &children[i] << endl; }
     }
 
     return false;

--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -277,10 +277,8 @@ bool PeakGroup::deleteChild(PeakGroup* child ) {
                    children.end());
 
     // child was found and removed
-    if (children.size() != preDeletionChildCount) {
-        child->clear();
+    if (children.size() != preDeletionChildCount)
         return true;
-    }
 
     return false;
 }


### PR DESCRIPTION
The class `PeakGroup` offers a method to delete a child but this method was only clearing the space-intensive data structures for this child and not removing it from the vector that stores
children of a peak group. This has been fixed. As a result, a deleted child will no longer appear as a child of the peak group in exported CSV (and possibly other places where it might have been causing inconsistencies).

Issue: #261