### PR TITLE
Fix zero slices being set for slice-empty groups

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -241,6 +241,17 @@ bool PeakGroup::hasSlice() const
     return _sliceSet;
 }
 
+bool PeakGroup::sliceIsZero() const
+{
+    if (((mzUtils::almostEqual(_slice.mzmin, 0.0f)
+         && mzUtils::almostEqual(_slice.mzmax, 0.0f)))
+        || (mzUtils::almostEqual(_slice.rtmin, 0.0f)
+            && mzUtils::almostEqual(_slice.mzmin, 0.0f))) {
+        return true;
+    }
+    return false;
+}
+
 //TODO: a duplicate function getPeak exists. Delete this function
 Peak* PeakGroup::getSamplePeak(mzSample* sample) {
     for (unsigned int i=0; i< peaks.size(); i++ ) {

--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -224,6 +224,15 @@ class PeakGroup{
         bool hasSlice() const;
 
         /**
+         * @brief Check whether both bounds of the group's slice are close to
+         * zero in either m/z or rt dimensions.
+         * @return `true` if either slice's `mzmin` and `mzmax` are both close
+         * to zero or slice's `rtmin` and `rtmax` are both close to zero, false
+         * otherwise.
+         */
+        bool sliceIsZero() const;
+
+        /**
          * [getParent ]
          * @method getParent
          * @return []

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1502,7 +1502,7 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
 
     if (!group->srmId.empty()) {
         setSrmId(group->srmId);
-    } else if (group->hasSlice()) {
+    } else if (group->hasSlice() && !group->sliceIsZero()) {
         setMzSlice(group->getSlice());
     }
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3937,11 +3937,7 @@ QWidget* MainWindowWidgetAction::createWidget(QWidget *parent) {
                     if (selectedGroup == nullptr)
                         return;
 
-                    auto& slice = selectedGroup->getSlice();
-                    if ((mzUtils::almostEqual(slice.mzmin, 0.0f)
-                         && mzUtils::almostEqual(slice.mzmax, 0.0f))
-                        || (mzUtils::almostEqual(slice.rtmin, 0.0f)
-                            && mzUtils::almostEqual(slice.rtmax, 0.0f))) {
+                    if (selectedGroup->sliceIsZero()) {
                         toleranceSyncSwitch->setChecked(false);
                         toleranceSyncSwitch->setDisabled(true);
                     } else {


### PR DESCRIPTION
The session save format emDB was only recently added with slice bounds of peak groups. Older emDB files that do not have any slice information were presented as empty EICs, now that EIC widget uses only the group's slice information to construct the chromatogram. This has been fixed by ensuring that slice information is non-zero before showing a slice in the widget. The alternate behavior is the same as before (i.e., using the group's mean mz adjusted using the global cutoff values).