### PR TITLE
[Fix] Export labelled peaks in peak-detailed format

### DIFF
--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -205,8 +205,7 @@ void CSVReports::insertPeakInformationIntoCSVFile(PeakGroup* group)
     if (group->childCount() == 0) {
         writePeakInfo(group);
     } else {
-        for (auto& child : group->children)
-        writePeakInfo(&child);
+        insertIsotopes(group, true);
     }
 }
 
@@ -219,46 +218,15 @@ void CSVReports::insertGroupInformationIntoCSVFile(PeakGroup* group)
     }
 }
 
-void CSVReports::insertIsotopes(PeakGroup* group, bool userSelectedIsotopesOnly)
+void CSVReports::insertIsotopes(PeakGroup* group, bool peakMode)
 {
-    if (userSelectedIsotopesOnly) {
-        insertUserSelectedIsotopes(group);
-    } else {
-        insertAllIsotopes(group);
-    }
-}
-
-void CSVReports::insertUserSelectedIsotopes(PeakGroup* group)
-{
-    bool C13Flag = getMavenParameters()->C13Labeled_BPE;
-    bool N15Flag = getMavenParameters()->N15Labeled_BPE;
-    bool S34Flag = getMavenParameters()->S34Labeled_BPE;
-    bool D2Flag = getMavenParameters()->D2Labeled_BPE;
-
-    // iterate over all existing subgroups and for each isotope flag
-    // check if the subgroup contains the isotope's name as tagstring
-    // before writing it to the report. If any of the unselected
-    // labels are found, we discard the child group.
-    for (auto subGroup: group->children) {
-        if (!C13Flag && subGroup.tagString.find("C13") != std::string::npos)
-            continue;
-        if (!N15Flag && subGroup.tagString.find("N15") != std::string::npos)
-            continue;
-        if (!S34Flag && subGroup.tagString.find("S34") != std::string::npos)
-            continue;
-        if (!D2Flag && subGroup.tagString.find("D2") != std::string::npos)
-            continue;
-
+    for (auto& subGroup: group->children) {
         subGroup.metaGroupId = group->metaGroupId;
-        writeGroupInfo(&subGroup);
-    }
-}
-
-void CSVReports::insertAllIsotopes(PeakGroup* group)
-{
-    for (auto subGroup: group->children) {
-        subGroup.metaGroupId = group->metaGroupId;
-        writeGroupInfo(&subGroup);
+        if (peakMode) {
+            writePeakInfo(&subGroup);
+        } else {
+            writeGroupInfo(&subGroup);
+        }
     }
 }
 

--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -161,6 +161,7 @@ void CSVReports::insertPeakReportColumnNamesintoCSVFile()
                            << "compound"
                            << "compoundId"
                            << "formula"
+                           << "isotopeLabel"
                            << "sample"
                            << "peakMz"
                            << "mzmin"
@@ -199,10 +200,14 @@ void CSVReports::addGroup (PeakGroup* group) {
 
 }
 
-void CSVReports::insertPeakInformationIntoCSVFile(PeakGroup* group) {
-
-      writePeakInfo(group);
-
+void CSVReports::insertPeakInformationIntoCSVFile(PeakGroup* group)
+{
+    if (group->childCount() == 0) {
+        writePeakInfo(group);
+    } else {
+        for (auto& child : group->children)
+        writePeakInfo(&child);
+    }
 }
 
 void CSVReports::insertGroupInformationIntoCSVFile(PeakGroup* group)
@@ -439,10 +444,12 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
     string compoundName = "";
     string compoundID = "";
     string formula = "";
+    string isotopeLabel = "";
     if (group->getCompound() != NULL) {
         compoundName = sanitizeString(group->getCompound()->name.c_str()).toStdString();
         compoundID   = sanitizeString(group->getCompound()->id.c_str()).toStdString();
         formula = sanitizeString(group->getCompound()->formula().c_str()).toStdString();
+        isotopeLabel = sanitizeString(group->tagString.c_str()).toStdString();
     } else {
         // absence of a group compound means this group was created using untargeted detection,
         // we set compound name and ID to {mz}@{rt} strings for untargeted sets.
@@ -484,6 +491,7 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
                    << SEP << compoundName
                    << SEP << compoundID
                    << SEP << formula
+                   << SEP << isotopeLabel
                    << SEP << sampleName
                    << SEP << peak.peakMz
                    << SEP << peak.mzmin
@@ -516,6 +524,7 @@ void CSVReports::writePeakInfo(PeakGroup* group) {
                    << SEP << compoundName
                    << SEP << compoundID
                    << SEP << formula
+                   << SEP << isotopeLabel
                    << SEP << sampleName
                    << SEP << 0.0f
                    << SEP << 0.0f

--- a/src/core/libmaven/csvreports.h
+++ b/src/core/libmaven/csvreports.h
@@ -141,23 +141,11 @@ private:
     void insertGroupInformationIntoCSVFile(PeakGroup* group);
 
     /**
-     * @brief - Relays the function for inserting isotopes to `insertAllIsotopes` by default. Optionally
-     * this method can be used to call `insertUserSelectedIsotopes` by passing a second boolean argument
-     * with `true` value.
+     * @brief Insert all the child groups of the given group.
+     * @param peakMode If true, the `writePeakInfo` method will be called
+     * instead of `writeGroupInfo` to write the report.
      */
-    void insertIsotopes(PeakGroup* group, bool userSelectedIsotopesOnly = false);
-
-    /**
-     * @brief - Create a masslist with isotopes only currently selected by user (accessible through a
-     * global settings object) and then write the subgroups having these isotopes as tagrstrings, if they
-     * were found.
-     */
-    void insertUserSelectedIsotopes(PeakGroup* group);
-
-    /**
-     * @brief - Insert all the child groups of the given group.
-     */
-    void insertAllIsotopes(PeakGroup* group);
+    void insertIsotopes(PeakGroup* group, bool peakMode = false);
 
     string SEP;     /**@param-  separator in output file*/
 

--- a/tests/MavenTests/testCSVReports.cpp
+++ b/tests/MavenTests/testCSVReports.cpp
@@ -201,18 +201,18 @@ void TestCSVReports::verifyTargetedGroupReport(vector<mzSample*>& samplesToLoad,
     QVERIFY(parentValues[1] == "1");
     QVERIFY(parentValues[2] == "1");
     QVERIFY(parentValues[3] == "2");
-    // QVERIFY(parentValues[4] == "665.215942");
-    // QVERIFY(parentValues[5] == "1.463882");
-    // QVERIFY(parentValues[6] == "0.847695");
+    QCOMPARE(stof(parentValues[4]), 665.215942f);
+    QCOMPARE(stof(parentValues[5]), TestUtils::roundTo(1.463882f, 3));
+    QCOMPARE(stof(parentValues[6]), 0.847695f);
     QVERIFY(parentValues[7] == "C12 PARENT");
     QVERIFY(parentValues[8] == "Stachyose");
     QVERIFY(parentValues[9] == "HMDB03553");
     QVERIFY(parentValues[10] == "C24H42O21");
-    // QVERIFY(parentValues[12] == "0.646118");
-    // QVERIFY(parentValues[13] == "2.018557");
-    // QVERIFY(parentValues[14] == "665.215942");
-    // QVERIFY(parentValues[15] == "58567.76");
-    // QVERIFY(parentValues[16] == "38766.77");
+    QCOMPARE(stof(parentValues[11]), TestUtils::roundTo(0.646118f, 3));
+    QCOMPARE(stof(parentValues[12]), 2.018557f);
+    QCOMPARE(stof(parentValues[13]), 665.215942f);
+    QCOMPARE(stof(parentValues[14]), 58567.76f);
+    QCOMPARE(stof(parentValues[15]), 38766.77f);
 
     // check if labelled child values are correctly written
     vector<std::string> childValues;
@@ -222,18 +222,18 @@ void TestCSVReports::verifyTargetedGroupReport(vector<mzSample*>& samplesToLoad,
     QVERIFY(childValues[1] == "1");
     QVERIFY(childValues[2] == "2");
     QVERIFY(childValues[3] == "0");
-    // QVERIFY(childValues[4] == "666.219666");
-    // QVERIFY(childValues[5] == "1.475023");
-    // QVERIFY(childValues[6] == "0.130955");
+    QCOMPARE(stof(childValues[4]), 666.219666f);
+    QCOMPARE(stof(childValues[5]), TestUtils::roundTo(1.475023f, 3));
+    QCOMPARE(stof(childValues[6]), 0.130955f);
     QVERIFY(childValues[7] == "C13-label-1");
     QVERIFY(childValues[8] == "Stachyose");
     QVERIFY(childValues[9] == "HMDB03553");
     QVERIFY(childValues[10] == "C24H42O21");
-    // QVERIFY(childValues[11] == "0.634977");
-    // QVERIFY(childValues[12] == "2.565203");
-    // QVERIFY(childValues[13] == "665.215942");
-    // QVERIFY(childValues[14] == "6103.33");
-    // QVERIFY(childValues[15] == "0.00");
+    QCOMPARE(stof(childValues[11]), TestUtils::roundTo(0.634977f, 3));
+    QCOMPARE(stof(childValues[12]), 2.565203f);
+    QCOMPARE(stof(childValues[13]), 665.215942f);
+    QCOMPARE(stof(childValues[14]), 6103.33f);
+    QCOMPARE(stof(childValues[15]), 0.00f);
 }
 
 void TestCSVReports::verifyUntargetedGroupReport(vector<mzSample*>& samplesToLoad,
@@ -272,18 +272,18 @@ void TestCSVReports::verifyUntargetedGroupReport(vector<mzSample*>& samplesToLoa
     QVERIFY(parentValues[1] == "15");
     QVERIFY(parentValues[2] == "1");
     QVERIFY(parentValues[3] == "2");
-    // QVERIFY(parentValues[4] == "210.150269");
-    // QVERIFY(parentValues[5] == "16.714417");
-    // QVERIFY(parentValues[6] == "0.803334");
+    QCOMPARE(stof(parentValues[4]), 210.150269f);
+    QCOMPARE(stof(parentValues[5]), TestUtils::roundTo(16.714417f, 3));
+    QCOMPARE(stof(parentValues[6]), 0.803054f);
     QVERIFY(parentValues[7] == "");
     QVERIFY(parentValues[8] == "210.150269@16.714417");
     QVERIFY(parentValues[9] == "210.150269@16.714417");
     QVERIFY(parentValues[10] == "");
-    QVERIFY(parentValues[11] == "0.000");
-    QVERIFY(parentValues[12] == "0.000000");
-    // QVERIFY(parentValues[13] == "210.150269");
-    // QVERIFY(parentValues[14] == "1234094464.00");
-    // QVERIFY(parentValues[15] == "1199781760.00");
+    QCOMPARE(stof(parentValues[11]), TestUtils::roundTo(0.000f, 3));
+    QCOMPARE(stof(parentValues[12]), 0.000000f);
+    QCOMPARE(stof(parentValues[13]), 210.150269f);
+    QCOMPARE(stof(parentValues[14]), 1234094464.00f);
+    QCOMPARE(stof(parentValues[15]), 1199781760.00f);
 }
 
 void TestCSVReports::verifyTargetedPeakReport(vector<mzSample*>& samplesToLoad,
@@ -323,24 +323,27 @@ void TestCSVReports::verifyTargetedPeakReport(vector<mzSample*>& samplesToLoad,
     QVERIFY(peakValues1[2] == "HMDB03553");
     QVERIFY(peakValues1[3] == "C24H42O21");
     QVERIFY(peakValues1[4] == "C12 PARENT");
-    // QVERIFY(peakValues1[5] == "testsample_2");
-    // QVERIFY(peakValues1[6] == "665.216309");
-    // QVERIFY(peakValues1[7] == "665.216431");
-    // QVERIFY(peakValues1[8] == "665.216736");
-    // QVERIFY(peakValues1[9] == "1.466");
-    // QVERIFY(peakValues1[10] == "1.426");
-    // QVERIFY(peakValues1[11] == "1.520");
-    // QVERIFY(peakValues1[12] == "0.667");
-    // QVERIFY(peakValues1[13] == "79580.98");
-    // QVERIFY(peakValues1[14] == "595991.69");
-    // QVERIFY(peakValues1[15] == "635897.38");
-    // QVERIFY(peakValues1[16] == "58567.76");
-    // QVERIFY(peakValues1[17] == "595991.69");
-    // QVERIFY(peakValues1[18] == "58567.76");
-    #ifndef WIN32
+#ifndef WIN32
+    // TODO: fix this separately, sample names are empty on Windows
+    QVERIFY(peakValues1[5] == "testsample_2");
+#endif
+    QCOMPARE(stof(peakValues1[6]), 665.216309f);
+    QCOMPARE(stof(peakValues1[7]), 665.216431f);
+    QCOMPARE(stof(peakValues1[8]), 665.216736f);
+    QCOMPARE(stof(peakValues1[9]), 1.466f);
+    QCOMPARE(stof(peakValues1[10]), 1.426f);
+    QCOMPARE(stof(peakValues1[11]), 1.520f);
+    QCOMPARE(stof(peakValues1[12]), 0.666f);
+    QCOMPARE(stof(peakValues1[13]), 79580.98f);
+    QCOMPARE(stof(peakValues1[14]), 595991.69f);
+    QCOMPARE(stof(peakValues1[15]), 635897.38f);
+    QCOMPARE(stof(peakValues1[16]), 58567.76f);
+    QCOMPARE(stof(peakValues1[17]), 595991.69f);
+    QCOMPARE(stof(peakValues1[18]), 58567.76f);
+#ifndef WIN32
     QVERIFY(peakValues1[19] == "18");
-    #endif
-    // QVERIFY(peakValues1[20] == "9.12");
+#endif
+    QCOMPARE(stof(peakValues1[20]), 9.12f);
     QVERIFY(peakValues1[21] == "0");
 
     // check if labelled child values are correctly written
@@ -352,24 +355,26 @@ void TestCSVReports::verifyTargetedPeakReport(vector<mzSample*>& samplesToLoad,
     QVERIFY(peakValues2[2] == "HMDB03553");
     QVERIFY(peakValues2[3] == "C24H42O21");
     QVERIFY(peakValues2[4] == "C12 PARENT");
-    // QVERIFY(peakValues2[5] == "testsample_3");
-    // QVERIFY(peakValues2[6] == "665.214966");
-    // QVERIFY(peakValues2[7] == "665.215210");
-    // QVERIFY(peakValues2[8] == "665.215088");
-    // QVERIFY(peakValues2[9] == "1.462");
-    // QVERIFY(peakValues2[10] == "1.377");
-    // QVERIFY(peakValues2[11] == "1.502");
-    // QVERIFY(peakValues2[12] == "0.848");
-    // QVERIFY(peakValues2[13] == "54565.93");
-    // QVERIFY(peakValues2[14] == "359001.78");
-    // QVERIFY(peakValues2[15] == "355344.88");
-    // QVERIFY(peakValues2[16] == "38766.77");
-    // QVERIFY(peakValues2[17] == "359001.78");
-    // QVERIFY(peakValues2[18] == "38766.77");
+#ifndef WIN32
+    QVERIFY(peakValues2[5] == "testsample_3");
+#endif
+    QCOMPARE(stof(peakValues2[6]), 665.214966f);
+    QCOMPARE(stof(peakValues2[7]), 665.215210f);
+    QCOMPARE(stof(peakValues2[8]), 665.215088f);
+    QCOMPARE(stof(peakValues2[9]), 1.462f);
+    QCOMPARE(stof(peakValues2[10]), 1.377f);
+    QCOMPARE(stof(peakValues2[11]), 1.502f);
+    QCOMPARE(stof(peakValues2[12]), 0.848f);
+    QCOMPARE(stof(peakValues2[13]), 54565.93f);
+    QCOMPARE(stof(peakValues2[14]), 359001.78f);
+    QCOMPARE(stof(peakValues2[15]), 355344.88f);
+    QCOMPARE(stof(peakValues2[16]), 38766.77f);
+    QCOMPARE(stof(peakValues2[17]), 359001.78f);
+    QCOMPARE(stof(peakValues2[18]), 38766.77f);
     #ifndef WIN32
     QVERIFY(peakValues2[19] == "16");
     #endif
-    // QVERIFY(peakValues2[20] == "5456.59");
+    QCOMPARE(stof(peakValues2[20]), 5456.59f);
     QVERIFY(peakValues2[21] == "0");
 }
 
@@ -410,48 +415,23 @@ void TestCSVReports::verifyUntargetedPeakReport(vector<mzSample*>& samplesToLoad
     QVERIFY(peakValues1[2] == "210.150269@16.714417");
     QVERIFY(peakValues1[3] == "");
     QVERIFY(peakValues1[4] == "");
-    // QVERIFY(peakValues1[5] == "testsample_2");
-    // QVERIFY(peakValues1[6] == "210.150375");
-    // QVERIFY(peakValues1[7] == "210.150452");
-    // QVERIFY(peakValues1[8] == "210.150452");
-    // QVERIFY(peakValues1[9] == "16.710");
-    // QVERIFY(peakValues1[10] == "16.603");
-    // QVERIFY(peakValues1[11] == "17.392");
-    // QVERIFY(peakValues1[12] == "0.801");
-    // QVERIFY(peakValues1[13] == "1255329664.00");
-    // QVERIFY(peakValues1[14] == "30111416320.00");
-    // QVERIFY(peakValues1[15] == "30103683072.00");
-    // QVERIFY(peakValues1[16] == "1234160640.00");
-    // QVERIFY(peakValues1[17] == "30099625984.00");
-    // QVERIFY(peakValues1[18] == "1234094464.00");
+#ifndef WIN32
+    QVERIFY(peakValues1[5] == "testsample_2");
+#endif
+    QCOMPARE(stof(peakValues1[6]), 210.150375f);
+    QCOMPARE(stof(peakValues1[7]), 210.150452f);
+    QCOMPARE(stof(peakValues1[8]), 210.150452f);
+    QCOMPARE(stof(peakValues1[9]), 16.710f);
+    QCOMPARE(stof(peakValues1[10]), 16.603f);
+    QCOMPARE(stof(peakValues1[11]), 17.392f);
+    QCOMPARE(stof(peakValues1[12]), 0.801f);
+    QCOMPARE(stof(peakValues1[13]), 1255329664.00f);
+    QCOMPARE(stof(peakValues1[14]), 30111416320.00f);
+    QCOMPARE(stof(peakValues1[15]), 30103683072.00f);
+    QCOMPARE(stof(peakValues1[16]), 1234160640.00f);
+    QCOMPARE(stof(peakValues1[17]), 30099625984.00f);
+    QCOMPARE(stof(peakValues1[18]), 1234094464.00f);
     QVERIFY(peakValues1[19] == "178");
-    // QVERIFY(peakValues1[20] == "116.51");
+    QCOMPARE(stof(peakValues1[20]), 116.51f);
     QVERIFY(peakValues1[21] == "0");
-
-    // check if labelled child values are correctly written
-    vector<std::string> peakValues2;
-    mzUtils::splitNew(peakString2, "," , peakValues2);
-    QVERIFY(peakValues2.size() == 22);
-    QVERIFY(peakValues2[0] == "15");
-    QVERIFY(peakValues2[1] == "210.150269@16.714417");
-    QVERIFY(peakValues2[2] == "210.150269@16.714417");
-    QVERIFY(peakValues2[3] == "");
-    QVERIFY(peakValues2[4] == "");
-    // QVERIFY(peakValues2[5] == "testsample_3");
-    // QVERIFY(peakValues2[6] == "210.150055");
-    // QVERIFY(peakValues2[7] == "210.150101");
-    // QVERIFY(peakValues2[8] == "210.150101");
-    // QVERIFY(peakValues2[9] == "16.719");
-    // QVERIFY(peakValues2[10] == "16.612");
-    // QVERIFY(peakValues2[11] == "17.401");
-    // QVERIFY(peakValues2[12] == "0.803");
-    // QVERIFY(peakValues2[13] == "1221961088.00");
-    // QVERIFY(peakValues2[14] == "29895890944.00");
-    // QVERIFY(peakValues2[15] == "29900089344.00");
-    // QVERIFY(peakValues2[16] == "1199850368.00");
-    // QVERIFY(peakValues2[17] == "29883682816.00");
-    // QVERIFY(peakValues2[18] == "1199781760.00");
-    QVERIFY(peakValues2[19] == "178");
-    // QVERIFY(peakValues2[20] == "114.35");
-    QVERIFY(peakValues2[21] == "0");
 }

--- a/tests/MavenTests/testCSVReports.cpp
+++ b/tests/MavenTests/testCSVReports.cpp
@@ -101,6 +101,7 @@ void TestCSVReports::testopenPeakReport() {
              << "compound"
              << "compoundId"
              << "formula"
+             << "isotopeLabel"
              << "sample"
              << "peakMz"
              << "mzmin"
@@ -311,63 +312,65 @@ void TestCSVReports::verifyTargetedPeakReport(vector<mzSample*>& samplesToLoad,
     //check if number of columns is correct
     vector<std::string> header;
     mzUtils::splitNew(headersString, "," , header);
-    QVERIFY(header.size() == 21);
+    QVERIFY(header.size() == 22);
 
     // check if parent group values are correctly written
     vector<std::string> peakValues1;
     mzUtils::splitNew(peakString1, "," , peakValues1);
-    QVERIFY(peakValues1.size() == 21);
+    QVERIFY(peakValues1.size() == 22);
     QVERIFY(peakValues1[0] == "1");
     QVERIFY(peakValues1[1] == "Stachyose");
     QVERIFY(peakValues1[2] == "HMDB03553");
     QVERIFY(peakValues1[3] == "C24H42O21");
-    // QVERIFY(peakValues1[4] == "testsample_2");
-    // QVERIFY(peakValues1[5] == "665.216309");
-    // QVERIFY(peakValues1[6] == "665.216431");
-    // QVERIFY(peakValues1[7] == "665.216736");
-    // QVERIFY(peakValues1[8] == "1.466");
-    // QVERIFY(peakValues1[9] == "1.426");
-    // QVERIFY(peakValues1[10] == "1.520");
-    // QVERIFY(peakValues1[11] == "0.667");
-    // QVERIFY(peakValues1[12] == "79580.98");
-    // QVERIFY(peakValues1[13] == "595991.69");
-    // QVERIFY(peakValues1[14] == "635897.38");
-    // QVERIFY(peakValues1[15] == "58567.76");
-    // QVERIFY(peakValues1[16] == "595991.69");
-    // QVERIFY(peakValues1[17] == "58567.76");
+    QVERIFY(peakValues1[4] == "C12 PARENT");
+    // QVERIFY(peakValues1[5] == "testsample_2");
+    // QVERIFY(peakValues1[6] == "665.216309");
+    // QVERIFY(peakValues1[7] == "665.216431");
+    // QVERIFY(peakValues1[8] == "665.216736");
+    // QVERIFY(peakValues1[9] == "1.466");
+    // QVERIFY(peakValues1[10] == "1.426");
+    // QVERIFY(peakValues1[11] == "1.520");
+    // QVERIFY(peakValues1[12] == "0.667");
+    // QVERIFY(peakValues1[13] == "79580.98");
+    // QVERIFY(peakValues1[14] == "595991.69");
+    // QVERIFY(peakValues1[15] == "635897.38");
+    // QVERIFY(peakValues1[16] == "58567.76");
+    // QVERIFY(peakValues1[17] == "595991.69");
+    // QVERIFY(peakValues1[18] == "58567.76");
     #ifndef WIN32
-    QVERIFY(peakValues1[18] == "18");
+    QVERIFY(peakValues1[19] == "18");
     #endif
-    // QVERIFY(peakValues1[19] == "9.12");
-    QVERIFY(peakValues1[20] == "0");
+    // QVERIFY(peakValues1[20] == "9.12");
+    QVERIFY(peakValues1[21] == "0");
 
     // check if labelled child values are correctly written
     vector<std::string> peakValues2;
     mzUtils::splitNew(peakString2, "," , peakValues2);
-    QVERIFY(peakValues2.size() == 21);
+    QVERIFY(peakValues2.size() == 22);
     QVERIFY(peakValues2[0] == "1");
     QVERIFY(peakValues2[1] == "Stachyose");
     QVERIFY(peakValues2[2] == "HMDB03553");
     QVERIFY(peakValues2[3] == "C24H42O21");
-    // QVERIFY(peakValues2[4] == "testsample_3");
-    // QVERIFY(peakValues2[5] == "665.214966");
-    // QVERIFY(peakValues2[6] == "665.215210");
-    // QVERIFY(peakValues2[7] == "665.215088");
-    // QVERIFY(peakValues2[8] == "1.462");
-    // QVERIFY(peakValues2[9] == "1.377");
-    // QVERIFY(peakValues2[10] == "1.502");
-    // QVERIFY(peakValues2[11] == "0.848");
-    // QVERIFY(peakValues2[12] == "54565.93");
-    // QVERIFY(peakValues2[13] == "359001.78");
-    // QVERIFY(peakValues2[14] == "355344.88");
-    // QVERIFY(peakValues2[15] == "38766.77");
-    // QVERIFY(peakValues2[16] == "359001.78");
-    // QVERIFY(peakValues2[17] == "38766.77");
+    QVERIFY(peakValues2[4] == "C12 PARENT");
+    // QVERIFY(peakValues2[5] == "testsample_3");
+    // QVERIFY(peakValues2[6] == "665.214966");
+    // QVERIFY(peakValues2[7] == "665.215210");
+    // QVERIFY(peakValues2[8] == "665.215088");
+    // QVERIFY(peakValues2[9] == "1.462");
+    // QVERIFY(peakValues2[10] == "1.377");
+    // QVERIFY(peakValues2[11] == "1.502");
+    // QVERIFY(peakValues2[12] == "0.848");
+    // QVERIFY(peakValues2[13] == "54565.93");
+    // QVERIFY(peakValues2[14] == "359001.78");
+    // QVERIFY(peakValues2[15] == "355344.88");
+    // QVERIFY(peakValues2[16] == "38766.77");
+    // QVERIFY(peakValues2[17] == "359001.78");
+    // QVERIFY(peakValues2[18] == "38766.77");
     #ifndef WIN32
-    QVERIFY(peakValues2[18] == "16");
+    QVERIFY(peakValues2[19] == "16");
     #endif
-    // QVERIFY(peakValues2[19] == "5456.59");
-    QVERIFY(peakValues2[20] == "0");
+    // QVERIFY(peakValues2[20] == "5456.59");
+    QVERIFY(peakValues2[21] == "0");
 }
 
 void TestCSVReports::verifyUntargetedPeakReport(vector<mzSample*>& samplesToLoad,
@@ -396,57 +399,59 @@ void TestCSVReports::verifyUntargetedPeakReport(vector<mzSample*>& samplesToLoad
     //check if number of columns is correct
     vector<std::string> header;
     mzUtils::splitNew(headersString, "," , header);
-    QVERIFY(header.size() == 21);
+    QVERIFY(header.size() == 22);
 
     // check if parent group values are correctly written
     vector<std::string> peakValues1;
     mzUtils::splitNew(peakString1, "," , peakValues1);
-    QVERIFY(peakValues1.size() == 21);
+    QVERIFY(peakValues1.size() == 22);
     QVERIFY(peakValues1[0] == "15");
     QVERIFY(peakValues1[1] == "210.150269@16.714417");
     QVERIFY(peakValues1[2] == "210.150269@16.714417");
     QVERIFY(peakValues1[3] == "");
-    // QVERIFY(peakValues1[4] == "testsample_2");
-    // QVERIFY(peakValues1[5] == "210.150375");
-    // QVERIFY(peakValues1[6] == "210.150452");
+    QVERIFY(peakValues1[4] == "");
+    // QVERIFY(peakValues1[5] == "testsample_2");
+    // QVERIFY(peakValues1[6] == "210.150375");
     // QVERIFY(peakValues1[7] == "210.150452");
-    // QVERIFY(peakValues1[8] == "16.710");
-    // QVERIFY(peakValues1[9] == "16.603");
-    // QVERIFY(peakValues1[10] == "17.392");
-    // QVERIFY(peakValues1[11] == "0.801");
-    // QVERIFY(peakValues1[12] == "1255329664.00");
-    // QVERIFY(peakValues1[13] == "30111416320.00");
-    // QVERIFY(peakValues1[14] == "30103683072.00");
-    // QVERIFY(peakValues1[15] == "1234160640.00");
-    // QVERIFY(peakValues1[16] == "30099625984.00");
-    // QVERIFY(peakValues1[17] == "1234094464.00");
-    QVERIFY(peakValues1[18] == "178");
-    // QVERIFY(peakValues1[19] == "116.51");
-    QVERIFY(peakValues1[20] == "0");
+    // QVERIFY(peakValues1[8] == "210.150452");
+    // QVERIFY(peakValues1[9] == "16.710");
+    // QVERIFY(peakValues1[10] == "16.603");
+    // QVERIFY(peakValues1[11] == "17.392");
+    // QVERIFY(peakValues1[12] == "0.801");
+    // QVERIFY(peakValues1[13] == "1255329664.00");
+    // QVERIFY(peakValues1[14] == "30111416320.00");
+    // QVERIFY(peakValues1[15] == "30103683072.00");
+    // QVERIFY(peakValues1[16] == "1234160640.00");
+    // QVERIFY(peakValues1[17] == "30099625984.00");
+    // QVERIFY(peakValues1[18] == "1234094464.00");
+    QVERIFY(peakValues1[19] == "178");
+    // QVERIFY(peakValues1[20] == "116.51");
+    QVERIFY(peakValues1[21] == "0");
 
     // check if labelled child values are correctly written
     vector<std::string> peakValues2;
     mzUtils::splitNew(peakString2, "," , peakValues2);
-    QVERIFY(peakValues2.size() == 21);
+    QVERIFY(peakValues2.size() == 22);
     QVERIFY(peakValues2[0] == "15");
     QVERIFY(peakValues2[1] == "210.150269@16.714417");
     QVERIFY(peakValues2[2] == "210.150269@16.714417");
     QVERIFY(peakValues2[3] == "");
-    // QVERIFY(peakValues2[4] == "testsample_3");
-    // QVERIFY(peakValues2[5] == "210.150055");
-    // QVERIFY(peakValues2[6] == "210.150101");
+    QVERIFY(peakValues2[4] == "");
+    // QVERIFY(peakValues2[5] == "testsample_3");
+    // QVERIFY(peakValues2[6] == "210.150055");
     // QVERIFY(peakValues2[7] == "210.150101");
-    // QVERIFY(peakValues2[8] == "16.719");
-    // QVERIFY(peakValues2[9] == "16.612");
-    // QVERIFY(peakValues2[10] == "17.401");
-    // QVERIFY(peakValues2[11] == "0.803");
-    // QVERIFY(peakValues2[12] == "1221961088.00");
-    // QVERIFY(peakValues2[13] == "29895890944.00");
-    // QVERIFY(peakValues2[14] == "29900089344.00");
-    // QVERIFY(peakValues2[15] == "1199850368.00");
-    // QVERIFY(peakValues2[16] == "29883682816.00");
-    // QVERIFY(peakValues2[17] == "1199781760.00");
-    QVERIFY(peakValues2[18] == "178");
-    // QVERIFY(peakValues2[19] == "114.35");
-    QVERIFY(peakValues2[20] == "0");
+    // QVERIFY(peakValues2[8] == "210.150101");
+    // QVERIFY(peakValues2[9] == "16.719");
+    // QVERIFY(peakValues2[10] == "16.612");
+    // QVERIFY(peakValues2[11] == "17.401");
+    // QVERIFY(peakValues2[12] == "0.803");
+    // QVERIFY(peakValues2[13] == "1221961088.00");
+    // QVERIFY(peakValues2[14] == "29895890944.00");
+    // QVERIFY(peakValues2[15] == "29900089344.00");
+    // QVERIFY(peakValues2[16] == "1199850368.00");
+    // QVERIFY(peakValues2[17] == "29883682816.00");
+    // QVERIFY(peakValues2[18] == "1199781760.00");
+    QVERIFY(peakValues2[19] == "178");
+    // QVERIFY(peakValues2[20] == "114.35");
+    QVERIFY(peakValues2[21] == "0");
 }

--- a/tests/MavenTests/utilities.cpp
+++ b/tests/MavenTests/utilities.cpp
@@ -18,6 +18,18 @@ bool TestUtils::floatCompare(float a, float b)
     return fabs(a - b) < EPSILON;
 }
 
+float TestUtils::roundTo(float value, int numPlaces)
+{
+    float factor = powf(10.0f, numPlaces);
+    return roundf(value * factor) / factor;
+}
+
+double TestUtils::roundTo(double value, int numPlaces)
+{
+    double factor = pow(10.0, numPlaces);
+    return round(value * factor) / factor;
+}
+
 bool TestUtils::compareMaps(const map<string, int>& l,
                             const map<string, int>& k)
 {

--- a/tests/MavenTests/utilities.h
+++ b/tests/MavenTests/utilities.h
@@ -67,6 +67,8 @@ class TestUtils {
 
     public:
         static bool floatCompare(float a, float b);
+        static float roundTo(float a, int numPlaces);
+        static double roundTo(double a, int numPlaces);
         static bool compareMaps(const map<string,int> & l, const map<string,int> & k);
         static vector<Compound*> getCompoudDataBaseWithRT();
         static vector<Compound*> getCompoudDataBaseWithNORT();


### PR DESCRIPTION
Peaks of isotopic groups were not being exported in our peak-detailed format. Instead only the parent group's peaks were being written (and without any isotope label information). This has been fixed.