### PR TITLE
[Ftr] Notify users about ability to load zlib compressed data

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -183,14 +183,6 @@ using namespace mzUtils;
 	QString dataDir = ".";
 	unloadableFiles.reserve(50);
 
-    string logPath = QString(QStandardPaths::writableLocation(
-                                 QStandardPaths::GenericConfigLocation)
-                             + QDir::separator()
-                             + "ElMaven"
-                             + QDir::separator()
-                             + "version.log").toStdString();
-    versionLogger = new Logger(logPath, false, false);
-
 	QList<QString> dirs;
 	dirs << dataDir << QApplication::applicationDirPath()
 		 << QApplication::applicationDirPath() + "/../Resources/";
@@ -202,7 +194,6 @@ using namespace mzUtils;
 	}
 
 	setWindowTitle(programName + " " + STR(EL_MAVEN_VERSION));
-    versionLogger->info() << STR(EL_MAVEN_VERSION) << endl;
 
 	//locations of common files and directories
 	QString methodsFolder = settings->value("methodsFolder").value<QString>();
@@ -750,7 +741,6 @@ MainWindow::~MainWindow()
 {
 	analytics->sessionEnd();
     delete mavenParameters;
-    delete versionLogger;
 }
 
 void MainWindow::sendPeaksGA()
@@ -1597,6 +1587,17 @@ void MainWindow::analyticsAverageSpectra(){
 
 void MainWindow::open()
 {
+    // TODO: temporarily added for informing user, remove after a few releases
+    if (!_versionRecordExists()) {
+        QMessageBox msgBox;
+        msgBox.setText("El-MAVEN is now capable of reading files containing "
+                       "zlib compressed data. Please feel free to load such "
+                       "files, if you have any.");
+        msgBox.setIcon(QMessageBox::Information);
+        QPushButton* b = msgBox.addButton("Continue", QMessageBox::AcceptRole);
+        msgBox.exec();
+    }
+
     QString dir = ".";
 
     if (settings->contains("lastDir")) {
@@ -1964,6 +1965,58 @@ void MainWindow::setLastLoadedDatabase(QString filename)
     bool smallerThan2Mb = fileInfo.size() < 2000000;
     if (!nistFile || smallerThan2Mb)
         settings->setValue("lastDatabaseFile", filename);
+}
+
+bool MainWindow::_versionRecordExists()
+{
+    QString currentVersion = STR(EL_MAVEN_VERSION);
+    QString versionLogPath = QString(QStandardPaths::writableLocation(
+                                         QStandardPaths::GenericConfigLocation)
+                                     + QDir::separator()
+                                     + "ElMaven"
+                                     + QDir::separator()
+                                     + "version.log");
+
+    // lambda that can be used to log an entry for the current app version
+    auto logCurrentVersion = [&]() {
+        Logger versionLogger(versionLogPath.toStdString(), false, false);
+        versionLogger.info() << currentVersion.toStdString() << endl;
+    };
+
+    // lambda that checks whether two regex matches represent the same hits
+    auto sameVersionMatch = [](QRegularExpressionMatch& first,
+                               QRegularExpressionMatch& second) {
+        // for two successful matches of version strings, one of which might be
+        // "v0.8.0-beta.2-142-g1d3468ae", checks whether the groups (0.8.0),
+        // (beta) and (2) match or not; build numbers and tags are disregarded
+        return (first.captured(2) == second.captured(2)
+                && first.captured(4) == second.captured(4)
+                && first.captured(6) == second.captured(6));
+    };
+
+    QFile data(versionLogPath);
+    if (!data.open(QFile::ReadOnly) ) {
+        qDebug() << "Cannot open file: " << versionLogPath;
+        logCurrentVersion();
+        return false;
+    }
+
+    QRegularExpression
+        ver("v((\\d+\\.\\d+\\.\\d+)(-(beta|alpha))?(\\.(\\d)*)?(-(\\d+))?)");
+    auto currentVersionMatch = ver.match(currentVersion);
+
+    QTextStream stream(&data);
+    while (!stream.atEnd()) {
+        QString line = stream.readLine();
+        auto match = ver.match(line);
+        if (match.hasMatch()
+            && sameVersionMatch(currentVersionMatch, match)) {
+            return true;
+        }
+    }
+
+    logCurrentVersion();
+    return false;
 }
 
 void MainWindow::checkCorruptedSampleInjectionOrder()

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -28,6 +28,7 @@
 #include "isotopeswidget.h"
 #include "librarymanager.h"
 #include "ligandwidget.h"
+#include "common/logger.h"
 #include "logwidget.h"
 #include "mainwindow.h"
 #include "masscalcgui.h"
@@ -182,7 +183,14 @@ using namespace mzUtils;
 	QString dataDir = ".";
 	unloadableFiles.reserve(50);
 
-	
+    string logPath = QString(QStandardPaths::writableLocation(
+                                 QStandardPaths::GenericConfigLocation)
+                             + QDir::separator()
+                             + "ElMaven"
+                             + QDir::separator()
+                             + "version.log").toStdString();
+    versionLogger = new Logger(logPath, false, false);
+
 	QList<QString> dirs;
 	dirs << dataDir << QApplication::applicationDirPath()
 		 << QApplication::applicationDirPath() + "/../Resources/";
@@ -194,6 +202,7 @@ using namespace mzUtils;
 	}
 
 	setWindowTitle(programName + " " + STR(EL_MAVEN_VERSION));
+    versionLogger->info() << STR(EL_MAVEN_VERSION) << endl;
 
 	//locations of common files and directories
 	QString methodsFolder = settings->value("methodsFolder").value<QString>();
@@ -741,6 +750,7 @@ MainWindow::~MainWindow()
 {
 	analytics->sessionEnd();
     delete mavenParameters;
+    delete versionLogger;
 }
 
 void MainWindow::sendPeaksGA()

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -68,7 +68,6 @@ class Analytics;
 class AutoSave;
 class MavenParameters;
 class LibraryManager;
-class Logger;
 
 extern Database DB;
 
@@ -519,12 +518,6 @@ private:
      */
     QString _latestUserProjectName;
 
-    /**
-     * @brief A logger used to record all the builds of the application that
-     * have ever run on a given system.
-     */
-    Logger* versionLogger;
-
     QString newFileName;
 
     QString _newAutosaveFile();
@@ -540,6 +533,18 @@ private:
      * failed completely, i.e., no compounds were loaded.
      */
     void _notifyIfBadCompoundsDB(QString filename, bool failedToLoadCompletely);
+
+    /**
+     * @brief This method allows checking whether a version of the application
+     * has been run before on a user's system.
+     * @details If the current running version does not exist in the record, a
+     * `Logger` is used to add the version to the record, which is a file
+     * reserved for this purpose. The record will be used in future checks to
+     * deduce which versions have already been run before.
+     * @return `true` if the current version has been run on the system before,
+     * false otherwise.
+     */
+    bool _versionRecordExists();
 };
 
 struct FileLoader {

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -68,6 +68,7 @@ class Analytics;
 class AutoSave;
 class MavenParameters;
 class LibraryManager;
+class Logger;
 
 extern Database DB;
 
@@ -517,6 +518,12 @@ private:
      * when saving from explicit user command or final save when exiting app.
      */
     QString _latestUserProjectName;
+
+    /**
+     * @brief A logger used to record all the builds of the application that
+     * have ever run on a given system.
+     */
+    Logger* versionLogger;
 
     QString newFileName;
 


### PR DESCRIPTION
This patch adds a message box that informs the user (only on the first run of an El-MAVEN version), that they can now load sample files containing zlib compressed data.