### PR TITLE
[Ftr] Export sample metadata file template #1171

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2234,10 +2234,20 @@ void MainWindow::loadCompoundsFile()
 
 // open function for set csv
 void MainWindow::loadMetaInformation() {
-	QStringList filelist =
-			QFileDialog::getOpenFileNames(this, "Select Set Information File To Load",
-					".",
-					"All Known Formats(*.csv *.tab *.tab.txt);;Tab Delimited(*.tab);;Tab Delimited Text(*.tab.txt);;CSV File(*.csv)");
+    auto loadedSamples = getSamples();
+    if (loadedSamples.empty())
+        return;
+    auto lastSample = loadedSamples.back();
+    auto sampleDir = QFileInfo(lastSample->fileName.c_str()).dir();
+
+    QStringList filelist =
+        QFileDialog::getOpenFileNames(this,
+                                      "Select Set Information File To Load",
+                                      sampleDir.path(),
+                                      "All Known Formats(*.csv *.tab *.tab.txt);;"
+                                      "Tab Delimited(*.tab);;"
+                                      "Tab Delimited Text(*.tab.txt);;"
+                                      "CSV File(*.csv)");
 
     if ( filelist.size() == 0 || filelist[0].isEmpty() ) return;
     if(!loadMetaInformation(filelist[0])) {

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2263,7 +2263,7 @@ int MainWindow::loadMetaCsvFile(string filename){
     int lineCount=0;
     map<string, int>header;
     vector<string> headers;
-    static const string allHeadersarr[] = {"sample", "set", "scaling", "injection order"};
+    static const string allHeadersarr[] = {"sample", "set", "cohort," "scaling", "injection order"};
     vector<string> allHeaders (allHeadersarr, allHeadersarr + sizeof(allHeadersarr) / sizeof(allHeadersarr[0]) );
 
     //assume that files are tab delimited, unless matched ".csv", then comma delimited
@@ -2304,10 +2304,13 @@ int MainWindow::loadMetaCsvFile(string filename){
         int N=fields.size();
 
         if ( header.count("sample")&& header["sample"]<N) 	 sampleName = QString::fromUtf8(fields[ header["sample"] ].c_str());
-        if ( header.count("set")&& header["set"]<N)	set = fields[ header["set"] ];
-		else{
-			set = "";
-		}
+        if (header.count("set") && header["set"] < N) {
+            set = fields[header["set"]];
+        } else if (header.count("cohort") && header["cohort"] < N) {
+            set = fields[header["cohort"]];
+        } else {
+            set = "";
+        }
 
         float scalingFactor = 1.0f;
         if (header.count("scaling") && header["scaling"] < N) {

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2273,7 +2273,7 @@ int MainWindow::loadMetaCsvFile(string filename){
     int lineCount=0;
     map<string, int>header;
     vector<string> headers;
-    static const string allHeadersarr[] = {"sample", "set", "cohort," "scaling", "injection order"};
+    static const string allHeadersarr[] = {"sample", "set", "cohort", "scaling", "injection order"};
     vector<string> allHeaders (allHeadersarr, allHeadersarr + sizeof(allHeadersarr) / sizeof(allHeadersarr[0]) );
 
     //assume that files are tab delimited, unless matched ".csv", then comma delimited

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -186,10 +186,14 @@ void ProjectDockWidget::prepareSampleCohortFile(QString sampleCohortFileName) {
         << "Scaling" << ","
         << "Injection Order" << "\n";
 	for (const auto& sample : loadedSamples) {
+        QString injectionOrder = "";
+        if (sample->getInjectionOrder() > 0)
+            injectionOrder = QString::number(sample->getInjectionOrder());
+
         out << QString::fromStdString(sample->getSampleName()) << ","
             << QString::fromStdString(sample->getSetName()) << ","
             << QString::number(sample->getNormalizationConstant()) << ","
-            << QString::number(sample->getInjectionOrder()) << "\n";
+            << injectionOrder << "\n";
 	}
 
 	qDebug() << "sample cohort file prepared";

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -84,6 +84,14 @@ ProjectDockWidget::ProjectDockWidget(QMainWindow *parent):
             fileName = fileName + ".csv";
 
         prepareSampleCohortFile(fileName);
+
+        QMessageBox::information(this,
+                                 "Meta-data file exported",
+                                 QString("A file has been exported with your "
+                                         "current sample meta-data at the "
+                                         "location \"%1\". It can be edited "
+                                         "and imported back into "
+                                         "El-MAVEN.").arg(fileName));
     });
 
     QToolButton* loadMetadataButton = new QToolButton(toolBar);

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -832,8 +832,8 @@ bool PollyIntegration::validSampleCohort(QString sampleCohortFile, QStringList l
 	QStringList cohorts;
     while (!file.atEnd()) {
         QByteArray line = file.readLine();
-		QList<QByteArray> splitRow = line.split(',');
-		if (splitRow.size() != 2) {
+        QList<QByteArray> splitRow = line.split(',');
+        if (splitRow.size() < 2) {
             _log->debug() << "Missing column(s)" << std::flush;
 			return false;
         }


### PR DESCRIPTION
Editing metadata of samples within El-MAVEN, when the sample list is large quickly becomes tedious. For this reason we have metadata import facility. But generation of this metadata (CSV) file separately, is itself tedious for large number of samples. With this change users will be able to export a metadata template for their current set of loaded samples, which they can easily edit in a spreadsheet software and then use the import facility to get the desired effect.