### PR TITLE
Disable isotope reporting if no labels checked

### DIFF
--- a/src/gui/mzroll/isotopedialog.cpp
+++ b/src/gui/mzroll/isotopedialog.cpp
@@ -63,6 +63,19 @@ IsotopeDialog::IsotopeDialog(MainWindow* parent) : QDialog(parent) {
                                "Isotope Detection Switched",
                                state);
             });
+
+    auto checkIsotopeDetectionValid = [this](const bool checked) {
+        if (!D2Labeled_BPE->isChecked()
+            && !C13Labeled_BPE->isChecked()
+            && !N15Labeled_BPE->isChecked()
+            && !S34Labeled_BPE->isChecked()) {
+            reportIsotopesOptions->setChecked(false);
+        }
+    };
+    connect(D2Labeled_BPE, &QCheckBox::toggled, checkIsotopeDetectionValid);
+    connect(C13Labeled_BPE, &QCheckBox::toggled, checkIsotopeDetectionValid);
+    connect(N15Labeled_BPE, &QCheckBox::toggled, checkIsotopeDetectionValid);
+    connect(S34Labeled_BPE, &QCheckBox::toggled, checkIsotopeDetectionValid);
 }
 
 IsotopeDialog::~IsotopeDialog()


### PR DESCRIPTION
Isotope detection does not make sense when none of the isotopic labels are checked and therefore will be, hence, disabled as soon as all the labels are unchecked.