### PR TITLE
[Fix] Missing mz-intensity pairs from scans

### DIFF
--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -894,8 +894,8 @@ void mzSample::populateMzAndIntensity(const vector<float>& mzint, Scan* _scan)
         float intensityValue = mzint[j++];
         // cerr << mzValue << " " << intensityValue << endl;
         if (mzValue > 0 && intensityValue > 0) {
-            _scan->mz[i] = mzValue;
-            _scan->intensity[i] = intensityValue;
+            _scan->mz[count] = mzValue;
+            _scan->intensity[count] = intensityValue;
             count++;
         }
     }


### PR DESCRIPTION
While iterating over an mz-intensity pair vector (obtained from parsing mzXML spectra strings), we populate Scan::mz and Scan::intensity vectors in the exact same indexes as recorded in a scan. But some zero values could be present in-between two non-zero pairs, and when the mz and intensity vectors are resized to the non-zero count value, these zero pairs might end up staying while non-zero pairs are the end of the vectors are cleaved.