### PR TITLE
[Ftr] Read scaling metadata

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2263,7 +2263,7 @@ int MainWindow::loadMetaCsvFile(string filename){
     int lineCount=0;
     map<string, int>header;
     vector<string> headers;
-    static const string allHeadersarr[] = {"sample", "set", "injection order"};
+    static const string allHeadersarr[] = {"sample", "set", "scaling", "injection order"};
     vector<string> allHeaders (allHeadersarr, allHeadersarr + sizeof(allHeadersarr) / sizeof(allHeadersarr[0]) );
 
     //assume that files are tab delimited, unless matched ".csv", then comma delimited
@@ -2308,6 +2308,17 @@ int MainWindow::loadMetaCsvFile(string filename){
 		else{
 			set = "";
 		}
+
+        float scalingFactor = 1.0f;
+        if (header.count("scaling") && header["scaling"] < N) {
+            auto scaleString = fields[ header["scaling"] ];
+            istringstream iss(scaleString);
+            float tempScalingFactor = 1.0f;
+            iss >> noskipws >> tempScalingFactor;
+            if (iss.eof() && !iss.fail())
+                scalingFactor = tempScalingFactor;
+        }
+
         if (header.count("injection order") && header["injection order"]<N){
 
             string io = fields[header["injection order"]];
@@ -2343,8 +2354,8 @@ int MainWindow::loadMetaCsvFile(string filename){
 		if(!sample) continue; 
         sample->_setName = set;
         sample->setInjectionOrder(injectionOrder);
-       	loadCount++;
-
+        sample->setNormalizationConstant(scalingFactor);
+        loadCount++;
     }
     myfile.close();
     return loadCount;

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -4441,7 +4441,7 @@ mzSample* MainWindow::getSampleByName(QString name) {
     //non perfect matching
     for(int i=0; i < samples.size(); i++) {
         if (samples[i] == NULL) continue;
-        if (samples[i]->sampleName == name.toStdString()) {
+        if (samples[i]->sampleName == mzUtils::cleanFilename(name.toStdString())) {
             return samples[i];
         }
     }

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -113,7 +113,7 @@ void ProjectDatabase::saveSamples(const vector<mzSample*>& samples)
         samplesQuery->bind(":color_blue", s->color[2]);
         samplesQuery->bind(":color_alpha", s->color[3]);
 
-        samplesQuery->bind(":normal_const", s->getNormalizationConstant());
+        samplesQuery->bind(":norml_const", s->getNormalizationConstant());
 
         samplesQuery->bind(":transform_a0", 0);
         samplesQuery->bind(":transform_a1", 0);


### PR DESCRIPTION
A metadata (CSV) file is used in El-MAVEN to allow setting various parameters for sample list to be set. This CSV file can now also be used to supply the normalization (scaling) factor.