### PR TITLE
Fix regex pattern for matching table names

### DIFF
--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -2006,15 +2006,15 @@ void TableDockWidget::setTitleForId(int tableId, const QString& tableTitle)
   } else if (title.isEmpty()) {
       title = QString("Peak Table ") + QString::number(tableId);
   } else {
-    QString expression("(%1)(\\((\\d+)\\)$)");
+    QString expression("^(%1) (?:\\((\\d+)\\)$)");
     QRegularExpression re(expression.arg(tableTitle));
     bool titleExists = false;
     int highestCounter = 0;
-    for (auto &existingTitle : _idTitleMap.values()) {
+    for (auto& existingTitle : _idTitleMap.values()) {
       QRegularExpressionMatch match = re.match(existingTitle);
       if (match.hasMatch()) {
         titleExists = true;
-        int currentCounter = match.captured(3).toInt();
+        int currentCounter = match.captured(2).toInt();
         highestCounter = currentCounter > highestCounter ? currentCounter
                                                          : highestCounter;
       } else if (existingTitle == tableTitle) {


### PR DESCRIPTION
The pattern matching for querying whether tables of a certain name already exist or not, was incorrect and has been fixed.