### PR TITLE
[Fix] Incorrect peak count in results table #1142

### DIFF
--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -382,7 +382,8 @@ void TableDockWidget::addRow(PeakGroup *group, QTreeWidgetItem *root) {
 
   if (viewType == groupView) {
     item->setText(5, QString::number(group->expectedRtDiff, 'f', 2));
-    item->setText(6, QString::number(group->sampleCount));
+    item->setText(6, QString::number(group->sampleCount
+                                     + group->blankSampleCount));
     item->setText(7, QString::number(group->goodPeakCount));
     item->setText(8, QString::number(group->maxNoNoiseObs));
     item->setText(9, QString::number(extractMaxIntensity(group), 'g', 3));


### PR DESCRIPTION
Peak table shows the number of (non-blank) samples in which a peak was detected as the "# peaks" value. If in presence of blank samples, a peak-group has an above-threshold quality peak from the blanks, then the good peak count (show as "# good") will include them as well. The two metrics (total peak count and total good peak count) should not be different in their consideration of blank samples. This has been corrected. The displayed peak count will now be shown as the sum of peak-counts from blank and non-blank samples.