### PR TITLE
[Ftr] Warn user about sample load failure #676

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -588,6 +588,28 @@ using namespace mzUtils;
     connect(fileLoader,
             SIGNAL(sqliteDBUnrecognizedVersion(QString)),
             SLOT(_handleUnrecognizedProjectVersion(QString)));
+    connect(fileLoader,
+            &mzFileIO::sampleLoadFailed,
+            this,
+            [=](QList<QString> sampleFiles) {
+                QMessageBox msgBox;
+                msgBox.setWindowTitle("Sample load failure");
+                QString fileHtmlList = "";
+                for (auto& filepath : sampleFiles) {
+                    QFileInfo fi(filepath);
+                    fileHtmlList += "<li>" + fi.fileName();
+                }
+                auto htmlText = QString("<p>The following sample files "
+                                        "failed to load:</p>"
+                                        "<ul>%1</ul>").arg(fileHtmlList);
+                msgBox.setText(htmlText);
+                msgBox.setInformativeText("Please make sure your file import "
+                                          "settings do not conflict with the "
+                                          "type of samples being loaded.");
+                msgBox.setStyleSheet("QMessageBox { font-weight: normal; }");
+                msgBox.addButton(QMessageBox::Ok);
+                msgBox.exec();
+            });
 
     connect(spectralHitsDockWidget,SIGNAL(updateProgressBar(QString,int,int)), SLOT(setProgressBar(QString, int,int)));
     connect(eicWidget,SIGNAL(scanChanged(Scan*)),spectraWidget,SLOT(setScan(Scan*)));

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -520,6 +520,7 @@ void mzFileIO::fileImport(void) {
     int numMS1SamplesLoaded = 0;
     int numMS2SamplesLoaded = 0;
     int numPRMSamplesLoaded = 0;
+    QList<QString> samplesFailedToLoad;
     qDebug() << "uploadMultiprocessing: " <<  uploadMultiprocessing << endl;
     if (uploadMultiprocessing) {
         int iter = 0;
@@ -538,6 +539,8 @@ void mzFileIO::fileImport(void) {
                 } else if (sample->ms1ScanCount() && sample->ms2ScanCount()) {
                     ++numPRMSamplesLoaded;
                 }
+            } else {
+                samplesFailedToLoad.append(filename);
             }
 
             #pragma omp atomic
@@ -561,6 +564,8 @@ void mzFileIO::fileImport(void) {
                 } else if (sample->ms1ScanCount() && sample->ms2ScanCount()) {
                     ++numPRMSamplesLoaded;
                 }
+            } else {
+                samplesFailedToLoad.append(filename);
             }
 
             iter++;
@@ -606,6 +611,8 @@ void mzFileIO::fileImport(void) {
     Q_EMIT(updateProgressBar("Done importing", samples.size(), samples.size()));
     if (samples.size() > 0)
         Q_EMIT(sampleLoaded());
+    if (samplesFailedToLoad.size() > 0)
+        Q_EMIT(sampleLoadFailed(samplesFailedToLoad));
     if (spectralhits.size() > 0)
         Q_EMIT(spectraLoaded());
     if (projects.size() > 0)

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -265,6 +265,7 @@ Q_OBJECT
      void updateStatusString(QString);
      void updateProgressBar(QString,int,int);
      void sampleLoaded();
+     void sampleLoadFailed(QList<QString>);
      void spectraLoaded();
      void projectLoaded();
      void peaklistLoaded();


### PR DESCRIPTION
There might be various reasons due to which some (or all) samples can end up failing to load. Currently, there is no notification on such events which can be confusing to the user. Ideally, the exact reason for failure would help them understand what went wrong. In future we can have a proper error propagation mechanism, but for now we can at least inform users about the samples that failed to load.