### PR TITLE
[Fix] Use correct slice for isotope-parent correlation #861

### DIFF
--- a/src/core/libmaven/isotopeDetection.cpp
+++ b/src/core/libmaven/isotopeDetection.cpp
@@ -205,6 +205,11 @@ bool IsotopeDetection::filterIsotope(Isotope x, float isotopePeakIntensity, floa
     //here w should really be determined by the minRt and maxRt for the parent and child peaks
     if (parentGroup)
     {
+        float isotopeMass = x.mass;
+        Compound* compound = parentGroup->getCompound();
+        float parentMass = MassCalculator::computeMass(compound->formula, 
+                                                       _mavenParameters->getCharge(compound));
+
         Peak* parentPeak = parentGroup->getPeak(sample);
         float rtmin = parentGroup->minRt;
         float rtmax = parentGroup->maxRt;
@@ -213,8 +218,6 @@ bool IsotopeDetection::filterIsotope(Isotope x, float isotopePeakIntensity, floa
             rtmin = parentPeak->rtmin;
             rtmax = parentPeak->rtmax;
         }
-        float isotopeMass = x.mass;
-        float parentMass = parentGroup->meanMz;
         float w = _mavenParameters->maxIsotopeScanDiff
             * _mavenParameters->avgScanTime;
         double c = sample->correlation(


### PR DESCRIPTION
Isotopic groups are filtered out in case the EIC does not have a strong correlation with the parent EIC.
Since the parentMass used in the correlation calculation was the groupMz instead of compoundMz, the correlation was incorrect in some cases and resulted in filtration of C12 parent groups