### PR TITLE
Fix last database load

### DIFF
--- a/src/gui/mzroll/librarymanager.cpp
+++ b/src/gui/mzroll/librarymanager.cpp
@@ -98,6 +98,21 @@ void LibraryManager::deleteSelectedDatabase()
     worker->deleteRecord(databaseRecord);
 }
 
+QString LibraryManager::filePathForDatabase(const QString& databaseName)
+{
+    QTreeWidgetItemIterator iter(libraryTable);
+    while (*iter) {
+        auto item = *iter;
+        auto var = item->data(0, Qt::UserRole);
+        auto database = var.value<LibraryRecord>();
+        if (databaseName == database.databaseName) {
+            return database.absolutePath;
+        }
+        ++iter;
+    }
+    return "";
+}
+
 void LibraryManager::_refreshDatabases()
 {
     libraryTable->clear();

--- a/src/gui/mzroll/librarymanager.h
+++ b/src/gui/mzroll/librarymanager.h
@@ -51,6 +51,16 @@ public slots:
      */
     void deleteSelectedDatabase();
 
+    /**
+     * @brief Obtain the file path for a given database name, if it exists in
+     * the library records.
+     * @param databaseName A `QString` containing the name of the stored
+     * database.
+     * @return A `QString` containing the absolute path of the database file. If
+     * the database is not found in library, then an empty string is returned.
+     */
+    QString filePathForDatabase(const QString& databaseName);
+
 protected:
     /**
      * @brief Overriding this method so that its contents are called everytime

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -239,8 +239,11 @@ void LigandWidget::setDatabase(QString dbname) {
                                               variant(dbname.toStdString()));
     }
 
-    _mw->getSettings()->setValue("lastCompoundDatabase", getDatabaseName());
-    Q_EMIT databaseChanged(getDatabaseName());
+    auto dbName = getDatabaseName();
+    auto dbPath = _mw->getLibraryManager()->filePathForDatabase(dbName);
+    _mw->setLastLoadedDatabase(dbPath);
+    _mw->getSettings()->setValue("lastCompoundDatabase", dbName);
+    Q_EMIT databaseChanged(dbName);
     showTable();
 }
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1897,16 +1897,11 @@ void MainWindow::_postCompoundsDBLoadActions(QString filename,
             analytics->hitEvent("PRM", "LoadedSpectralLibrary");
         }
 
-        // do not save NIST library files for automatic load when starting next
-        // session, unless they are less than 2Mb in size
-        QFileInfo fileInfo(filename);
+        setLastLoadedDatabase(filename);
+
         bool isMSPFile = filename.endsWith("msp", Qt::CaseInsensitive);
         bool isSPTXTFile = filename.endsWith("sptxt", Qt::CaseInsensitive);
         bool nistFile = isMSPFile || isSPTXTFile;
-        bool smallerThan2Mb = fileInfo.size() < 2000000;
-        if (!nistFile || smallerThan2Mb)
-            settings->setValue("lastDatabaseFile", filename);
-
         if (nistFile)
             _warnIfNISTPolarityMismatch();
 
@@ -2028,6 +2023,17 @@ void MainWindow::_warnIfNISTPolarityMismatch()
             analytics->hitEvent("PRM", "Closed", "Polarity Mismatch prompt");
         }
     }
+}
+
+void MainWindow::setLastLoadedDatabase(QString filename)
+{
+    QFileInfo fileInfo(filename);
+    bool isMSPFile = filename.endsWith("msp", Qt::CaseInsensitive);
+    bool isSPTXTFile = filename.endsWith("sptxt", Qt::CaseInsensitive);
+    bool nistFile = isMSPFile || isSPTXTFile;
+    bool smallerThan2Mb = fileInfo.size() < 2000000;
+    if (!nistFile || smallerThan2Mb)
+        settings->setValue("lastDatabaseFile", filename);
 }
 
 void MainWindow::checkCorruptedSampleInjectionOrder()

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -412,6 +412,15 @@ public Q_SLOTS:
      */
     QString getLatestUserProject();
 
+    /**
+     * @brief Save the filename of a compound database that should be loaded the
+     * next time El-MAVEN is started.
+     * @details NIST library files having size greater than 2Mb, are not saved
+     * for automatic load when starting the next session.
+     * @param filename Save the name of the file.
+     */
+    void setLastLoadedDatabase(QString filename);
+
 private Q_SLOTS:
 	void createMenus();
 	void openURL(int choice);


### PR DESCRIPTION
The current behavior of always loading the last compound database loaded (other than default ones), has been changed to load only the selected database of the last El-MAVEN session.