### PR TITLE
Preserve window size over sessions

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2507,7 +2507,7 @@ void MainWindow::readSettings() {
 
 void MainWindow::writeSettings() {
 	settings->setValue("pos", pos());
-	settings->setValue("size", size()*0.7);
+    settings->setValue("size", size());
 	settings->setValue("massCutoffWindowBox", massCutoffWindowBox->value());
 	settings->setValue("ionChargeBox", ionChargeBox->value());
 	settings->setValue("geometry", saveGeometry());


### PR DESCRIPTION
El-MAVEN has some in-built code written to read saved window size from the last session. But the window size itself was being scaled down by a factor of 0.7 and saved in application settings. This
led to El-MAVEN's window shrinking every new session. This scaling has been removed and now El-MAVEN should spawn at the exact position and size as when it was last (normally) closed.

Issue: #820