### PR TITLE
Enable sorting in sample list

### DIFF
--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -975,7 +975,7 @@ ProjectTreeWidget::ProjectTreeWidget(QWidget* parent) : QTreeWidget(parent)
                                            currentHeader->parentWidget());
     setHeader(newHeader);
     connect(newHeader,
-            &QHeaderView::sortIndicatorChanged,
+            &ProjectHeaderView::sortRequested,
             this,
             [=](int column, Qt::SortOrder sortOrder) {
                 sortByColumn(column, sortOrder);
@@ -1028,9 +1028,11 @@ void ProjectHeaderView::mouseReleaseEvent(QMouseEvent* event)
             && sortIndicatorSection() == column
             && sortIndicatorOrder() == Qt::AscendingOrder) {
             setSortIndicator(column, Qt::DescendingOrder);
+            emit sortRequested(column, Qt::DescendingOrder);
         } else {
             setSortIndicatorShown(true);
             setSortIndicator(column, Qt::AscendingOrder);
+            emit sortRequested(column, Qt::AscendingOrder);
         }
     }
     QHeaderView::mouseReleaseEvent(event);

--- a/src/gui/mzroll/projectdockwidget.h
+++ b/src/gui/mzroll/projectdockwidget.h
@@ -147,6 +147,7 @@ public:
 
 Q_SIGNALS:
     void itemDropped(QTreeWidgetItem* item);
+    void itemsSorted();
 
 protected:
     void dragEnterEvent(QDragEnterEvent* event);
@@ -154,6 +155,22 @@ protected:
 
 private:
     QTreeWidgetItem* _draggedItem;
+};
+
+
+/**
+ * @brief The ProjectHeaderView class has been created to provide an added
+ * sorting facility, even if the widget as been turned to enable drag-n-drop.
+ */
+class ProjectHeaderView : public QHeaderView
+{
+    Q_OBJECT
+
+public:
+    ProjectHeaderView(Qt::Orientation orientation, QWidget* parent);
+
+protected:
+    void mouseReleaseEvent(QMouseEvent* event);
 };
 
 #endif // PROJECTDOCKWIDGET_H

--- a/src/gui/mzroll/projectdockwidget.h
+++ b/src/gui/mzroll/projectdockwidget.h
@@ -169,6 +169,16 @@ class ProjectHeaderView : public QHeaderView
 public:
     ProjectHeaderView(Qt::Orientation orientation, QWidget* parent);
 
+signals:
+    /**
+     * @brief Emitted whenever the column header is clicked, and should be
+     * considered as a request to sort items based on the contents of this
+     * column.
+     * @param column An integer denoting the column that should be sorted for.
+     * @param sortOrder The sort order for contents of the clicked column.
+     */
+    void sortRequested(int column, Qt::SortOrder sortOrder);
+
 protected:
     void mouseReleaseEvent(QMouseEvent* event);
 };


### PR DESCRIPTION
The sort-by-column ordering in `ProjectDockWidget` had to be disabled in favor of drag-and-drop feature (limitation posed by default QTreeWidget behaviour). But, we can have both of these mechanisms exist at the same time, by overriding the mouse-release events of tree widget and its header view.

Issue: #937