### PR TITLE
[UI] Remove Save option from ligand widget

### DIFF
--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -61,17 +61,8 @@ LigandWidget::LigandWidget(MainWindow* mw) {
   connect(this, SIGNAL(compoundFocused(Compound*)), mw, SLOT(setCompoundFocus(Compound*)));
   connect(this, SIGNAL(urlChanged(QString)), mw, SLOT(setUrl(QString)));
 
-  saveButton = new QToolButton(toolBar);
-  saveButton->setIcon(QIcon(rsrcPath + "/filesave.png"));
-  saveButton->setToolTip("Save Compound List");
-  connect(saveButton,SIGNAL(clicked()), SLOT(saveCompoundList()));
-
-
-  saveButton->setEnabled(false);
-
   toolBar->addWidget(databaseSelect);
   toolBar->addWidget(loadButton);
-  toolBar->addWidget(saveButton);
 
   //Feature updated when merging with Maven776- Filter out compounds based on a keyword.
   filterEditor = new QLineEdit(toolBar);
@@ -258,20 +249,6 @@ void LigandWidget::setDatabase(QString dbname) {
 void LigandWidget::databaseChanged(int index) {
     QString dbname = databaseSelect->currentText();
     setDatabase(dbname);
-    setDatabaseAltered(dbname, alteredDatabases[dbname]);
-}
-
-void LigandWidget::setDatabaseAltered(QString name, bool altered) {
-    alteredDatabases[name]=altered;
-    QString dbname = databaseSelect->currentText();
-
-    if (dbname == name && altered == true) {
-        saveButton->setEnabled(true);
-    }
-
-    if (dbname == name && altered == false) {
-        saveButton->setEnabled(false);
-    }
 }
 
 void LigandWidget::setCompoundFocus(Compound* c) {
@@ -490,22 +467,6 @@ void LigandWidget::resetColor()
     }
 }
 
-
-void LigandWidget::saveCompoundList(){
-
-    QSettings *settings = _mw->getSettings();
-    QString dbname = databaseSelect->currentText();
-    QString dbfilename = databaseSelect->currentText() + ".tab";
-    QString dataDir = settings->value("dataDir").value<QString>();
-    QString methodsFolder =     dataDir +  "/"  + settings->value("methodsFolder").value<QString>();
-
-    QString fileName = QFileDialog::getSaveFileName(
-                this, "Export Compounds to Filename", methodsFolder, "TAB (*.tab)");
-
-    saveCompoundList(fileName, dbname);
-
-}
-
 void LigandWidget::saveCompoundList(QString fileName,QString dbname){
 
    if (fileName.isEmpty()) return;
@@ -564,7 +525,6 @@ void LigandWidget::saveCompoundList(QString fileName,QString dbname){
             out << category.join(";") << SEP;
             out << "\n";
         }
-        setDatabaseAltered(databaseSelect->currentText(),false);
     }
 }
 

--- a/src/gui/mzroll/ligandwidget.h
+++ b/src/gui/mzroll/ligandwidget.h
@@ -49,7 +49,6 @@ public:
     void clear() { treeWidget->clear(); }
     void showNext();
     void showLast();
-    void setDatabaseAltered(QString dbame,bool altered);
 	Compound* getSelectedCompound();
     void loadCompoundDBMzroll(QString fileName);
     void setHash();
@@ -72,7 +71,6 @@ public Q_SLOTS:
      */
     void resetColor();
 
-    void saveCompoundList();
     void saveCompoundList(QString fileName,QString dbname);
     void updateTable() { showTable(); }
     void updateCurrentItemData();
@@ -103,13 +101,10 @@ private:
 
     QTreeWidget *treeWidget;
     QComboBox *databaseSelect;
-    QToolButton *saveButton;
     QToolButton *loadButton;
     QLineEdit*  filterEditor;
     QPoint dragStartPosition;
     QHash<Compound *, QTreeWidgetItem *> CompoundsHash;
-
-    QHash<QString,bool>alteredDatabases;
 
     MainWindow* _mw;
     QString filterString;

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -289,10 +289,7 @@ void EicPoint::linkCompound() {
            // _mw->getEicWidget()->addNote(_peak->peakMz,_peak->peakIntensity, "Compound Link");
             _mw->getEicWidget()->saveRetentionTime();
 
-            //upadte ligand widget
-            QString dbname(_group->compound->db.c_str());
-            _mw->ligandWidget->setDatabaseAltered(dbname,true);
-            //_mw->ligandWidget->updateTable();
+            //update ligand widget
             _mw->ligandWidget->updateCurrentItemData();
 
             //update pathway widget with new concentration information


### PR DESCRIPTION
There was a 'Save' button on the ligand widget toolbar to save altered databases to a file.
Since the ligand widget is not editable, the feature is redundant.