### PR TITLE
Enable logging for CLI

### DIFF
--- a/src/cli/peakdetector/main.cpp
+++ b/src/cli/peakdetector/main.cpp
@@ -31,7 +31,16 @@ int main(int argc, char *argv[]) {
     #endif
 	// Polly CLI part over..
 
-    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI();
+    QString parentFolder = "ElMaven";
+    QString logFile = "peakdetector_cli.log";
+    QString fpath = QStandardPaths::writableLocation(
+                        QStandardPaths::GenericConfigLocation)
+                    + QDir::separator()
+                    + parentFolder
+                    + QDir::separator()
+                    + logFile;
+    Logger log(fpath.toStdString(), true);
+    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI(&log);
 
      #ifndef __APPLE__
      double programStartTime = getTime();
@@ -90,15 +99,6 @@ int main(int argc, char *argv[]) {
 		peakdetectorCLI->writeReport("compounds",jsPath,nodePath);
 	}
     else if (!(peakdetectorCLI->pollyArgs.isEmpty())){
-        QString parentFolder = "ElMaven";
-        QString logFile = "peakdetector_cli.log";
-        QString fpath = QStandardPaths::writableLocation(
-                            QStandardPaths::GenericConfigLocation)
-                        + QDir::separator()
-                        + parentFolder
-                        + QDir::separator()
-                        + logFile;
-        Logger log(fpath.toStdString(), true, false);
         log.info() << "No peaks found. Please try again with different "
                       "parameters."
                    << flush;

--- a/src/cli/peakdetector/main.cpp
+++ b/src/cli/peakdetector/main.cpp
@@ -1,6 +1,6 @@
-#include "peakdetectorcli.h"
 #include <QCoreApplication>
 
+#include "common/logger.h"
 #include "mavenparameters.h"
 #include "peakdetectorcli.h"
 
@@ -89,8 +89,19 @@ int main(int argc, char *argv[]) {
 	if (peakdetectorCLI->mavenParameters->allgroups.size() > 0) {
 		peakdetectorCLI->writeReport("compounds",jsPath,nodePath);
 	}
-	else if (!(peakdetectorCLI->pollyArgs.isEmpty())){
-        qDebug()<<"No peaks found. Please try again with different parameters.";
+    else if (!(peakdetectorCLI->pollyArgs.isEmpty())){
+        QString parentFolder = "ElMaven";
+        QString logFile = "peakdetector_cli.log";
+        QString fpath = QStandardPaths::writableLocation(
+                            QStandardPaths::GenericConfigLocation)
+                        + QDir::separator()
+                        + parentFolder
+                        + QDir::separator()
+                        + logFile;
+        Logger log(fpath.toStdString(), true, false);
+        log.info() << "No peaks found. Please try again with different "
+                      "parameters."
+                   << flush;
 	}
 
 	//cleanup

--- a/src/cli/peakdetector/main.cpp
+++ b/src/cli/peakdetector/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char *argv[]) {
 		peakdetectorCLI->writeReport("compounds",jsPath,nodePath);
 	}
 	else if (!(peakdetectorCLI->pollyArgs.isEmpty())){
-		qDebug()<<"no peaks found..Please try again with different parameters";
+        qDebug()<<"No peaks found. Please try again with different parameters.";
 	}
 
 	//cleanup

--- a/src/cli/peakdetector/peakdetector.pro
+++ b/src/cli/peakdetector/peakdetector.pro
@@ -41,6 +41,8 @@ LIBS +=  -lmaven         \
          -lpollyCLI      \
          -lcommon
 
+unix: LIBS += -lboost_system -lboost_filesystem
+
 !macx: LIBS += -fopenmp
 
 macx {

--- a/src/cli/peakdetector/peakdetectorcli.cpp
+++ b/src/cli/peakdetector/peakdetectorcli.cpp
@@ -7,18 +7,9 @@
 #include "mzUtils.h"
 #include "peakdetectorcli.h"
 
-PeakDetectorCLI::PeakDetectorCLI()
+PeakDetectorCLI::PeakDetectorCLI(Logger* log)
 {
-    QString parentFolder = "ElMaven";
-    QString logFile = "peakdetector_cli.log";
-    QString fpath = QStandardPaths::writableLocation(
-                        QStandardPaths::GenericConfigLocation)
-                    + QDir::separator()
-                    + parentFolder
-                    + QDir::separator()
-                    + logFile;
-    _log = new Logger(fpath.toStdString(), true);
-
+    _log = log;
     status = true;
     textStatus = "";
     mavenParameters = new MavenParameters();
@@ -39,7 +30,6 @@ PeakDetectorCLI::~PeakDetectorCLI()
 {
     delete _dlManager;
     delete _pollyIntegration;
-    delete _log;
 }
 
 void PeakDetectorCLI::processOptions(int argc, char* argv[])

--- a/src/cli/peakdetector/peakdetectorcli.cpp
+++ b/src/cli/peakdetector/peakdetectorcli.cpp
@@ -1,6 +1,7 @@
 #include "common/downloadmanager.h"
 #include "Compound.h"
 #include "csvparser.h"
+#include "common/logger.h"
 #include "mavenparameters.h"
 #include "masscutofftype.h"
 #include "mzUtils.h"
@@ -8,6 +9,16 @@
 
 PeakDetectorCLI::PeakDetectorCLI()
 {
+    QString parentFolder = "ElMaven";
+    QString logFile = "peakdetector_cli.log";
+    QString fpath = QStandardPaths::writableLocation(
+                        QStandardPaths::GenericConfigLocation)
+                    + QDir::separator()
+                    + parentFolder
+                    + QDir::separator()
+                    + logFile;
+    _log = new Logger(fpath.toStdString(), true);
+
     status = true;
     textStatus = "";
     mavenParameters = new MavenParameters();
@@ -28,6 +39,7 @@ PeakDetectorCLI::~PeakDetectorCLI()
 {
     delete _dlManager;
     delete _pollyIntegration;
+    delete _log;
 }
 
 void PeakDetectorCLI::processOptions(int argc, char* argv[])
@@ -227,12 +239,11 @@ void PeakDetectorCLI::processOptions(int argc, char* argv[])
         }
     }
 
-    cout << "Running with arguments: ";
-
+    string argsInfo = "Running with arguments: ";
     for (int i = 0; i < argc; i++)
-        cout << argv[i] << " ";
-
-    cout << "\n" << endl;
+        argsInfo += string(argv[i]) + " ";
+    _log->info() << argsInfo << std::flush;
+    cout << endl;
 
     if (iter.index() < argc) {
         for (int i = iter.index(); i < argc; i++)
@@ -255,7 +266,10 @@ void PeakDetectorCLI::processXML(const char* fileName)
     }
 
     if (xmlFile) {
-        cout << "\nFound config file " << fileName << ". Processing…" << endl;
+        _log->info() << "Found config file "
+                     << fileName
+                     << ". Processing…"
+                     << std::flush;
 
         xml_document doc;
         doc.load_file(fileName, pugi::parse_minimal);
@@ -281,6 +295,7 @@ void PeakDetectorCLI::processXML(const char* fileName)
 
         textStatus += errorMsg;
     }
+    cout << endl;
 }
 
 void PeakDetectorCLI::createXMLFile(const char* fileName)
@@ -319,7 +334,9 @@ void PeakDetectorCLI::_processOptionsArgsXML(xml_node& optionsArgs)
             mavenParameters->compoundMassCutoffWindow->setMassCutoffAndType(
                 atof(node.attribute("value").value()), "ppm");
         } else {
-            cerr << "Unknown config node: " << node.name() << endl;
+            _log->error() << "Unknown config node: "
+                          << node.name()
+                          << std::flush;
         }
     }
 }
@@ -465,7 +482,9 @@ void PeakDetectorCLI::_processPeaksArgsXML(xml_node& peaksArgs)
                 atof(node.attribute("value").value());
 
         } else {
-            cerr << "Unknown config node: " << node.name() << endl;
+            _log->error() << "Unknown config node: "
+                          << node.name()
+                          << std::flush;
         }
     }
 }
@@ -507,14 +526,16 @@ void PeakDetectorCLI::_processGeneralArgsXML(xml_node& generalArgs)
             filenames.push_back(sampleStr);
 
         } else {
-            cerr << "Unknown config node: " << node.name() << endl;
+            _log->error() << "Unknown config node: "
+                          << node.name()
+                          << std::flush;
         }
     }
 }
 
 void PeakDetectorCLI::loadClassificationModel(string clsfModelFilename)
 {
-    cout << "Loading classifiation model…" << endl;
+    _log->info() << "Loading classifiation model…" << std::flush;
     mavenParameters->clsf = new ClassifierNeuralNet();
     mavenParameters->clsf->loadModel(clsfModelFilename);
     cout << endl;
@@ -524,36 +545,37 @@ void PeakDetectorCLI::loadCompoundsFile()
 {
     // exit if no db file has been provided
     if (mavenParameters->ligandDbFilename.empty()) {
-        cerr << "Please provide a compound database file to proceed with "
-                "targeted analysis. Use the '-h' argument to see all available "
-                "options."
-             << endl;
+        _log->error() << "Please provide a compound database file to proceed "
+                         "with targeted analysis. Use the '-h' argument to see "
+                         "all available options."
+                      << std::flush;
         exit(0);
     }
 
     // load compound list
     mavenParameters->processAllSlices = false;
-    cout << "Loading compound database…" << endl;
+    _log->info() << "Loading compound database…" << std::flush;
     int loadCount = _db.loadCompoundCSVFile(mavenParameters->ligandDbFilename);
     mavenParameters->compounds = _db.compoundsDB;
 
     // exit if db is empty
     if (loadCount == 0) {
-        cerr << "Warning: Given compound database is empty!" << endl;
+        _log->error() << "Warning: Given compound database is empty!"
+                      << std::flush;
         exit(1);
     }
 
     // check for invalid compounds
     if (_db.invalidRows.size() > 0) {
-        cout << "The following compounds had insufficient information for peak "
-                "detection, and were not loaded:"
-             << endl;
-        for (auto compoundID : _db.invalidRows) {
-            cout << " - " << compoundID << endl;
-        }
+        string debugStr = "The following compounds had insufficient information "
+                          "for peak detection, and were not loaded:\n";
+        for (auto compoundID : _db.invalidRows)
+            debugStr += " - " + compoundID + "\n";
+        _log->debug() << debugStr << std::flush;
     }
 
-    cout << "Loaded " << loadCount << " compounds\n" << endl;
+    _log->info() << "Loaded " << loadCount << " compounds" << std::flush;
+    cout << endl;
 }
 
 void PeakDetectorCLI::loadSamples(vector<string>& filenames)
@@ -561,7 +583,7 @@ void PeakDetectorCLI::loadSamples(vector<string>& filenames)
 #ifndef __APPLE__
     double startLoadingTime = getTime();
 #endif
-    cout << "Loading samples…" << endl;
+    _log->info() << "Loading samples…" << std::flush;
 
     for (unsigned int i = 0; i < filenames.size(); i++) {
         mzSample* sample = new mzSample();
@@ -570,7 +592,9 @@ void PeakDetectorCLI::loadSamples(vector<string>& filenames)
         sample->isSelected = true;
         if (sample->scans.size() >= 1) {
             mavenParameters->samples.push_back(sample);
-            cout << "Loaded Sample: " << sample->getSampleName() << endl;
+            _log->info() << "Loaded Sample: "
+                         << sample->getSampleName()
+                         << std::flush;
         } else {
             if (sample != NULL) {
                 delete sample;
@@ -580,7 +604,7 @@ void PeakDetectorCLI::loadSamples(vector<string>& filenames)
     }
 
     if (mavenParameters->samples.size() == 0) {
-        cout << "Nothing to process. Exiting…" << endl;
+        _log->error() << "Nothing to process. Exiting…" << std::flush;
         exit(1);
     }
 
@@ -588,8 +612,11 @@ void PeakDetectorCLI::loadSamples(vector<string>& filenames)
          mavenParameters->samples.end(),
          mzSample::compSampleSort);
 
-    cout << "Loaded " << mavenParameters->samples.size()
-         << " samples\n" << endl;
+    _log->info() << "Loaded "
+                 << mavenParameters->samples.size()
+                 << " samples"
+                 << std::flush;
+    cout << endl;
 
 #ifndef __APPLE__
     cout << "Execution time (sample loading): "
@@ -613,8 +640,9 @@ void PeakDetectorCLI::_makeSampleCohortFile(QString sampleCohortFilename,
         out << sampleName << ",\n";
     }
 
-    qDebug()
-        << "Sample cohort file prepared. Moving on to gsheet interface now…";
+    _log->debug() << "Sample cohort file prepared. Moving on to gsheet "
+                     "interface now…"
+                  << std::flush;
     file.close();
 }
 
@@ -628,8 +656,9 @@ QString PeakDetectorCLI::_isReadyForPolly()
         return message;
     }
     if (!saveJsonEIC) {
-        qDebug() << "JSON file is required for using Polly applications. "
-                    "Overriding existing settings to save JSON data file…";
+        _log->debug() << "JSON file is required for using Polly applications. "
+                         "Overriding existing settings to save JSON data file…"
+                      << std::flush;
         saveJsonEIC = true;
     }
     return message;
@@ -714,26 +743,26 @@ bool PeakDetectorCLI::_incompatibleWithPollyApp()
             onlyMS2 = false;
     }
     if (onlyMS2 && _currentPollyApp == PollyApp::PollyPhi) {
-        cerr << "PollyPhi currently does not support purely MS2 data. "
-             << "Please use an MS1 or DDA dataset."
-             << endl;
+        _log->debug() << "PollyPhi currently does not support purely MS2 data. "
+                      << "Please use an MS1 or DDA dataset."
+                      << std::flush;
         return true;
     }
     
     //Untargeted data is not compatible with any app atm
     if (mavenParameters->processAllSlices) {
-        cerr << "Untargeted data is not supported on Polly. Please switch off"
-             << " mass slicing and provide a compound database."
-             << endl;
+        _log->debug() << "Untargeted data is not supported on Polly. Please switch off"
+                      << " mass slicing and provide a compound database."
+                      << std::flush;
         return true;
     }
 
     //Unlabelled data is not the desired data for PollyPhi
     if (!mavenParameters->pullIsotopesFlag && 
         _currentPollyApp == PollyApp::PollyPhi) {
-        cerr << "PollyPhi is used for the analysis of labeled data. Please "
-             << "switch on isotope detection using paramater -f."
-             << endl;
+        _log->debug() << "PollyPhi is used for the analysis of labeled data. Please "
+                      << "switch on isotope detection using paramater -f."
+                     << std::flush;
         return true;
     }
 
@@ -746,7 +775,7 @@ void PeakDetectorCLI::writeReport(string setName,
 {
     // TODO kailash, this function should not have jsPath and nodePath as its
     // arguments…
-    cout << "Writing report for groups…" << endl;
+    _log->info() << "Writing report for groups…" << std::flush;
 
     // reduce groups
     _groupReduction();
@@ -757,10 +786,8 @@ void PeakDetectorCLI::writeReport(string setName,
         mzUtils::createDir(mavenParameters->outputdir.c_str());
         string fileName = mavenParameters->outputdir + setName;
 
-        // save Eic Json
+        _log->info() << "Saving data reports…" << std::flush;
         saveJson(fileName);
-
-        // save output CSV
         saveCSV(fileName, false);
     } else {
         if (_incompatibleWithPollyApp())
@@ -768,7 +795,6 @@ void PeakDetectorCLI::writeReport(string setName,
 
         // try uploading to Polly
         QMap<QString, QString> creds = _readCredentialsFromXml(pollyArgs);
-        cout << "Uploading to Polly now…" << endl;
         QDateTime currentTime;
         const QString format = "dd-MM-yyyy_hh_mm_ss";
         QString datetimestamp = currentTime.currentDateTime().toString(format);
@@ -802,17 +828,18 @@ void PeakDetectorCLI::writeReport(string setName,
             prepareCompoundDbForPolly(compoundDbFilename + ".csv");
         QString readyStatus = _isReadyForPolly();
         if (!(readyStatus == "ready") || compoundDbStatus == 0) {
-            qDebug() << "Error while preparing files for Polly: "
-                     << readyStatus;
+            _log->debug() << "Error while preparing files for Polly: "
+                          << readyStatus.toStdString()
+                          << std::flush;
             return;
         }
 
-        // save Eic Json
+        _log->info() << "Storing temporary data files…" << std::flush;
         saveJson(jsonFilename.toStdString());
-
-        // save output CSV
         saveCSV(csvFilename.toStdString(), true);
+        cout << endl;
 
+        _log->info() << "Uploading data files to Polly…" << std::flush;
         try {
             // add more files to upload, if desired…
             QStringList filesToBeUploaded =
@@ -834,14 +861,16 @@ void PeakDetectorCLI::writeReport(string setName,
                 if (validSampleCohort) {
                     bool statusSampleCopy = QFile::copy(
                         _sampleCohortFile, sampleCohortFilename + ".csv");
-                    qDebug() << "Sample cohort copy status: "
-                             << statusSampleCopy;
+                    _log->debug() << "Sample cohort copy status: "
+                                  << statusSampleCopy
+                                  << std::flush;
                     _redirectTo = "relative_lcms_elmaven";
                 } else {
-                    qDebug() << "There was some problem with the sample cohort "
-                                "file, you will be redirected to an interface "
-                                "on Polly where you can make the cohort file "
-                                "again.";
+                    _log->debug() << "There was some problem with the sample cohort "
+                                     "file, you will be redirected to an interface "
+                                     "on Polly where you can make the cohort file "
+                                     "again."
+                                  << std::flush;
                     _makeSampleCohortFile(sampleCohortFilename + ".csv",
                                          loadedSamples);
                 }
@@ -864,39 +893,33 @@ void PeakDetectorCLI::writeReport(string setName,
                 redirectionUrl = _getRedirectionUrl(datetimestamp,
                                                     uploadProjectId);
             } else {
-                cerr << "Unable to upload data to Polly." << endl;
+                _log->error() << "Unable to upload data to Polly."
+                              << std::flush;
             }
 
-            // NOTE: Adding this to help clients of this CLI to be able to
-            // access the redirection URL.
-            QString fname = "polly_redirection_url.txt";
-            QString fpath = QStandardPaths::writableLocation(
-                                QStandardPaths::GenericConfigLocation)
-                            + QDir::separator()
-                            + fname;
-            ofstream ofs(fpath.toStdString());
-            ofs << redirectionUrl.toStdString() << endl;
-            ofs.close();
+            _log->debug() << "Redirection URL: \""
+                          << redirectionUrl.toStdString()
+                          << "\""
+                          << std::flush;
 
-            // if redirection URL is not empty then we can print it on console
-            // and send the user an email with that URL
+            // if redirection URL is not empty then we send the user an email
+            // with that URL
             if (!redirectionUrl.isEmpty()) {
-                cerr << "Redirection URL: \""
-                     << redirectionUrl.toStdString()
-                     << "\""
-                     << endl;
-
                 bool response = _sendUserEmail(creds, redirectionUrl);
                 string status = response == 1 ? "success"
                                               : "failure";
-                cerr << "Emailer status: " << status << "!" << endl;
+                _log->info() << "Emailer status: "
+                             << status
+                             << "!"
+                             << std::flush;
             } else {
-                cerr << "Unable to obtain a redirection URL." << endl;
+                _log->error() << "Failed to obtain a redirection URL."
+                              << std::flush;
             }
         } catch (...) {
-            cerr << "Unable to upload data to Polly. "
-                    "Please check the CLI arguments."
-                 << endl;
+            _log->error() << "Something went wrong when trying to upload data "
+                             "to Polly. Please check the CLI arguments."
+                          << std::flush;
         }
         bool status = qdir.removeRecursively();
     }
@@ -926,9 +949,9 @@ QString PeakDetectorCLI::_getRedirectionUrl(QString datetimestamp,
                                                         uploadProjectId,
                                                         datetimestamp);
         } else {
-            cerr << "Unable to create workflow request id. "
-                    "Please try again."
-                 << endl;
+            _log->error() << "Unable to create workflow request id. Please try "
+                             "again."
+                          << std::flush;
         }
         break;
     } case PollyApp::QuantFit: {
@@ -989,7 +1012,7 @@ void PeakDetectorCLI::saveJson(string setName)
         string fileName = setName + ".json";
         _jsonReports->saveMzEICJson(
             fileName, mavenParameters->allgroups, mavenParameters->samples);
-        cout << "Saved JSON output file: " << fileName << endl;
+        _log->info() << "JSON output file: " << fileName << std::flush;
 #ifndef __APPLE__
         cout << "Execution time (saving EIC in JSON) : "
              << getTime() - startSavingJson << " seconds.\n";
@@ -1003,8 +1026,9 @@ QMap<QString, QString> PeakDetectorCLI::_readCredentialsFromXml(QString filename
     QDomDocument doc;
     QFile file(filename);
     if (!file.open(QIODevice::ReadOnly) || !doc.setContent(&file)) {
-        qDebug() << "Something is wrong with your credentials file. Please try "
-                    "again with a valid xml file.";
+        _log->error() << "Something is wrong with your credentials file. "
+                         "Please try again with a valid xml file."
+                      << std::flush;
         return creds;
     }
 
@@ -1014,8 +1038,9 @@ QMap<QString, QString> PeakDetectorCLI::_readCredentialsFromXml(QString filename
     // you could check the root tag name here if it matters
     QString rootTag = docElem.tagName();  // == credentials
     if (rootTag != "credentials") {
-        qDebug() << "The root tag of your credentials file is not correct. "
-                    "Please try again with a valid xml file.";
+        _log->error() << "The root tag of your credentials file is not "
+                         "correct. Please try again with a valid xml file."
+                      << std::flush;
         return creds;
     }
     QDomNodeList polly_creds = doc.elementsByTagName("pollyaccountdetails");
@@ -1024,8 +1049,9 @@ QMap<QString, QString> PeakDetectorCLI::_readCredentialsFromXml(QString filename
         QDomElement username = n.firstChildElement("username");
         QDomElement password = n.firstChildElement("password");
         if (username.isNull() || password.isNull()) {
-            qDebug() << "Both username and password must be provided in the "
-                        "credentials file.Please try again";
+            _log->error() << "Both username and password must be provided in "
+                             "the credentials file.Please try again"
+                          << std::flush;
             return creds;
         }
         creds["polly_username"] = username.text();
@@ -1056,21 +1082,22 @@ QString PeakDetectorCLI::uploadToPolly(QString jsPath,
     ErrorStatus response = _pollyIntegration->activeInternet();
     if (response == ErrorStatus::Failure ||
         response == ErrorStatus::Error) {
-        cerr << "No internet access. Please connect to the internet and try "
-                "again"
-             << endl;
+        _log->error() << "No internet access. Please connect to the internet "
+                         "and try again."
+                      << std::flush;
         return uploadProjectId;
     }
 
     ErrorStatus loginResponse = _pollyIntegration->authenticateLogin(
         creds["polly_username"], creds["polly_password"]);
     if (loginResponse == ErrorStatus::Failure) {
-        cerr << "Incorrect credentials. Please check." << endl;
+        _log->error() << "Incorrect credentials. Please recheck." << std::flush;
         return uploadProjectId;
     } else if (loginResponse == ErrorStatus::Error) {
-        cerr << "A server error was encountered. Please contact tech support "
-                "at elmaven@elucidata.io if the problem persists."
-             << endl;
+        _log->error() << "A server error was encountered. Please contact tech "
+                         "support at elmaven@elucidata.io if the problem "
+                         "persists."
+                      << std::flush;
         return uploadProjectId;
     }
 
@@ -1080,7 +1107,6 @@ QString PeakDetectorCLI::uploadToPolly(QString jsPath,
     QVariantMap projectNamesId = _pollyIntegration->getUserProjects();
     QStringList keys = projectNamesId.keys();
     QString projectId;
-    QString defaultprojectId;
     if (_pollyProject.isEmpty()) {
         _pollyProject = "Default_Elmaven_Polly_Project";
     }
@@ -1094,10 +1120,10 @@ QString PeakDetectorCLI::uploadToPolly(QString jsPath,
         // In case no project matches with the user defined name,
         // Create the project and upload to it. This makes the project name to
         // be mandatory.
-        cerr << "Creating new project with name: \""
-             << _pollyProject.toStdString()
-             << "\""
-             << endl;
+        _log->error() << "Creating new project with name: \""
+                      << _pollyProject.toStdString()
+                      << "\""
+                      << std::flush;
         QString newProjectId =
             _pollyIntegration->createProjectOnPolly(_pollyProject);
         uploadProjectId = newProjectId;
@@ -1156,7 +1182,7 @@ void PeakDetectorCLI::saveCSV(string setName, bool pollyExport)
     csvreports->setMavenParameters(mavenParameters);
 
     if (mavenParameters->allgroups.size() == 0) {
-        cout << "Writing to CSV failed: no groups found." << endl;
+        _log->info() << "Writing to CSV failed: no groups found." << std::flush;
         return;
     }
 
@@ -1250,13 +1276,14 @@ void PeakDetectorCLI::saveCSV(string setName, bool pollyExport)
     }
 
     if (csvreports->getErrorReport() != "") {
-        cout << "Writing to CSV failed with error - "
-             << csvreports->getErrorReport().toStdString()
-             << "." << endl;
+        _log->info() << "Writing to CSV failed with error - "
+                     << csvreports->getErrorReport().toStdString()
+                     << "."
+                     << std::flush;
         return;
     }
 
-    cout << "Saved CSV output file: " << fileName << endl;
+    _log->info() << "CSV output file: " << fileName << std::flush;
 
 #ifndef __APPLE__
     cout << "\tExecution time (Saving CSV): "
@@ -1269,8 +1296,10 @@ void PeakDetectorCLI::reduceGroups()
     sort(mavenParameters->allgroups.begin(),
          mavenParameters->allgroups.end(),
          PeakGroup::compMz);
-    cout << "Reducing " << mavenParameters->allgroups.size()
-         << " groups…" << endl;
+    _log->info() << "Reducing "
+                 << mavenParameters->allgroups.size()
+                 << " groups…"
+                 << std::flush;
 
     // init deleteFlag
     for (unsigned int i = 0; i < mavenParameters->allgroups.size(); i++) {
@@ -1322,8 +1351,10 @@ void PeakDetectorCLI::reduceGroups()
         }
     }
     mavenParameters->allgroups = allgroups_;
-    cout << "Done. Final group count: " << mavenParameters->allgroups.size()
-         << "\n" << endl;
+    _log->info() << "Done. Final group count: "
+                 << mavenParameters->allgroups.size()
+                 << std::flush;
+    cout << endl;
 }
 
 double get_wall_time()

--- a/src/cli/peakdetector/peakdetectorcli.h
+++ b/src/cli/peakdetector/peakdetectorcli.h
@@ -70,7 +70,7 @@ public:
     QString pollyArgs;
     AlignmentMode alignMode;
 
-    PeakDetectorCLI();
+    PeakDetectorCLI(Logger* log);
     ~PeakDetectorCLI();
 
     /**

--- a/src/cli/peakdetector/peakdetectorcli.h
+++ b/src/cli/peakdetector/peakdetectorcli.h
@@ -48,6 +48,7 @@ using namespace std;
 class PollyIntegration;
 class ParseOptions;
 class DownloadManager;
+class Logger;
 
 class PeakDetectorCLI
 {
@@ -195,6 +196,7 @@ private:
     bool _reduceGroupsFlag;
     PollyApp _currentPollyApp;
     QString _pollyExtraInfo;
+    Logger *_log;
 
     /**
      * [Load Arguments for Options Dialog]

--- a/src/common/common.pro
+++ b/src/common/common.pro
@@ -1,4 +1,5 @@
 include($$mac_compiler)
+include($$mzroll_pri)
 MOC_DIR=$$top_builddir/tmp/common/
 OBJECTS_DIR=$$top_builddir/tmp/common/
 
@@ -16,6 +17,8 @@ QMAKE_CXXFLAGS += -std=c++11
 
 INCLUDEPATH += $$top_srcdir/src
 
-SOURCES += downloadmanager.cpp
+SOURCES += downloadmanager.cpp \
+           logger.cpp
 
-HEADERS += downloadmanager.h
+HEADERS += downloadmanager.h \
+           logger.h

--- a/src/common/downloadmanager.h
+++ b/src/common/downloadmanager.h
@@ -4,6 +4,7 @@
 #include <QUrl>
 #include <QNetworkReply>
 
+class Logger;
 class QNetworkAccessManager;
 class QNetworkRequest;
 class QUrl;
@@ -40,6 +41,7 @@ private:
     QNetworkReply* _reply;
     QUrl _url;
     QByteArray _data;
+    Logger* _log;
 };
 
 #endif // DOWNLOADMANAGER_H

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -1,0 +1,53 @@
+#include "logger.h"
+#include "boost/filesystem.hpp"
+
+Logger::Logger(std::string filename, bool writeToConsole, bool overwrite)
+{
+    if (overwrite && boost::filesystem::exists(filename))
+        boost::filesystem::remove(filename);
+
+    _infoBuffer = new LogBuffer(filename, "INFO", writeToConsole);
+    _debugBuffer = new LogBuffer(filename, "DEBUG", writeToConsole);
+    _errorBuffer = new LogBuffer(filename, "ERROR", writeToConsole);
+    _infoStream = new std::ostream(_infoBuffer);
+    _debugStream = new std::ostream(_debugBuffer);
+    _errorStream = new std::ostream(_errorBuffer);
+}
+
+Logger::~Logger()
+{
+    delete _infoBuffer;
+    delete _debugBuffer;
+    delete _errorBuffer;
+    delete _infoStream;
+    delete _debugStream;
+    delete _errorStream;
+}
+
+std::ostream& Logger::info()
+{
+    return *_infoStream;
+}
+
+std::ostream& Logger::debug()
+{
+    return *_debugStream;
+}
+
+std::ostream& Logger::error()
+{
+    return *_errorStream;
+}
+
+LogBuffer::LogBuffer(const std::string& filename,
+                     const std::string& type,
+                     bool writeToConsole)
+    : _stream(filename, std::fstream::app)
+    , _logType(type)
+    , _writeToConsole(writeToConsole)
+{}
+
+LogBuffer::~LogBuffer()
+{
+    _stream.close();
+}

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -1,0 +1,164 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+class LogBuffer;
+
+/**
+ * @brief The Logger class can be used to write logs to a file, leveraging
+ * standard string stream operations.
+ */
+class Logger
+{
+public:
+    /**
+     * @brief Once created, a `Logger` object is associated to a file to which
+     * it keeps appending information, debug or error strings.
+     * @details The file to which logs are written is not allowed to be changed,
+     * once constructed.
+     * @param filename A string storing the name of the file to which logs will
+     * be written.
+     * @param writeToConsole Optional parameter, that if set to true, will cause
+     * all strings passed through to any of the streams to be also printed on
+     * standard output.
+     * @param overwrite Optional paramater, that if set to true, will instruct
+     * the constructor to immediately delete any existing file at the provided
+     * path. This is set to `true` by default.
+     */
+    Logger(std::string filename,
+           bool writeToConsole = false,
+           bool overwrite = true);
+
+    /**
+     * @brief Destructor. Deletes all streams and associated buffers.
+     */
+    ~Logger();
+
+    /**
+     * @brief This output stream should be used to write general information
+     * to the log.
+     * @return A reference to a `std::ostream` object.
+     */
+    std::ostream& info();
+
+    /**
+     * @brief This output stream should be used to write debug strings to the
+     * log.
+     * @return A reference to a `std::ostream` object.
+     */
+    std::ostream& debug();
+
+    /**
+     * @brief This output stream should be used to write error strings to the
+     * log.
+     * @return A reference to a `std::ostream` object.
+     */
+    std::ostream& error();
+
+private:
+    /**
+     * @brief Buffer to which information strings are written.
+     */
+    LogBuffer* _infoBuffer;
+
+    /**
+     * @brief Buffer to which debug strings are written.
+     */
+    LogBuffer* _debugBuffer;
+
+    /**
+     * @brief Buffer to which error strings are written.
+     */
+    LogBuffer* _errorBuffer;
+
+    /**
+     * @brief An output stream which uses `_infoBuffer` as its base.
+     */
+    std::ostream* _infoStream;
+
+    /**
+     * @brief An output stream which uses `_debugBuffer` as its base.
+     */
+    std::ostream* _debugStream;
+
+    /**
+     * @brief An output stream which uses `_errorBuffer` as its base.
+     */
+    std::ostream* _errorStream;
+};
+
+/**
+ * @brief The LogBuffer class is used by the `Logger` class internally to
+ * represent its stream buffers.
+ */
+class LogBuffer : public std::stringbuf
+{
+public:
+    /**
+     * @brief Create a string buffer that carries its own copy of a file stream
+     * to which it writes everything.
+     * @details The internal file stream is always opened in append mode. So,
+     * any existing contents of the file between write operations are preserved.
+     * @param filename A string containing the name of the file to which this
+     * buffer logs.
+     * @param type A string containing the type name of the log string which
+     * will be appear on the first line of each log entry, along with a time
+     * record.
+     * @param writeToConsole An optional parameter that if set to true will
+     * also write every log entry to the standard output, but without the line
+     * containing log type and time record.
+     */
+    LogBuffer(const std::string& filename,
+              const std::string& type,
+              bool writeToConsole = false);
+
+    /**
+     * @brief Destructor. Closes internal filestream.
+     */
+    ~LogBuffer();
+
+    /**
+     * @brief Overriden virtual method that takes care of our custom output
+     * behaviour, whenever the buffer is flushed. See constructor of this class
+     * for more details.
+     */
+    virtual int sync() {
+        auto now = std::chrono::system_clock::now();
+        auto current_time = std::chrono::system_clock::to_time_t(now);
+
+        // write to log file
+        _stream << _logType << " | " << std::ctime(&current_time)
+                << str() << std::endl;
+
+        if (_writeToConsole)
+            std::cout << str() << std::endl;
+
+        // clear buffer
+        str("");
+
+        return 0;
+    }
+
+private:
+    /**
+     * @brief Internal output filestream to which all logs are written.
+     */
+    std::ofstream _stream;
+
+    /**
+     * @brief The string "type" that will mark the beginning of a log entry.
+     */
+    std::string _logType;
+
+    /**
+     * @brief Predicate that controls priting to standard output, as a secondary
+     * effect.
+     */
+    bool _writeToConsole;
+};
+
+#endif // LOGGER_H

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -68,7 +68,6 @@ PollyIntegration::~PollyIntegration()
         }
         delete _fPtr;
     }
-    qDebug()<<"exiting PollyIntegration now....";
 }
 
 QString PollyIntegration::getCredFile(){

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -1,5 +1,6 @@
 #include "pollyintegration.h"
 #include <common/downloadmanager.h>
+#include <common/logger.h>
 #include <QTemporaryFile>
 
 PollyIntegration::PollyIntegration(DownloadManager* dlManager):
@@ -8,6 +9,16 @@ PollyIntegration::PollyIntegration(DownloadManager* dlManager):
     jsPath(""),
     _fPtr(nullptr)
 {
+    QString parentFolder = "ElMaven";
+    QString logFile = "polly_integration.log";
+    QString fpath = QStandardPaths::writableLocation(
+                        QStandardPaths::GenericConfigLocation)
+                    + QDir::separator()
+                    + parentFolder
+                    + QDir::separator()
+                    + logFile;
+    _log = new Logger(fpath.toStdString());
+
     credFile = QStandardPaths::writableLocation(QStandardPaths::QStandardPaths::GenericConfigLocation) + QDir::separator() + "cred_file";
 
     // It's important to look for node in the system first, as it might not always be present in the bin dir.
@@ -42,11 +53,15 @@ void PollyIntegration::requestSuccess()
     _fPtr->setFileTemplate(QDir::tempPath() + QDir::separator() + "index.js");
     if(_fPtr->open()) {
         _fPtr->write(_dlManager->getData());
-        qDebug() << "data written to file: " << _fPtr->fileName();
+        _log->debug() << "Data written to file: "
+                      << _fPtr->fileName().toStdString()
+                      << std::flush;
         jsPath = _fPtr->fileName();
     } else {
         jsPath = "";
-        qDebug() << "unable to open temp file: " << _fPtr->errorString();
+        _log->error() << "Unable to open temp file: "
+                      << _fPtr->errorString().toStdString()
+                      << std::flush;
     }
     _fPtr->close();
 }
@@ -54,20 +69,24 @@ void PollyIntegration::requestSuccess()
 void PollyIntegration::requestFailed()
 {
     jsPath = "";
-    qDebug() << "failed to download file";
+    _log->error() << "Failed to download file" << std::flush;
 }
 
 PollyIntegration::~PollyIntegration()
 {
     if(_fPtr != nullptr) {
         if(_fPtr->remove())
-            qDebug() << "removed file";
+            _log->debug() << "Removed file" << std::flush;
         else {
-            qDebug() << "error: " << _fPtr->error();
-            qDebug() << _fPtr->errorString();
+            _log->error() << "Error: "
+                          << _fPtr->error()
+                          << "\n"
+                          << _fPtr->errorString().toStdString()
+                          << std::flush;
         }
         delete _fPtr;
     }
+    delete _log;
 }
 
 QString PollyIntegration::getCredFile(){
@@ -77,7 +96,8 @@ QString PollyIntegration::getCredFile(){
 bool PollyIntegration::_checkForIndexFile()
 {
     if(!_fPtr || !_fPtr->exists()) {
-        qDebug() << "Index file not found, trying to download index file ";
+        _log->debug() << "Index file not found, trying to download index file…"
+                      << std::flush;
         // synchronous request;
         _dlManager->setRequest(indexFileURL, this, false);
         if(!_dlManager->err) {
@@ -109,12 +129,12 @@ QList<QByteArray> PollyIntegration::runQtProcess(QString command, QStringList ar
 
     QProcess process;
     QStringList arg;
-    qDebug() << "js file being used: " << jsPath;
+    _log->debug() << "JS file being used: "
+                  << jsPath.toStdString()
+                  << std::flush;
     arg << jsPath; // where index.js files is placed
     arg << command; // what command to pass to index.js. eg. authenticate
     arg << args; // required params by that command . eg username, password
-    // qDebug()<<"nodePath"<<nodePath;
-    // qDebug()<<"args -"<<arg;
 
     // nodePath = "PATH_OF_MAVEN/bin/node.exe"
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
@@ -127,11 +147,15 @@ QList<QByteArray> PollyIntegration::runQtProcess(QString command, QStringList ar
     process.start();
     //TODO kailash, use threading for this, it should not just run indefinitely 
     process.waitForFinished(-1);
-    QByteArray result = process.readAllStandardOutput();
-    QByteArray result2 = process.readAllStandardError();
-    qDebug()<<"StandardOutput  - "<<result;
-    qDebug()<<"StandardError, if any  - "<<result2;
-    return QList<QByteArray>()<<result<<result2;
+    QByteArray stdOutput = process.readAllStandardOutput();
+    QByteArray stdError = process.readAllStandardError();
+    _log->debug() << "StandardOutput - "
+                  << stdOutput.toStdString()
+                  << std::flush;
+    _log->debug() << "StandardError - "
+                  << stdError.toStdString()
+                  << std::flush;
+    return QList<QByteArray>() << stdOutput << stdError;
 }
 
 QString PollyIntegration::parseId(QByteArray result){
@@ -474,14 +498,18 @@ int PollyIntegration::checkNodeExecutable() {
 }
 
 int PollyIntegration::askForLogin() {
-    qDebug() << "credFile  -\n" << credFile;
+    _log->debug() << "Credentials File -\n"
+                  << credFile.toStdString()
+                  << std::flush;
     QFile file (credFile);
     QFile refreshTokenFile (credFile + "_refreshToken");
     if (file.exists() && refreshTokenFile.exists()) {
-        qDebug() << "both tokens exist.. moving on to refresh now..";
+        _log->debug() << "Both tokens exist, moving on to refresh now…"
+                      << std::flush;
         return 0;
     }
-    qDebug() <<"both tokens do not exist.. moving on to login now..";
+    _log->debug() <<"Both tokens do not exist, moving on to login now…"
+                  << std::flush;
     return 1;
 }
 
@@ -700,7 +728,6 @@ ErrorStatus PollyIntegration::sendEmail(QString userEmail,
                                  QString appName)
 {
     QString command2 = "send_email";
-    qDebug() << userEmail << emailMessage << emailContent << appName;
     QList<QByteArray> resultAndError = runQtProcess(command2,
                                                     QStringList() << userEmail
                                                                   << emailMessage
@@ -732,7 +759,9 @@ ErrorStatus PollyIntegration::sendEmail(QString userEmail,
 
 
 QPair<ErrorStatus, QStringList> PollyIntegration::exportData(QStringList filenames, QString projectId) {
-    qDebug() << "files to be uploaded " << filenames;
+    _log->debug() << "Files to be uploaded: "
+                  << filenames.join(", ").toStdString()
+                  << std::flush;
     QStringList patchId;
 
     QElapsedTimer timer;
@@ -744,7 +773,9 @@ QPair<ErrorStatus, QStringList> PollyIntegration::exportData(QStringList filenam
 
     QString url_with_wildcard = getFileUploadURLs(resultAndError.at(0));
     patchId = get_project_upload_url_commands(url_with_wildcard, filenames);
-    qDebug() << "time taken in uploading json file, by polly cli is - " << timer.elapsed();
+    _log->debug() << "Time spent uploading JSON file, through Polly CLI: "
+                  << timer.elapsed()
+                  << std::flush;
     
     return qMakePair(ErrorStatus::Success, patchId);
 }
@@ -782,16 +813,18 @@ ErrorStatus PollyIntegration::UploadPeaksToCloud(QString session_indentifier, QS
 
     QString uploadUrl = getFileUploadURLs(resultAndError.at(0));
     ErrorStatus status = UploadToCloud(uploadUrl, filePath);
-    qDebug() << "time taken in uploading json file, by polly cli is - " << timer.elapsed();
+    _log->debug() << "Time spent uploading JSON file, through Polly CLI: "
+                  << timer.elapsed()
+                  << std::flush;
     return status;
 }
 
 bool PollyIntegration::validSampleCohort(QString sampleCohortFile, QStringList loadedSamples) {
-	qDebug() << "Validating sample cohort file now";
+    _log->debug() << "Validating sample cohort file…" << std::flush;
 	
     QFile file(sampleCohortFile);
     if (!file.open(QIODevice::ReadOnly)) {
-        qDebug() << file.errorString();
+        _log->debug() << file.errorString().toStdString() << std::flush;
 		return false;
     }
 
@@ -801,7 +834,7 @@ bool PollyIntegration::validSampleCohort(QString sampleCohortFile, QStringList l
         QByteArray line = file.readLine();
 		QList<QByteArray> splitRow = line.split(',');
 		if (splitRow.size() != 2) {
-            qDebug() << "Missing column(s)";
+            _log->debug() << "Missing column(s)" << std::flush;
 			return false;
         }
 		
@@ -813,7 +846,7 @@ bool PollyIntegration::validSampleCohort(QString sampleCohortFile, QStringList l
 		QString cohortName = splitRow.at(1);
         
         if (cohortName.trimmed().isEmpty()) {
-            qDebug() << "Cohort missing for some samples";
+            _log->debug() << "Cohort missing for some samples" << std::flush;
             return false;
         }
 
@@ -827,13 +860,19 @@ bool PollyIntegration::validSampleCohort(QString sampleCohortFile, QStringList l
 	    qSort(loadedSamples);
 	
 	    if (!(samples == loadedSamples)) {
-		    qDebug() << "The sample cohort file contains different sample names than the samples loaded in Elmaven...Please try again with the correct file" << endl;
+            _log->debug() << "The sample cohort file contains different sample "
+                             "names than the samples loaded in Elmaven… Please "
+                             "try again with the correct file"
+                          << std::flush;
 		    return false;
 	    }                               
     }
 	
 	if (!validCohorts(cohorts)) {
-		qDebug() << "The sample cohort file contains more than 9 cohorts. As of now, Polly supports only 9 or less cohorts..please try again with the correct file";
+        _log->debug() << "The sample cohort file contains more than 9 cohorts. "
+                         "As of now, Polly supports only 9 or less cohorts. "
+                         "Please try reducing the number of cohorts."
+                      << std::flush;
 		return false;
 	}
 

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -4,6 +4,8 @@
 #include <QtCore>
 #include <QObject>
 
+class Logger;
+
 enum class PollyApp: int
 {
     FirstView = 0,
@@ -188,6 +190,7 @@ private:
     QTemporaryFile* _fPtr;
     unsigned int _retries;
     QString indexFileURL;
+    Logger *_log;
 
     QPair<ErrorStatus, QMap<QString, QStringList>> _fetchAppLicense();
     bool _checkForIndexFile();

--- a/tests/MavenTests/MavenTests.pro
+++ b/tests/MavenTests/MavenTests.pro
@@ -34,6 +34,7 @@ macx {
 QMAKE_LFLAGS += -L$$top_builddir/libs/
 
 LIBS += -lmaven -lpugixml -lneural -lcsvparser -lpls -lErrorHandling -lLogger -lcdfread -lz -lnetcdf -lobiwarp -lpollyCLI -lcommon
+unix: LIBS += -lboost_system -lboost_filesystem
 !macx: LIBS += -fopenmp
 
 macx {

--- a/tests/MavenTests/testCLI.cpp
+++ b/tests/MavenTests/testCLI.cpp
@@ -1,6 +1,7 @@
 #include "testCLI.h"
 #include "databases.h"
 #include "classifierNeuralNet.h"
+#include "common/logger.h"
 #include "csvreports.h"
 #include "masscutofftype.h"
 #include "mavenparameters.h"
@@ -8,7 +9,17 @@
 #include "peakdetectorcli.h"
 #include "utilities.h"
 
-TestCLI::TestCLI() {
+TestCLI::TestCLI()
+{
+    QString parentFolder = "ElMaven";
+    QString logFile = "peakdetector_cli.log";
+    QString fpath = QStandardPaths::writableLocation(
+                        QStandardPaths::GenericConfigLocation)
+                    + QDir::separator()
+                    + parentFolder
+                    + QDir::separator()
+                    + logFile;
+    _log = new Logger(fpath.toStdString(), true);
 
     xmlPath = "bin/methods/test.xml";
     createXmlPath = "bin/methods/createTest.xml";
@@ -26,7 +37,7 @@ TestCLI::~TestCLI() {
 
 void TestCLI::testLoadClassificationModel() {
     
-    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI();
+    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI(_log);
     peakdetectorCLI->loadClassificationModel(clsfPath);
 
     QVERIFY(peakdetectorCLI->mavenParameters->clsf->hasModel());
@@ -35,7 +46,7 @@ void TestCLI::testLoadClassificationModel() {
 
 void TestCLI::testLoadCompoundsFile() {
 
-    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI();
+    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI(_log);
     peakdetectorCLI->mavenParameters->ligandDbFilename = dbPath;
     peakdetectorCLI->loadCompoundsFile();
 
@@ -45,7 +56,7 @@ void TestCLI::testLoadCompoundsFile() {
 
 void TestCLI::testLoadSamples() {
 
-    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI();
+    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI(_log);
     peakdetectorCLI->filenames.push_back(normalSample);
     peakdetectorCLI->filenames.push_back(blankSample);
 
@@ -59,7 +70,7 @@ void TestCLI::testLoadSamples() {
 
 void TestCLI::testProcessXml() {
 
-    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI();
+    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI(_log);
     peakdetectorCLI->processXML((char*)xmlPath);
 
     QVERIFY(peakdetectorCLI->mavenParameters->ionizationMode == -1);
@@ -108,7 +119,7 @@ void TestCLI::testProcessXml() {
 
 void TestCLI::testCreateXMLFile() {
 
-    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI();
+    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI(_log);
     peakdetectorCLI->createXMLFile((char*)createXmlPath);
 
 
@@ -125,7 +136,7 @@ void TestCLI::testCreateXMLFile() {
 
 void TestCLI::testReduceGroups() {
 
-    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI();
+    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI(_log);
 
 	peakdetectorCLI->processXML((char*)xmlPath);
 
@@ -159,7 +170,7 @@ void TestCLI::testReduceGroups() {
 
 void TestCLI::testWriteReport() {
 
-    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI();
+    PeakDetectorCLI* peakdetectorCLI = new PeakDetectorCLI(_log);
 
 	peakdetectorCLI->processXML((char*)xmlPath);
 

--- a/tests/MavenTests/testCLI.h
+++ b/tests/MavenTests/testCLI.h
@@ -8,6 +8,7 @@
 #include <QtTest>
 
 class PeakDetectorCLI;
+class Logger;
 
 using namespace std;
 
@@ -25,6 +26,7 @@ class TestCLI : public QObject {
         const char* blankSample;
         const char* xmlPath;
         const char* createXmlPath;
+        Logger* _log;
 
     private Q_SLOTS:
         void testLoadClassificationModel();


### PR DESCRIPTION
Logs are a very useful way of recording and persisting the output from an ongoing process. It is also very easy to read them and extract meaningful information for developers who might be interested in debugging or querying the state of the process at any point of time. Since, CLI is now being used by mutliple parties for different kinds of integration, logging the output and response from Polly APIs can help them at runtime to diagnose whether the process completed successfully or whether it failed and its point of failure in such a case.

Issue: #1143 