### PR TITLE
[Fix] Allow ignoring close event

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -976,18 +976,24 @@ void MainWindow::saveProject(bool explicitSave)
         // if no projects were saved or opened
         if (_latestUserProjectName.isEmpty()) {
             QString message = "Would you like to save your data for this "
-                              "session as a project?";
+                              "session as a project, before you quit?";
             QMessageBox::StandardButton reply;
             reply = QMessageBox::question(this,
                                           "Save as project",
                                           message,
-                                          QMessageBox::Yes | QMessageBox::No,
+                                          QMessageBox::Yes
+                                              | QMessageBox::No
+                                              | QMessageBox::Cancel,
                                           QMessageBox::Yes);
+            if (reply == QMessageBox::Cancel) {
+                settings->setValue("closeEvent", 0);
+                return;
+            }
 
             // remove timestamp autosave file in any case
             fileLoader->closeSQLiteProject();
             QFile::remove(_currentProjectName);
-            if (reply != QMessageBox::Yes)
+            if (reply == QMessageBox::No)
                 return;
 
             _currentProjectName = "";
@@ -1011,6 +1017,10 @@ void MainWindow::saveProject(bool explicitSave)
             msgBox.setDefaultButton(saveButton);
             msgBox.setEscapeButton(cancelButton);
             msgBox.exec();
+            if (msgBox.clickedButton() == cancelButton) {
+                settings->setValue("closeEvent", 0);
+                return;
+            }
 
             // remove current project file only if it was created by autosave
             if (this->timestampFileExists) {
@@ -1032,6 +1042,11 @@ void MainWindow::saveProject(bool explicitSave)
             if (_currentProjectName.isEmpty())
                 return;
         }
+
+        QMessageBox msgBox(this);
+        msgBox.setText("Please wait. Your project is being saved…");
+        msgBox.setStandardButtons(QMessageBox::NoButton);
+        msgBox.open();
         this->autosave->saveProjectWorker();
     } else if (explicitSave) {
         _currentProjectName = _getProjectFilenameFromProjectDockWidget();
@@ -2552,16 +2567,16 @@ void MainWindow::closeEvent(QCloseEvent* event)
     settings->setValue("closeEvent", 1);
     this->saveProject();
 
-    QMessageBox msgBox(this);
-    msgBox.setText("Please wait. Your project is being saved…");
-    msgBox.setStandardButtons(QMessageBox::NoButton);
-    msgBox.open();
-
     writeSettings();
 
     // wait until autosave has finished
     while(autosave->isRunning())
         QApplication::processEvents();
+
+    if (settings->value("closeEvent").toInt() == 0) {
+        event->ignore();
+        return;
+    }
 
     event->accept();
 }

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -999,8 +999,10 @@ void MainWindow::saveProject(bool explicitSave)
             _currentProjectName = "";
             _setProjectFilenameIfEmpty();
 
-            if (_currentProjectName.isEmpty())
+            if (_currentProjectName.isEmpty()) {
+                settings->setValue("closeEvent", 0);
                 return;
+            }
 
             analytics->hitEvent("Project Save", "emDB");
         } else {
@@ -1039,8 +1041,10 @@ void MainWindow::saveProject(bool explicitSave)
                 return;
             }
 
-            if (_currentProjectName.isEmpty())
+            if (_currentProjectName.isEmpty()) {
+                settings->setValue("closeEvent", 0);
                 return;
+            }
         }
 
         QMessageBox msgBox(this);


### PR DESCRIPTION
When project saving feature was added, a prompt would appear asking the user to save their session before the exit. Once the "close" button of the main application was clicked, there was no way of cancelling the exit event (with or without saving). With this patch, the user will have the option to ignore the exit event by either selecting "Cancel" button or pressing "Esc" when then save prompt appears.