### PR TITLE
Alpha fixes

### DIFF
--- a/src/core/libmaven/isotopeDetection.cpp
+++ b/src/core/libmaven/isotopeDetection.cpp
@@ -160,6 +160,13 @@ map<string, PeakGroup> IsotopeDetection::getIsotopes(PeakGroup* parentgroup, vec
                     g.expectedAbundance = expectedAbundance;
                     g.isotopeC13count = x.C13;
                     g.setSelectedSamples(parentgroup->samples);
+
+                    // create a slice for this group; RT will be updated later
+                    mzSlice childSlice(mzmin,
+                                       mzmax,
+                                       0.0f,
+                                       numeric_limits<float>::max());
+                    g.setSlice(childSlice);
                     isotopes[isotopeName] = g;
                 }
                 isotopes[isotopeName].addPeak(*nearestPeak); //add nearestPeak to isotope peak list
@@ -320,10 +327,16 @@ void IsotopeDetection::childStatistics(
 
     child.tagString = isotopeName;
     child.groupId = parentgroup->groupId;
-    child.setCompound(parentgroup->getCompound());
     child.parent = parentgroup;
     child.setType(PeakGroup::Isotope);
     child.groupStatistics();
+
+    // we now have the RT limits for the isotopic group
+    mzSlice currentSlice = child.getSlice();
+    currentSlice.rtmin = child.minRt;
+    currentSlice.rtmax = child.maxRt;
+    child.setSlice(currentSlice);
+    child.setCompound(parentgroup->getCompound());
 
     bool deltaRtCheckFlag = _mavenParameters->deltaRtCheckFlag;
     float compoundRTWindow = _mavenParameters->compoundRTWindow;

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -209,7 +209,6 @@ void EicPoint::_updateWidgetsForScan(MainWindow* mw, Scan* scan)
             mw->fragSpectraDockWidget->setVisible(true);
             mw->fragSpectraDockWidget->raise();
             mw->fragSpectraWidget->overlayScan(scan);
-            mw->fragSpectraWidget->overlayCompoundFragmentation(mw->ligandWidget->getSelectedCompound());
         }
         if(scan->mslevel == 2)
             mw->spectralHitsDockWidget->limitPrecursorMz(scan->precursorMz);


### PR DESCRIPTION
This PR contains the following fixes:
* Fix raw spectra overlay being cleared when fragmentation widget is resized (for groups in table).
* Fix isotopic peak groups missing slice values.