### PR TITLE
[AppVeyor] Terminate build on compilation errors

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,6 +60,9 @@ build_script:
           if ( Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER ) {
               echo "Compiling in debug mode ..."
               &{ bash -lc "cd C:/projects/ElMaven/ ; echo no | ./run.sh" 2>&1 | %{ "$_" } }
+              if ( $LASTEXITCODE -ne 0 ) {
+                  exit 1
+              }
               bash -lc "lcov -b /c/Projects/ElMaven/src/core/libmaven/ --capture --directory /c/projects/build/tmp/maven/ --output-file /c/projects/ElMaven/lcov.info --no-external"
               &{ bash -lc "lcov --summary /c/projects/ElMaven/lcov.info" 2>&1 | %{ "$_" } }
           } else {
@@ -69,6 +72,9 @@ build_script:
               # ignored (make's warnings would otherwise be treated as error
               # signals by powershell).
               &{ make --silent -j4 2>&1 | %{ "$_" } }
+              if ( $LASTEXITCODE -ne 0 ) {
+                  exit 1
+              }
           }
 
 

--- a/crashhandler/crashreporter/file_uploader.cpp
+++ b/crashhandler/crashreporter/file_uploader.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QStandardPaths>
 #include <QApplication>
+#include <QSettings>
 
 #ifdef Q_OS_MAC
 #include "macuploader/interface.h"
@@ -59,8 +60,8 @@ void FileUploader::uploadMinidump()
                                         + "mixpanel.ini");
     auto settings = new QSettings(settingsPath, QSettings::IniFormat);
     QString clientId;
-    if (settings->contains("mixpanel-uuid")) {
-        clientId = gaSettings->value("mixpanel-uuid").toString();
+    if (settings->contains("mixpanel-uuid"))
+        clientId = settings->value("mixpanel-uuid").toString();
 
     qDebug() << "dump path: " << _dumpPath;
     qDebug() << "app name " << STR(APPNAME);


### PR DESCRIPTION
`make`'s warnings are interpreted as exceptions by AppVeyor's PowerShell environment. They are being handled by wrapping the compilation commands in a PS script block, but there was no check that would stop the build script in case of an actual compilation failure. This has been fixed by checking if the `$LASTEXITCODE` variable (which stores the return value of the last executable) is other than zero and terminating if that's the case.

The first commit should fail, because there were syntax errors in our crashreporter's `file_uploader.cpp` source. This file is compiled when in release mode and if the compilation fails, the build should stop. This tests whether our new exit code check works or not.

The second commit fixes the syntax errors and therefore, passes our build script.