### PR TITLE
[Fix] Update isotope plot on peak-group selection #703

### DIFF
--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -233,7 +233,6 @@ void EicWidget::integrateRegion(float rtmin, float rtmax) {
         eicParameters->_integratedGroup.computeFragPattern(ppm);
         eicParameters->_integratedGroup.matchFragmentation(ppm, scoringAlgo);
     }
-    getMainWindow()->isotopeWidget->updateIsotopicBarplot(&eicParameters->_integratedGroup);
     getMainWindow()->isotopeWidget->setPeakGroupAndMore(&eicParameters->_integratedGroup, true);
 }
 

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -127,6 +127,7 @@ void IsotopeWidget::setPeakGroupAndMore(PeakGroup *grp, bool bookmarkflg)
 		return;
 	
 	computeIsotopes(isotopeParameters->_formula);
+    updateIsotopicBarplot(grp);
 }
 
 void IsotopeWidget::updateIsotopicBarplot(PeakGroup *grp)

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1452,7 +1452,14 @@ void MainWindow::setCompoundFocus(Compound*c) {
 		if (isotopeWidget && isotopeWidget->isVisible()) {
 			isotopeWidget->setCompound(c);
 			isotopeWidget->setPeakGroupAndMore(selectedGroup);
-		}
+        } else if (isotopeWidget
+                   && isotopePlot
+                   && isotopePlot->isVisible()
+                   && selectedGroup
+                   && selectedGroup->getCompound() != NULL) {
+            isotopeWidget->updateIsotopicBarplot(selectedGroup);
+        }
+
 		if (fragSpectraWidget->isVisible())
 			fragSpectraWidget->overlayPeakGroup(selectedGroup);
     }
@@ -3326,7 +3333,13 @@ void MainWindow::setPeakGroup(PeakGroup* group) {
 
 	if (isotopeWidget && isotopeWidget->isVisible() && group->getCompound() != NULL) {
 		isotopeWidget->setPeakGroupAndMore(group);
-	}
+    } else if (isotopeWidget
+               && isotopePlot
+               && isotopePlot->isVisible()
+               && group
+               && group->getCompound() != NULL) {
+        isotopeWidget->updateIsotopicBarplot(group);
+    }
 
     if ( group->getCompound() != NULL) {
 		if (group->ms2EventCount) fragSpectraDockWidget->setVisible(true);

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -271,7 +271,6 @@ void EicPoint::setClipboardToIsotopes() {
                                   "Clipboard",
                                   "Isotopes Information");
     if (_group && _group->getCompound() != NULL && ! _group->getCompound()->formula.empty()) {
-        _mw->isotopeWidget->updateIsotopicBarplot(_group);
         _mw->isotopeWidget->setPeakGroupAndMore(_group, true);
         if (_peak)
             _mw->isotopeWidget->peakSelected(_peak, _group);


### PR DESCRIPTION
This patch will refresh isotope plot widget for the last peak-group selected in the current peak table.