### PR TITLE
[AppVeyor] Use Qt 5.12.3 for creating installers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ cache:
     - C:\msys64\var\cache\pacman\pkg
 
 install:
-    - SET "PATH=C:\Qt\5.12.4\mingw73_64\bin;C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%"
+    - SET "PATH=C:\Qt\5.12.3\mingw73_64\bin;C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%"
 
     - bash -lc "pacman -S --needed --noconfirm mingw64/mingw-w64-x86_64-hdf5 mingw64/mingw-w64-x86_64-netcdf mingw64/mingw-w64-x86_64-boost"
 


### PR DESCRIPTION
Qt 5.11 has worked well for El-MAVEN for the past few releases,
except v0.8.0 where moving to Qt 5.12.4 had brought in some more
than tolerable UI issues. However, x64 MinGW builds for Qt 5.11
are no longer available on AppVeyor build images. Fortunately,
these issues are not present in 5.12.3 . For the next release,
therefore, El-MAVEN will revert to using Qt 5.12.3 as its UI
framework. This change (and the issues) are only applicable to
automated installers generated for the Windows platform (upgrade
never happened for Linux or Mac OS).

Issue: #1140