### PR TITLE
[Fix] Filter formula string for special characters #1168

### DIFF
--- a/src/cli/peakdetector/peakdetectorcli.cpp
+++ b/src/cli/peakdetector/peakdetectorcli.cpp
@@ -754,7 +754,7 @@ int PeakDetectorCLI::prepareCompoundDbForPolly(QString fileName)
                 out << compound->productMz << SEP;
                 out << compound->expectedRt << SEP;
                 out << compound->id.c_str() << SEP;
-                out << compound->formula.c_str() << SEP;
+                out << compound->formula().c_str() << SEP;
                 out << compound->srmId.c_str() << SEP;
                 out << category.join(";") << SEP;
                 out << "\n";
@@ -1315,7 +1315,7 @@ void PeakDetectorCLI::saveCSV(string setName, bool pollyExport)
                 PeakGroup newGroup = group;
                 Compound* compound = group.getCompound();
                 float compoundMz = MassCalculator::computeMass(
-                    compound->formula, mavenParameters->getCharge(compound));
+                    compound->formula(), mavenParameters->getCharge(compound));
                 float cutoffDist = massCutoffDist(
                     group.meanMz, compoundMz, mavenParameters->massCutoffMerge);
                 if (cutoffDist

--- a/src/core/libmaven/Compound.cpp
+++ b/src/core/libmaven/Compound.cpp
@@ -8,13 +8,13 @@ using namespace mzUtils;
 Compound::Compound(string id, string name, string formula, int charge ) {
     this->id = id;
     this->name = name;
-    this->formula = formula;
+    this->setFormula(formula);
     this->charge = charge;
     /**
     *@brief  -   calculate mass of compound by its formula and assign it to mass
     *@see  - double MassCalculator::computeNeutralMass(string formula) in mzMassCalculator.cpp
     */
-    this->mass =  MassCalculator::computeNeutralMass(formula);
+    this->mass =  MassCalculator::computeNeutralMass(_formula);
     this->expectedRt = -1;
     this->logP = 0;
 
@@ -32,7 +32,7 @@ bool Compound::operator == (const Compound& rhs) const
 {
     return (id == rhs.id
             && name == rhs.name
-            && formula == rhs.formula
+            && formula() == rhs.formula()
             && kegg_id == rhs.kegg_id
             && pubchem_id == rhs.pubchem_id
             && hmdb_id == rhs.hmdb_id
@@ -76,7 +76,7 @@ float Compound::adjustedMass(int charge) {
     *@return    -    total mass by formula minus loss of electrons' mass 
     *@see  -  double MassCalculator::computeMass(string formula, int charge) in mzMassCalculator.cpp
     */
-    return MassCalculator::computeMass(formula,charge);
+     return MassCalculator::computeMass(_formula, charge);
 }
 
 Compound::Type Compound::type() const {

--- a/src/core/libmaven/Compound.h
+++ b/src/core/libmaven/Compound.h
@@ -1,6 +1,7 @@
 #ifndef COMPOUND_H
 #define COMPOUND_H
 
+#include "constants.h"
 #include "standardincludes.h"
 #include "PeakGroup.h"
 
@@ -28,6 +29,11 @@ class Compound{
         *@param - _groupUnlinked will check  wether Compound and PeakGroup are linked or not
         */
         bool      _groupUnlinked;
+
+        /**
+         * Formula of the compound.
+         */
+        string _formula;
 
     public:
         enum class Type {
@@ -65,11 +71,51 @@ class Compound{
         string id;          /**@param - compund id */
 
         string name;        /**@param -  name of compound */
-        string formula;         /**@param -  formula of compound */
         string kegg_id;         /**@param -  kegg_id-    Kyoto Encyclopedia of Genes and Genomes id*/
         string pubchem_id;      /**@param  -  pubchem_id -    PubChem id*/
         string hmdb_id;         /**@param  -  hmdb_id-    Human Metabolome Database id */
         string alias;       /**@param   -  alias name of compound   */
+
+        /**
+         * @brief Obtain the formula set for this compound.
+         * @return A string representing a valid chemical formula.
+         */
+        string formula() const { return _formula; }
+
+        /**
+         * @brief Set the formula of this compound.
+         * @details Some basic filtering will be done on the formula string
+         * provided as the argument.
+         * @param formula Ideally, an alpha-numeric string, representing a valid
+         * chemical formula.
+         */
+        void setFormula(string formula) { _formula = filterFormula(formula); }
+
+        /**
+         * @brief Filters an arbitrary string and gets rid of any characters
+         * that are not allowed to be part of a small molecule formula.
+         * @details It should be noted that this is only a filter and not a
+         * parser of any sort. This function can be used to strip a possible
+         * formula string to a form which is equivalent to how El-MAVEN
+         * currently understands a checmical formula. The parsing scheme in
+         * `MassCalculator::getComposition` can be used as a guide.
+         * @param formulaString Any arbitrary string.
+         * @return A string stripped of all non-chemical characters.
+         */
+        static string filterFormula(string formulaString)
+        {
+            string validChars = CHE_FORMULA_ALPHA_UPP
+                                + CHE_FORMULA_ALPHA_LOW
+                                + CHE_FORMULA_COFF;
+            formulaString.erase(remove_if(formulaString.begin(),
+                                          formulaString.end(),
+                                          [validChars] (const char& c) {
+                                              return (validChars.find(c)
+                                                      == string::npos);
+                                          }),
+                                formulaString.end());
+            return formulaString;
+        }
 
         /**
          * @brief A simple string in form of a line notation for describing the
@@ -170,7 +216,7 @@ class Compound{
         /**
         *@brief  -  utility function to compare compound by formula for sorting purpose
         */
-        static bool compFormula(const Compound* a, const Compound* b ) { return(a->formula < b->formula); }
+        static bool compFormula(const Compound* a, const Compound* b ) { return(a->formula() < b->formula()); }
         /**
         *@brief   -  utility function to compare compound by number of reactions
         *it is involved in

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -444,7 +444,7 @@ void PeakDetector::identifyFeatures(const vector<Compound*>& identificationSet)
         bool matchFound = false;
         for (auto compound : identificationSet) {
             float mz = 0.0f;
-            if (compound->formula.length()) {
+            if (compound->formula().length()) {
                 int charge = mavenParameters->getCharge(compound);
                 mz = compound->adjustedMass(charge);
             } else {

--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -541,13 +541,13 @@ double PeakGroup::getExpectedMz(int charge) {
         && childCount() == 0
         && hasSlice()
         && _slice.compound != NULL
-        && !_slice.compound->formula.empty()
+        && !_slice.compound->formula().empty()
         && _slice.compound->mass > 0
     ) { 
         return expectedMz;
     }
     else if (!isIsotope() && hasSlice() && _slice.compound != NULL && _slice.compound->mass > 0) {
-        if (!_slice.compound->formula.empty()) {
+        if (!_slice.compound->formula().empty()) {
             mz = _slice.compound->adjustedMass(charge);
         } else {
             mz = _slice.compound->mass;

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -352,8 +352,8 @@ void CSVReports::writeGroupInfo(PeakGroup* group) {
     if (group->getCompound() != NULL) {
         compoundName = sanitizeString(group->getCompound()->name.c_str()).toStdString();
         compoundID   = sanitizeString(group->getCompound()->id.c_str()).toStdString();
-        formula = sanitizeString(group->getCompound()->formula.c_str()).toStdString();
-        if (!group->getCompound()->formula.empty()) {
+        formula = sanitizeString(group->getCompound()->formula().c_str()).toStdString();
+        if (!group->getCompound()->formula().empty()) {
             int charge = getMavenParameters()->getCharge(group->getCompound());
             if (group->parent != NULL) {
                 ppmDist = mzUtils::massCutoffDist((double) group->getExpectedMz(charge),
@@ -442,7 +442,7 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
     if (group->getCompound() != NULL) {
         compoundName = sanitizeString(group->getCompound()->name.c_str()).toStdString();
         compoundID   = sanitizeString(group->getCompound()->id.c_str()).toStdString();
-        formula = sanitizeString(group->getCompound()->formula.c_str()).toStdString();
+        formula = sanitizeString(group->getCompound()->formula().c_str()).toStdString();
     } else {
         // absence of a group compound means this group was created using untargeted detection,
         // we set compound name and ID to {mz}@{rt} strings for untargeted sets.

--- a/src/core/libmaven/databases.cpp
+++ b/src/core/libmaven/databases.cpp
@@ -216,7 +216,7 @@ bool Databases::addCompound(Compound* c) {
                 //compound from the same database
                 currentCompound->id = c->id;
                 currentCompound->name = c->name;
-                currentCompound->formula = c->formula;
+                currentCompound->setFormula(c->formula());
                 currentCompound->srmId = c->srmId;
                 currentCompound->expectedRt = c->expectedRt;
                 currentCompound->charge = c->charge;

--- a/src/core/libmaven/datastructures/mzSlice.cpp
+++ b/src/core/libmaven/datastructures/mzSlice.cpp
@@ -31,11 +31,11 @@ mzSlice::mzSlice()
 bool mzSlice::calculateMzMinMax(MassCutoff *compoundMassCutoffWindow, int charge)
 {
 	
-	//Calculating the mzmin and mzmax
-	if (!this->compound->formula.empty())
+    //Calculating the mzmin and mzmax
+    if (!this->compound->formula().empty())
 	{
-		//Computing the mass if the formula is given
-		double mass = MassCalculator::computeMass(this->compound->formula, charge);
+        //Computing the mass if the formula is given
+        double mass = MassCalculator::computeMass(this->compound->formula(), charge);
 		this->mzmin = mass - compoundMassCutoffWindow->massCutoffValue(mass);
 		this->mzmax = mass + compoundMassCutoffWindow->massCutoffValue(mass);
 	}

--- a/src/core/libmaven/isotopeDetection.cpp
+++ b/src/core/libmaven/isotopeDetection.cpp
@@ -35,12 +35,12 @@ void IsotopeDetection::pullIsotopes(PeakGroup* parentgroup)
         return;
     if (parentgroup->getCompound() == NULL)
         return;
-    if (parentgroup->getCompound()->formula.empty() == true)
+    if (parentgroup->getCompound()->formula().empty() == true)
         return;
     if (_mavenParameters->samples.size() == 0)
         return;
 
-    string formula = parentgroup->getCompound()->formula; //parent formula
+    string formula = parentgroup->getCompound()->formula(); //parent formula
     int charge = _mavenParameters->getCharge(parentgroup->getCompound());//generate isotope list for parent mass
 
     vector<Isotope> masslist = MassCalculator::computeIsotopes(
@@ -214,7 +214,7 @@ bool IsotopeDetection::filterIsotope(Isotope x, float isotopePeakIntensity, floa
     {
         float isotopeMass = x.mass;
         Compound* compound = parentGroup->getCompound();
-        float parentMass = MassCalculator::computeMass(compound->formula, 
+        float parentMass = MassCalculator::computeMass(compound->formula(),
                                                        _mavenParameters->getCharge(compound));
 
         Peak* parentPeak = parentGroup->getPeak(sample);

--- a/src/core/libmaven/isotopelogic.cpp
+++ b/src/core/libmaven/isotopelogic.cpp
@@ -14,8 +14,8 @@ void IsotopeLogic::userChangedFormula() {
 
 	_group = NULL;
 
-	tempCompound->formula = _formula;
-	tempCompound->name = "Unknown_" + _formula;
+    tempCompound->setFormula(_formula);
+    tempCompound->name = "Unknown_" + tempCompound->formula();
 	tempCompound->id = "unknown";
 	_compound = tempCompound;
 }

--- a/src/core/libmaven/jsonReports.cpp
+++ b/src/core/libmaven/jsonReports.cpp
@@ -67,7 +67,7 @@ void JSONReports::_writeCompoundLink(PeakGroup& grp, ofstream& filename)
     filename << "\"compoundId\": "<< _sanitizeJSONstring(compoundID) ;
     string compoundName = grp.getCompound()->name;
     filename << ",\n" << "\"compoundName\": "<< _sanitizeJSONstring(compoundName);
-    string formula = grp.getCompound()->formula;
+    string formula = grp.getCompound()->formula();
     filename << ",\n" << "\"formula\": "<< _sanitizeJSONstring(formula);
     filename << ",\n" << "\"expectedRt\": " << grp.getCompound()->expectedRt;
     filename << ",\n" << "\"expectedMz\": " << mz ;

--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -467,8 +467,8 @@ int Database::loadNISTLibrary(QString filepath,
             // before reading the next record or ending stream, save the
             // compound created from last record
             if (currentCompound and !currentCompound->name.empty()) {
-                if (!currentCompound->formula.empty()) {
-                    auto formula = currentCompound->formula;
+                if (!currentCompound->formula().empty()) {
+                    auto formula = currentCompound->formula();
                     auto exactMass = MassCalculator::computeMass(formula, 0);
                     currentCompound->mass = exactMass;
                 }
@@ -537,12 +537,12 @@ int Database::loadNISTLibrary(QString filepath,
             QString formula = line.mid(9, line.length()).simplified();
             formula.replace("\"", "", Qt::CaseInsensitive);
             if (!formula.isEmpty())
-                currentCompound->formula = formula.toStdString();
+                currentCompound->setFormula(formula.toStdString());
         } else if (line.startsWith("MOLECULE FORMULA:", Qt::CaseInsensitive)) {
             QString formula = line.mid(17, line.length()).simplified();
             formula.replace("\"", "", Qt::CaseInsensitive);
             if (!formula.isEmpty())
-                currentCompound->formula = formula.toStdString();
+                currentCompound->setFormula(formula.toStdString());
         } else if (line.startsWith("CATEGORY:", Qt::CaseInsensitive)) {
             currentCompound->category.push_back(line.mid(10, line.length())
                                                     .simplified()
@@ -560,9 +560,9 @@ int Database::loadNISTLibrary(QString filepath,
         } else if (line.startsWith("COMMENT:", Qt::CaseInsensitive)) {
             QString comment = line.mid(8, line.length()).simplified();
             if (comment.contains(formulaMatch)) {
-                currentCompound->formula = formulaMatch.capturedTexts()
-                                                       .at(1)
-                                                       .toStdString();
+                currentCompound->setFormula(formulaMatch.capturedTexts()
+                                                        .at(1)
+                                                        .toStdString());
             }
             if (comment.contains(retentionTimeMatch)) {
                 currentCompound->expectedRt = retentionTimeMatch.capturedTexts()

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1407,7 +1407,7 @@ void EicWidget::setCompound(Compound* c)
 	MassCutoff* massCutoff=getMainWindow()->getUserMassCutoff(); 
 	float mz = 0;
 
-	if (!c->formula.empty()) {
+    if (!c->formula().empty()) {
 		int charge = getMainWindow()->mavenParameters->getCharge(c);
 		mz = c->adjustedMass(charge);
 	} else {

--- a/src/gui/mzroll/gallerywidget.cpp
+++ b/src/gui/mzroll/gallerywidget.cpp
@@ -118,9 +118,9 @@ void GalleryWidget::addEicPlots(std::vector<Compound*>&compounds) {
 		slice.rtmax = 1e9;
 		if (!c->srmId.empty()) slice.srmId=c->srmId;
 
-		if (!c->formula.empty()) {
-			int charge = mainwindow->mavenParameters->getCharge(c);
-			double mass = mcalc.computeMass(c->formula,charge);
+        if (!c->formula().empty()) {
+            int charge = mainwindow->mavenParameters->getCharge(c);
+            double mass = mcalc.computeMass(c->formula(), charge);
             double massCutoffW = massCutoff->massCutoffValue(mass);
             slice.mzmin = mass-massCutoffW;
             slice.mzmax = mass+massCutoffW;

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -143,8 +143,8 @@ void IsotopeWidget::setCompound(Compound *cpd)
 {
 	clearWidget();
 	if (cpd == NULL)
-		return;
-	QString f = QString(cpd->formula.c_str());
+        return;
+    QString f = QString(cpd->formula().c_str());
 	//isotopeParameters->_group = NULL;
 	isotopeParameters->_compound = cpd;
 	setWindowTitle("Isotopes:" + QString(cpd->name.c_str()));

--- a/src/gui/mzroll/ligandwidget.cpp
+++ b/src/gui/mzroll/ligandwidget.cpp
@@ -292,7 +292,7 @@ void LigandWidget::showMatches(QString needle) {
                     QStringList stack;
                     stack << compound->name.c_str()
                           << compound->id.c_str()
-                          << compound->formula.c_str();
+                          << compound->formula().c_str();
 
                     if( compound->category.size()) {
                         for(int i=0; i < compound->category.size(); i++) {
@@ -357,7 +357,7 @@ void LigandWidget::showTable() {
         float precursorMz = compound->precursorMz;
         float productMz = compound->productMz;
 
-        if (compound->formula.length()) {
+        if (compound->formula().length()) {
             int charge = _mw->mavenParameters->getCharge(compound);
             mz = compound->adjustedMass(charge);
         } 
@@ -378,8 +378,8 @@ void LigandWidget::showTable() {
 
         if (compound->charge)
             addItem(parent, "Charge", compound->charge);
-        if (compound->formula.length())
-            addItem(parent, "Formula", compound->formula.c_str());
+        if (compound->formula().length())
+            addItem(parent, "Formula", compound->formula().c_str());
         if (compound->precursorMz && compound->fragmentMzValues.size() == 0)
             addItem(parent, "Precursor Mz", compound->precursorMz);
         if (compound->productMz)
@@ -521,7 +521,7 @@ void LigandWidget::saveCompoundList(QString fileName,QString dbname){
             out << compound->productMz    << SEP;
             out << compound->expectedRt   << SEP;
             out << compound->id.c_str() <<  SEP;
-            out << compound->formula.c_str() << SEP;
+            out << compound->formula().c_str() << SEP;
             out << compound->srmId.c_str() << SEP;
             out << category.join(";") << SEP;
             out << "\n";
@@ -621,7 +621,7 @@ QList<Compound*> LigandWidget::parseXMLRemoteCompounds()
             if (currentTag == "item") {
                 if (remoteCompound !=NULL) {
 
-                    if (!remoteCompound->formula.empty()) {
+                    if (!remoteCompound->formula().empty()) {
                         remoteCompound->mass=remoteCompound->adjustedMass(0);
                     }
 
@@ -653,7 +653,7 @@ QList<Compound*> LigandWidget::parseXMLRemoteCompounds()
                 remoteCompound->name = xmltext.toStdString();
 
             else if (currentTag == "formula")
-                remoteCompound->formula = xmltext.toStdString();
+                remoteCompound->setFormula(xmltext.toStdString());
 
             else if (currentTag == "kegg_id")
                 remoteCompound->kegg_id = xmltext.toStdString();
@@ -729,7 +729,7 @@ void LigandWidget::matchFragmentation() {
 
     int charge = _mw->mavenParameters->getCharge(c); //user specified ionization mode
 	float precursorMz = c->precursorMz;
-    if (!c->formula.empty()) precursorMz = c->adjustedMass(charge);
+    if (!c->formula().empty()) precursorMz = c->adjustedMass(charge);
 
     for(int i=0; i < mzCount; i++ ) {
                         float mz = c->fragmentMzValues[i];

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1451,8 +1451,8 @@ void MainWindow::setCompoundFocus(Compound*c) {
 	qDebug() << "setCompoundFocus:" << c->name.c_str() << " " << charge << " "
 			<< c->expectedRt;
 
-	float mz = c->mass;
-	if (!c->formula.empty())
+    float mz = c->mass;
+    if (!c->formula().empty())
 		mz = c->adjustedMass(charge);
     searchText->setText(QString::number(mz, 'f', 8));
 
@@ -4294,10 +4294,10 @@ MatrixXf MainWindow::getIsotopicMatrix(PeakGroup* group) {
 			MM(j, i) = values[j];  //rows=samples, columns=isotopes
 	}
 
-	int numberofCarbons = 0;
-	if (group->getCompound() && !group->getCompound()->formula.empty()) {
-		map<string, int> composition = MassCalculator::getComposition(
-				group->getCompound()->formula);
+    int numberofCarbons = 0;
+    if (group->getCompound() && !group->getCompound()->formula().empty()) {
+        map<string, int> composition = MassCalculator::getComposition(
+            group->getCompound()->formula());
 		numberofCarbons = composition["C"];
 	}
 	isotopeC13Correct(MM, numberofCarbons, carbonIsotopeSpecies);
@@ -4349,10 +4349,10 @@ MatrixXf MainWindow::getIsotopicMatrixIsoWidget(PeakGroup* group) {
 		}
 	}
 
-	int numberofCarbons = 0;
-	if (group->getCompound() && !group->getCompound()->formula.empty()) {
-		map<string, int> composition = MassCalculator::getComposition(
-				group->getCompound()->formula);
+    int numberofCarbons = 0;
+    if (group->getCompound() && !group->getCompound()->formula().empty()) {
+        map<string, int> composition = MassCalculator::getComposition(
+            group->getCompound()->formula());
 		numberofCarbons = composition["C"];
 	}
 

--- a/src/gui/mzroll/masscalcgui.cpp
+++ b/src/gui/mzroll/masscalcgui.cpp
@@ -149,7 +149,7 @@ QSet<Compound*> MassCalcWidget::findMathchingCompounds(float mz, MassCutoff *mas
         Compound* c = *itr;
         if (!c)
             continue;
-        double cmass = MassCalculator::computeMass(c->formula, charge);
+        double cmass = MassCalculator::computeMass(c->formula(), charge);
         if (mzUtils::massCutoffDist((double) cmass,
                                     (double) mz,
                                     massCutoff) < massCutoff->getMassCutoff()
@@ -169,8 +169,8 @@ void MassCalcWidget::getMatches() {
     delete_all(matches);
     Q_FOREACH(Compound* c, compounds) {
         MassCalculator::Match* m = new MassCalculator::Match();
-        m->name = c->formula;
-        m->mass = MassCalculator::computeMass(c->formula,
+        m->name = c->formula();
+        m->mass = MassCalculator::computeMass(c->formula(),
                                               _mw->mavenParameters->getCharge(c));
         m->diff = mzUtils::massCutoffDist((double)m->mass,
                                           (double)_mz,

--- a/src/gui/mzroll/pathwaywidget.cpp
+++ b/src/gui/mzroll/pathwaywidget.cpp
@@ -360,8 +360,8 @@ void PathwayWidget::setCompound(Compound* c) {
 	clear();
 
 	//set title
-	QString title = QString(c->name.c_str()) + " "
-			+ QString(c->formula.c_str());
+    QString title = QString(c->name.c_str()) + " "
+                    + QString(c->formula().c_str());
 	setTitle(title);
 
 	//get reactions
@@ -444,8 +444,8 @@ void PathwayWidget::setCompoundFocus(Compound* c) {
 		return;
 	_focusedCompound = c;
 
-	QString title = QString(c->name.c_str()) + ": "
-			+ QString(c->formula.c_str());
+    QString title = QString(c->name.c_str()) + ": "
+                    + QString(c->formula().c_str());
 	setTitle(title);
 
 	c = _focusedCompound;
@@ -1185,8 +1185,8 @@ void PathwayWidget::saveModelFile(QString filename) {
 			stream.writeAttribute("ycoord",QString::number(node->pos().y()));
 		}
 
-		if (c) {
-			stream.writeAttribute("formula",c->formula.c_str());
+        if (c) {
+            stream.writeAttribute("formula", c->formula().c_str());
 			stream.writeAttribute("expectedRt",QString::number(c->expectedRt));
 			//stream.writeAttribute("name",c->name.c_str());
 		}

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -270,7 +270,9 @@ void EicPoint::setClipboardToIsotopes() {
     _mw->getAnalytics()->hitEvent("Exports",
                                   "Clipboard",
                                   "Isotopes Information");
-    if (_group && _group->getCompound() != NULL && ! _group->getCompound()->formula.empty()) {
+    if (_group
+        && _group->getCompound() != NULL
+        && ! _group->getCompound()->formula().empty()) {
         _mw->isotopeWidget->setPeakGroupAndMore(_group, true);
         if (_peak)
             _mw->isotopeWidget->peakSelected(_peak, _group);
@@ -307,7 +309,8 @@ void EicPoint::contextMenuEvent ( QGraphicsSceneMouseEvent* event ) {
     connect(c1, SIGNAL(triggered()), SLOT(setClipboardToGroup()));
 
     if (_group && _group->getCompound() ) {
-       if ( _group->isIsotope() == false && !_group->getCompound()->formula.empty() ) {
+       if ( _group->isIsotope() == false
+            && !_group->getCompound()->formula().empty() ) {
             QAction* z = menu.addAction("Copy Isotope Information to Clipboard");
             z->setIcon(QIcon(rsrcPath + "/copyCSV.png"));
             connect(z, SIGNAL(triggered()), SLOT(setClipboardToIsotopes()));

--- a/src/gui/mzroll/spectrawidget.cpp
+++ b/src/gui/mzroll/spectrawidget.cpp
@@ -298,7 +298,7 @@ void SpectraWidget::overlayCompoundFragmentation(Compound* c)
         hit.score = 0;
     //TODO: precursormz should be preset as the compound m/z
     //compound->mass should be reserved for exact mass or renamed
-    if (!c->formula.empty())
+    if (!c->formula().empty())
         c->precursorMz = c->adjustedMass(mainwindow->mavenParameters->getCharge(c));
     if (mzUtils::almostEqual(c->precursorMz, 0.0f))
         c->precursorMz = c->mass;

--- a/src/gui/mzroll/suggest.cpp
+++ b/src/gui/mzroll/suggest.cpp
@@ -124,7 +124,7 @@ void SuggestPopup::doSearchCompounds(QString needle) {
     for(unsigned int i=0;  i < DB.compoundsDB.size(); i++ ) {
         Compound* c = DB.compoundsDB[i];
         QString name(c->name.c_str() );
-        QString formula(c->formula.c_str() );
+        QString formula(c->formula().c_str() );
         QString id(c->id.c_str() );
 
         if ( name.length()==0) continue;

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -450,7 +450,7 @@ void ProjectDatabase::saveCompounds(const set<Compound*>& seenCompounds)
         compoundsQuery->bind(":compound_id", c->id);
         compoundsQuery->bind(":db_name", c->db);
         compoundsQuery->bind(":name", c->name);
-        compoundsQuery->bind(":formula", c->formula);
+        compoundsQuery->bind(":formula", c->formula());
         compoundsQuery->bind(":smile_string", c->smileString);
         compoundsQuery->bind(":srm_id", c->srmId);
 

--- a/tests/MavenTests/testIsotopeDetection.cpp
+++ b/tests/MavenTests/testIsotopeDetection.cpp
@@ -64,7 +64,7 @@ void TestIsotopeDetection::testgetIsotopes() {
     peakDetector.processSlices(slices, "compounds");
     PeakGroup* parentgroup = &mavenparameters->allgroups[0];
 
-    string formula = parentgroup->getCompound()->formula;
+    string formula = parentgroup->getCompound()->formula();
 
     int charge = mavenparameters->getCharge(parentgroup->getCompound());
 

--- a/tests/MavenTests/testLoadDB.cpp
+++ b/tests/MavenTests/testLoadDB.cpp
@@ -50,7 +50,7 @@ void TestLoadDB::testExtractCompoundfromEachLineNormal() {
     TestUtils::floatCompare(compound->expectedRt, 14.14) && \
     TestUtils::floatCompare(compound->charge, -1) && \
     name.compare(compound->name) == 0 && \
-    formula.compare(compound->formula) == 0 && \
+    formula.compare(compound->formula()) == 0 && \
     id.compare(compound->id) == 0 && \
     db.compare(compound->db) == 0);
 }
@@ -78,7 +78,7 @@ void TestLoadDB::testExtractCompoundfromEachLineWithNoMz() {
     TestUtils::floatCompare(compound->expectedRt, 14.14) && \
     TestUtils::floatCompare(compound->charge, -1) && \
     name.compare(compound->name) == 0 && \
-    formula.compare(compound->formula) == 0 && \
+    formula.compare(compound->formula()) == 0 && \
     id.compare(compound->id) == 0 && \
     db.compare(compound->db) == 0);
 }
@@ -129,7 +129,7 @@ void TestLoadDB::testExtractCompoundfromEachLineWithExpRTandRT() {
     TestUtils::floatCompare(compound->expectedRt, 12.14) && \
     TestUtils::floatCompare(compound->charge, -1) && \
     name.compare(compound->name) == 0 && \
-    formula.compare(compound->formula) == 0 && \
+    formula.compare(compound->formula()) == 0 && \
     id.compare(compound->id) == 0 && \
     db.compare(compound->db) == 0);
 }
@@ -159,7 +159,7 @@ void TestLoadDB::testExtractCompoundfromEachLineWithCompoundField() {
     TestUtils::floatCompare(compound->expectedRt, 14.14) && \
     TestUtils::floatCompare(compound->charge, -1) && \
     compoundname.compare(compound->name) == 0 && \
-    formula.compare(compound->formula) == 0 && \
+    formula.compare(compound->formula()) == 0 && \
     id.compare(compound->id) == 0 && \
     db.compare(compound->db) == 0);
 }


### PR DESCRIPTION
Only a subset of alpha-numeric characters are read from formula strings from any compound database. But internally the formula is still saved as the same string that was provided with the database. This, although it does not affect El-MAVEN much, can be problematic for downstream analysis where valid chemical formula (as in KEGG DB notation) may be expected. Therefore, with this commit, all formula strings will be stripped as soon as they are assigned to a compound, and exported to different formats/destinations as such.