### PR TITLE
[Fix] Pick MS2 events over individual peaks RT

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -793,7 +793,8 @@ vector<Scan*> PeakGroup::getFragmentationEvents()
     for(auto peak : peaks) {
         mzSample* sample = peak.getSample();
         if (sample == NULL) continue;
-        vector<Scan*> scans = sample->getFragmentationEvents(&_slice);
+        mzSlice slice(minMz, maxMz, peak.rtmin, peak.rtmax);
+        vector<Scan*> scans = sample->getFragmentationEvents(&slice);
 
         matchedScans.insert(matchedScans.end(), scans.begin(), scans.end());
     }


### PR DESCRIPTION
During our PeakGroup-mzSlice refactoring (PR #686), accidentally a change was introduced, which made calculation for MS2 group (consensus) spectra get calculated for each sample over the entire peak-group's RT coverage. Originally it was so that only those MS2 scans for a sample were considered for which the fragmentation RT lied within that sample's individiual peak. The post-refactor method is incorrect (and was unintentional) which is being undone with this commit.

This same fix will also help us get back to the original peak detection efficiency for DDA samples. Since more MS2 scans were being considered for each sample, the consensus spectra creation process was slower leading to a more time-consuming detection process.