### PR TITLE
[UI] Add close button to widgets

### DIFF
--- a/src/gui/mzroll/isotopeplotdockwidget.cpp
+++ b/src/gui/mzroll/isotopeplotdockwidget.cpp
@@ -35,45 +35,33 @@ void IsotopePlotDockWidget::setToolBar()
     toolBar->setFloatable(false);
     toolBar->setMovable(false);
 
-    QLabel *title = new QLabel("Isotope Plot: ");
+    QLabel *title = new QLabel("Isotope Plot");
+    title->setStyleSheet("QLabel { margin-left: 6px; }");
     toolBar->addWidget(title);
 
+    toolBar->addSeparator();
+    toolBar->addWidget(new QLabel("Labels: "));
+
     QWidget* spacer1 = new QWidget();
-    spacer1->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     toolBar->addWidget(spacer1);
 
     QCheckBox *C13 = new QCheckBox("C13");
     C13->setChecked(true);
     toolBar->addWidget(C13);
 
-    QWidget *spacer2 = new QWidget();
-    spacer2->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    toolBar->addWidget(spacer2);
-
     QCheckBox *N15 = new QCheckBox("N15");
     N15->setChecked(false);
     toolBar->addWidget(N15);
-
-    QWidget *spacer3 = new QWidget();
-    spacer3->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    toolBar->addWidget(spacer3);
 
     QCheckBox *D2 = new QCheckBox("D2");
     D2->setChecked(false);
     toolBar->addWidget(D2);
 
-    QWidget *spacer4 = new QWidget();
-    spacer4->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    toolBar->addWidget(spacer4);
-
     QCheckBox *S34 = new QCheckBox("S34");
     S34->setChecked(false);
     toolBar->addWidget(S34);
 
-    QWidget *spacer5 = new QWidget();
-    spacer5->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    toolBar->addWidget(spacer5);
-
+    toolBar->addSeparator();
     QLabel *pool = new QLabel("Other: <");
     toolBar->addWidget(pool);
 
@@ -84,6 +72,18 @@ void IsotopePlotDockWidget::setToolBar()
     poolLabels->setToolTip("Show < x% as Other");
     poolLabels->setSuffix(" %");
     toolBar->addWidget(poolLabels);
+
+    QWidget* spacer = new QWidget(toolBar);
+    spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar->addWidget(spacer);
+
+    QToolButton *closeButton = new QToolButton(toolBar);
+    closeButton->setIcon(this->style()->standardIcon(QStyle::SP_DockWidgetCloseButton));
+    connect(closeButton,
+            &QToolButton::clicked,
+            this,
+            &IsotopePlotDockWidget::hide);
+    toolBar->addWidget(closeButton);
 
     setTitleBarWidget(toolBar);
 

--- a/src/gui/mzroll/scatterplot.cpp
+++ b/src/gui/mzroll/scatterplot.cpp
@@ -106,7 +106,7 @@ void ScatterPlot::setupToolBar() {
 	spacerWidget->setVisible(true);
 
     QToolButton *btnClose = new QToolButton(toolBar);
-    btnClose->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
+    btnClose->setIcon(style()->standardIcon(QStyle::SP_DockWidgetCloseButton));
     connect(btnClose, SIGNAL(clicked()), this, SLOT(hide()));
 
     toolBar->addWidget(bntResetZoom);

--- a/src/gui/mzroll/treedockwidget.cpp
+++ b/src/gui/mzroll/treedockwidget.cpp
@@ -461,7 +461,7 @@ void TreeDockWidget::setQQQToolBar() {
     amuQ1->setRange(0.001, 2.0);
     amuQ1->setValue(_mainWindow->getSettings()->value("amuQ1").toDouble());
     amuQ1->setSingleStep(0.1);	//amu step
-    amuQ1->setToolTip("PrecursorMz Tolerance");
+    amuQ1->setToolTip("Precursor mz tolerance");
     amuQ1->setSuffix(" amu");
     amuQ1->setMinimumWidth(20);
 
@@ -472,7 +472,7 @@ void TreeDockWidget::setQQQToolBar() {
     amuQ3->setRange(0.001, 2.0);
     amuQ3->setValue(_mainWindow->getSettings()->value("amuQ3").toDouble());
     amuQ3->setSingleStep(0.1);	//amu step
-    amuQ3->setToolTip("ProductMz Tolerance");
+    amuQ3->setToolTip("Product mz tolerance");
     amuQ3->setSuffix(" amu");
     amuQ3->setMinimumWidth(20);
     connect(amuQ3, SIGNAL(valueChanged(double)),_mainWindow->getSettingsForm(), SLOT(setQ3Tollrance(double)));
@@ -482,14 +482,29 @@ void TreeDockWidget::setQQQToolBar() {
     associateCompounds->setIcon(QIcon(rsrcPath + "/link.png"));
     associateCompounds->setToolTip(tr("Associate Compounds with MRM Transtions"));
     
-    toolBar->addWidget(new QLabel("Q1"));
+    auto q1Label = new QLabel("Q1 tolerance");
+    q1Label->setStyleSheet("QLabel { margin-left: 6px; }");
+    toolBar->addWidget(q1Label);
     toolBar->addWidget(amuQ1);
-    toolBar->addWidget(new QLabel("Q3"));
+    toolBar->addSeparator();
+    toolBar->addWidget(new QLabel("Q3 tolerance"));
     toolBar->addWidget(amuQ3);
+    toolBar->addSeparator();
     toolBar->addWidget(associateCompounds);
 
-    setTitleBarWidget(toolBar);
+    QWidget* spacer = new QWidget(toolBar);
+    spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar->addWidget(spacer);
 
+    QToolButton *closeButton = new QToolButton(toolBar);
+    closeButton->setIcon(this->style()->standardIcon(QStyle::SP_DockWidgetCloseButton));
+    connect(closeButton,
+            &QToolButton::clicked,
+            this,
+            &TreeDockWidget::hide);
+    toolBar->addWidget(closeButton);
+
+    setTitleBarWidget(toolBar);
 }
 
 void TreeDockWidget::manualAnnotation(QTreeWidgetItem * item) {


### PR DESCRIPTION
Three widgets (isotope plot dock widget, scatterplot widget and SRM widget) were missing close buttons. They have been added with one. This will help the user by not forcing them to find which buttons correspond to which button when they want to close them.