### PR TITLE
Beta fixes (v0.9.1-beta.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,36 +148,55 @@ _To make sure the environment has ben setup correctly make sure the correct vers
 
 
 #### <a name="build"> </a> Build
-- `cd ElMaven`
-- For release builds : `qmake CONFIG+=release build.pro`
-- For debug builds : `qmake CONFIG+=debug build.pro`
-- `make -j4`
-- If you want to run tests and want to do a clean build, you can skip the above steps and just run the command from ElMaven directory: `./run.sh`
-- Run El-MAVEN: `bin/El-MAVEN`
+For release builds
+
+    cd ElMaven
+    qmake CONFIG+=release build.pro
+    make -j4
+
+For debug builds
+
+    cd ElMaven
+    qmake CONFIG+=debug build.pro
+    make -j4
+
+If, following earlier steps, El-MAVEN was linked to sentry-native on MacOS, then
+two additional commands need to be run for crash reporter to work correctly
+(this assumes that the `$SENTRY_MACOSX_BIN` env var is defined already):
+
+    install_name_tool -change @rpath/libsentry_crashpad.dylib $SENTRY_MACOSX_BIN/libsentry_crashpad.dylib bin/El-MAVEN.app/Contents/MacOS/El-MAVEN
+    cp $SENTRY_MACOSX_BIN/crashpad_handler bin/El-MAVEN.app/Contents/MacOS/
+
+To run the GUI application execute
+- Windows: `bin/El-MAVEN.exe`
+- Linux: `bin/El-MAVEN`
+- MacOS: `bin/El-MAVEN/Contents/MacOS/El-MAVEN`
+
+If you want to run tests or do a clean build, you can skip the above steps and
+simply execute our build script (in root source directory): `./run.sh`
+
+
 ### Switching versions
 
-Users can switch between versions once they have compiled El-MAVEN successfully on their system. Follow these steps to pull a specific release:
-
-- Choose the version you wish to install from the list of releases. (We recommend the version tagged "Latest release". Pre-releases are not stable and should be avoided)
+Users can switch between versions once they have compiled El-MAVEN successfully
+on their system. To pull a specific release, please follow these steps:
+- Choose the version you wish to install from the list of releases. We recommend
+the version tagged "Latest release". Pre-releases are not stable and should be
+avoided, unless you intend to test features in development.
 - Find the version tag (v0.2.x, 0.1.x, etc) on the left of release notes.
 - Open your terminal and move to the installation folder
 - Give the following commands in the terminal:  
-`cd ElMaven`  
-`./uninstall.sh` (to uninstall your current version)  
-`git checkout develop`  
-`git pull`  
-`git checkout v0.x.y` (Eg. v0.1.5)
+    ```bash
+    cd ElMaven
+    ./uninstall.sh # (to uninstall your current version)
+    git checkout develop
+    git pull
+    git checkout vx.y.z # (for example, v0.8.0)
+    ```
 - Build the new version using the following command:
+    * For Windows and Ubuntu: `./run.sh`
+    * For Mac: `source ~/.bash_profile && ./run.sh`
 
-For Windows and Ubuntu: 
-`./run.sh`
-
-For Mac:  
-`source ~/.bash_profile`
-
-`qmake CONFIG+=debug -o Makefile build.pro`
-
-`make -j4`
 
 ## El-MAVEN features
 

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1543,7 +1543,11 @@ void EicWidget::setSensitiveToTolerance(bool sensitive)
     if (sensitive) {
         setMassCutoff(getMainWindow()->getUserMassCutoff());
     } else {
-        setPeakGroup(eicParameters->selectedGroup());
+        // a new `PeakGroup` object has to be created because the `setPeakGroup`
+        // method initiates a `cleanup` that erases all peakgroups in
+        // `eicParameters` object; `eicParameters->selectedGroup()` might also
+        // be deleted which leads to corruption
+        setPeakGroup(new PeakGroup(*eicParameters->selectedGroup()));
     }
 }
 

--- a/src/gui/mzroll/librarymanager.cpp
+++ b/src/gui/mzroll/librarymanager.cpp
@@ -56,6 +56,7 @@ void LibraryManager::addDatabase(const QString &filepath)
 void LibraryManager::importNewDatabase()
 {
     _mw->loadCompoundsFile();
+    close();
 }
 
 void LibraryManager::loadSelectedDatabase()
@@ -67,6 +68,7 @@ void LibraryManager::loadSelectedDatabase()
 
     if (QFile::exists(filepath)) {
         _mw->loadCompoundsFile(filepath);
+        close();
     } else {
         QMessageBox msgBox;
         msgBox.setText("This database no longer exists at its last known "

--- a/src/gui/mzroll/librarymanager.cpp
+++ b/src/gui/mzroll/librarymanager.cpp
@@ -9,6 +9,8 @@ LibraryManager::LibraryManager(MainWindow* parent)
 {
     setupUi(this);
     libraryTable->setSortingEnabled(true);
+    loadButton->setEnabled(false);
+    deleteButton->setEnabled(false);
 
     connect(importButton,
             &QPushButton::clicked,

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -743,6 +743,9 @@ void ProjectDockWidget::saveSQLiteProject()
 void ProjectDockWidget::savePeakGroupInSQLite(PeakGroup* group,
                                               QString filename)
 {
+    if (group == nullptr)
+        return;
+
     if (!_mainwindow->fileLoader->sqliteProjectIsOpen()
             && !filename.isEmpty()) {
         saveSQLiteProject(filename);


### PR DESCRIPTION
The following issues have been fixed:
* Crash when bookmarking a group repeatedly.
* "Load" and "Delete" buttons being enabled by default, leading to a crash when library is empty.
* Crash when toggling mass tolerance switch with a group created by hovering over peaks.