### PR TITLE
[Fix] Perform time unit conversion for mzML scans #1176

### DIFF
--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -481,9 +481,12 @@ void mzSample::parseMzMLSpectrumList(const xml_node& spectrumList)
 
         xml_node scanNode = spectrum.first_element_by_path("scanList/scan");
         map<string, string> scanAttr = mzML_cvParams(scanNode);
-        if (scanAttr.count("scan start time")) {
-            string rtStr = scanAttr["scan start time"];
+        if (scanAttr.count("scan start time minute")) {
+            string rtStr = scanAttr["scan start time minute"];
             rt = string2float(rtStr);
+        } else if (scanAttr.count("scan start time second")) {
+            string rtStr = scanAttr["scan start time second"];
+            rt = string2float(rtStr) / 60.0f;
         }
 
         if (scanAttr.count("filter string")) {
@@ -580,6 +583,10 @@ map<string, string> mzSample::mzML_cvParams(xml_node node)
          cv = cv.next_sibling("cvParam")) {
         string name = cv.attribute("name").value();
         string value = cv.attribute("value").value();
+        if (name == "scan start time") {
+            string unit = cv.attribute("unitName").value();
+            name += " " + unit;
+        }
         attr[name] = value;
         // cerr << name << "->" << value << endl;
     }


### PR DESCRIPTION
Sample files in mzML format store `cvParam` tags for each scan, one of which is used to extract the recorded start time for scans. This tag also has a "unitName" attribute which was not being used until now. All scan time values were assumed to be in minutes, which ended up making mzML files with scan time stored as seconds being read and visualized incorrectly. The behaviour has been fixed - RT values will be converted according the given unit for each scan.