### PR TITLE
[Fix] Cohort file deleted before validation

### DIFF
--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -821,10 +821,7 @@ QString PollyElmavenInterfaceDialog::_getRedirectionUrl(QString datetimestamp,
             return redirectionUrl;
 
         // send to google sheets if sample cohort file is not valid
-        QString CohortFileName = _writeableTempDir + QDir::separator()
-                                 + datetimestamp
-                                 + "_Cohort_Mapping_Elmaven.csv";
-        if (!_pollyIntegration->validSampleCohort(CohortFileName))
+        if (_lastCohortFileWasValid)
             landingPage = QString("gsheet_sym_polly_elmaven");
 
         if (workflowId == "-1")
@@ -927,6 +924,7 @@ QStringList PollyElmavenInterfaceDialog::_prepareFilesToUpload(QDir qdir,
         QString sampleCohortFileName = _writeableTempDir + QDir::separator() + datetimestamp +
                                         "_Cohort_Mapping_Elmaven.csv";
         _mainwindow->projectDockWidget->prepareSampleCohortFile(sampleCohortFileName);
+        _lastCohortFileWasValid = _pollyIntegration->validSampleCohort(CohortFileName);
 
         CSVReports csvrpt;
         QList<PeakGroup *> selectedGroups = peakTable->getSelectedGroups();

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -30,6 +30,7 @@ PollyElmavenInterfaceDialog::PollyElmavenInterfaceDialog(MainWindow* mw)
     _pollyIntegration = _mainwindow->getController()->iPolly;
     _loadingDialog = new PollyWaitDialog(this);
     _uploadInProgress = false;
+    _lastCohortFileWasValid = false;
 
     workflowMenu->setStyleSheet("QListView::item {"
                                 "border: 1px solid transparent;"
@@ -924,7 +925,7 @@ QStringList PollyElmavenInterfaceDialog::_prepareFilesToUpload(QDir qdir,
         QString sampleCohortFileName = _writeableTempDir + QDir::separator() + datetimestamp +
                                         "_Cohort_Mapping_Elmaven.csv";
         _mainwindow->projectDockWidget->prepareSampleCohortFile(sampleCohortFileName);
-        _lastCohortFileWasValid = _pollyIntegration->validSampleCohort(CohortFileName);
+        _lastCohortFileWasValid = _pollyIntegration->validSampleCohort(sampleCohortFileName);
 
         CSVReports csvrpt;
         QList<PeakGroup *> selectedGroups = peakTable->getSelectedGroups();
@@ -970,6 +971,7 @@ void PollyElmavenInterfaceDialog::_logout()
     usernameLabel->setText("");
     _licenseMap.clear();
     _redirectionUrlMap.clear();
+    _lastCohortFileWasValid = false;
     _pollyIntegration->logout();
     _projectNameIdMap = QVariantMap();
     _loadingDialog->close();

--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -266,6 +266,12 @@ private:
     bool _uploadInProgress;
 
     /**
+     * @brief A boolean that denotes whether the last sample cohort file
+     * prepared for upload was valid or not.
+     */
+    bool _lastCohortFileWasValid;
+
+    /**
      * @brief A worker thread that allows separating blocking operations from
      * the main event loop.
      */


### PR DESCRIPTION
An EPI file-uploader thread handles upload as well as removal of temporary files created for pushing to Polly. This thread deletes files as soon as they are uploaded, which leads to a case where the redirection URL always being generated for GSheet, even if a vaid sample-cohort file had existed and was uploaded.