### PR TITLE
Use double for Isotope object constructor #393

### DIFF
--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -769,7 +769,7 @@ class Isotope
     int S34;
     int H2;
 
-    Isotope(string name, float mass, int c = 0, int n = 0, int s = 0, int h = 0)
+    Isotope(string name, double mass, int c = 0, int n = 0, int s = 0, int h = 0)
     {
         this->mass = mass;
         this->name = name;


### PR DESCRIPTION
The function `MassCalculator::computeIsotopes` computes high-precision m/z values and stores them as `double` values. But while creating `Isotope` objects, the constructor would implicitly cast double values to a float which were then again stored as a double within the object itself. The intermediate conversion would make the mass values lose some precision which made the C12 parent isotope m/z value being a little different than the parent ion's.