### PR TITLE
[Travis] Explicitly downgrade libpulse dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ install:
       sudo apt-get install -y -qq lcov
       sudo apt-get update -qq;
       sudo apt-get install -y -qq --allow-unauthenticated qt5-qmake qtbase5-dev qtscript5-dev qtdeclarative5-dev libqt5webkit5-dev;
+      sudo apt-get install -y -qq --allow-unauthenticated --allow-downgrades libpulse-mainloop-glib0=1:8.0-0ubuntu3.10 libpulse0=1:8.0-0ubuntu3.10 libpulse-dev
       sudo apt-get install -y -qq --allow-unauthenticated libqt5opengl5 libqt5multimedia5 libqt5multimedia5-plugins qtmultimedia5-dev;
       sudo apt-get install -y -qq --allow-unauthenticated libsqlite3-dev libboost-all-dev libnetcdf-dev;
       eval "${MATRIX_EVAL}";


### PR DESCRIPTION
On Ubuntu 16.04 LTS, _libpulse-dev_ depends on _libpulse-mainloop-glib0_ (version `1:8.0-0ubuntu3.10`) and _libpulse0_ (version `1:8.0-0ubuntu3.10`). But the latest LTS packages for both these dependencies have been bumped to `1:8.0-0ubuntu3.11`, which makes "apt-get" decline installing libpulse-dev and its dependents (Qt5 multimedia libraries). Travis was stopping builds prematurely due to missing multimedia modules. This has been fixed by explicitly downgrading _libpulse-mainloop-glib0_ and _libpulse0_ to the last version.