### PR TITLE
[Fix] Mark C12 PARENT peak-group as same as parent #537

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -500,6 +500,15 @@ void PeakGroup::reduce() { // make sure there is only one peak per sample
     //	cerr << "\t\t\treduce() from " << startSize << " to " << peaks.size() << endl;
 }
 
+void PeakGroup::setLabel(char label)
+{
+    this->label = label;
+    for (auto& child : children) {
+        if (child.tagString == "C12 PARENT")
+            child.setLabel(label);
+    }
+}
+
 float PeakGroup::massCutoffDist(float cmass,MassCutoff *massCutoff)
 {
     return mzUtils::massCutoffDist(cmass,meanMz,massCutoff);

--- a/src/core/libmaven/PeakGroup.h
+++ b/src/core/libmaven/PeakGroup.h
@@ -277,7 +277,7 @@ class PeakGroup{
          * @method setLabel
          * @param  label    []
          */
-        inline void setLabel(char label) { this->label=label;}
+        void setLabel(char label);
 
         /**
          * [ppmDist ]

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -286,6 +286,10 @@ void TableDockWidget::updateItem(QTreeWidgetItem *item) {
       item->setHidden(false);
     }
   }
+
+  for (int i = 0; i < item->childCount(); ++i) {
+    updateItem(item->child(i));
+  }
 }
 
 void TableDockWidget::updateCompoundWidget() {


### PR DESCRIPTION
Peak-groups when marked good or bad are exported with their labels, except when they are isotopic parent groups. With this patch, along with the parent group, the child group labelled as "C12 PARENT" is also marked good/bad. This way when the table data is exported, the curation will be visible for parent isotopic group at least. The other isotopic groups will remain unmarked and left to the user's discretion.