### PR TITLE
[Fix] Sample number in EIC and samples widget

### DIFF
--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -107,7 +107,10 @@ mzSample* mzFileIO::loadSample(const QString& filename){
     if ( sample && sample->scans.size() > 0 ) {
         if (sample->sampleNumber > 0){
             qDebug() << sampleName;
-            QString sampleNumberInfo = " | Sample Number=" + QString::number(sample->sampleNumber);
+            QString sampleNumber =
+                sample->sampleNumber != -1 ? QString::number(sample->sampleNumber)
+                                           : "NA";
+            QString sampleNumberInfo = " | Sample Number=" + sampleNumber;
             sampleName = sampleName + sampleNumberInfo;
         }
 

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -82,15 +82,18 @@ void EicPoint::hoverEnterEvent (QGraphicsSceneHoverEvent*) {
 
 	string sampleName;
     if (_peak && _peak->getSample() ) {
-        sampleName = _peak->getSample()->sampleName;
-
+        auto sample = _peak->getSample();
+        QString sampleNumber =
+            sample->sampleNumber != -1 ? QString::number(sample->sampleNumber)
+                                       : "NA";
+        sampleName = sample->sampleName;
         setToolTip( "<b>  Sample: </b>"   + QString( sampleName.c_str() ) +
                           "<br> <b>intensity: </b>" +   QString::number(_peak->peakIntensity) +
                             "<br> <b>area: </b>" + 		  QString::number(_peak->peakAreaCorrected) +
                             "<br> <b>Spline Area: </b>" + 		  QString::number(_peak->peakSplineArea) +
                             "<br> <b>rt: </b>" +   QString::number(_peak->rt, 'f', 2 ) +
-                            "<br> <b>scan#: </b>" +   QString::number(_peak->scan ) + 
-                            "<br> <b>sample number: </b>" +   QString::number(_peak->getSample()->sampleNumber) + 
+                            "<br> <b>scan#: </b>" +   QString::number(_peak->scan ) +
+                            "<br> <b>sample number: </b>" + sampleNumber +
                             "<br> <b>m/z: </b>" + QString::number(_peak->peakMz, 'f', 6 )
                         );
 
@@ -113,11 +116,15 @@ void EicPoint::hoverEnterEvent (QGraphicsSceneHoverEvent*) {
 		   "<br> <b>Group Overlap Frac: </b>" + QString::number(_peak->groupOverlapFrac) +
 		 */
 	} 
-	if (_scan) { 
+    if (_scan) {
+        auto sample = _scan->getSample();
+        QString sampleNumber =
+            sample->sampleNumber != -1 ? QString::number(sample->sampleNumber)
+                                       : "NA";
 		setToolTip( "<b>  Sample: </b>"   + QString( _scan->sample->sampleName.c_str() ) +
 					"<br> <b>FilterLine: </b>" + 		  QString(_scan->filterLine.c_str() ) + 
 					"<br> <b>Scan#: </b>" +   QString::number(_scan->scannum) +
-                    "<br> <b>sample number: </b>" +   QString::number(_scan->sample->sampleNumber) + 
+                    "<br> <b>sample number: </b>" + sampleNumber +
 					"<br> <b>PrecursorMz: </b>" +   QString::number(_scan->precursorMz, 'f', 2 )
 		);
 	}

--- a/src/gui/mzroll/projectdockwidget.cpp
+++ b/src/gui/mzroll/projectdockwidget.cpp
@@ -554,7 +554,11 @@ void ProjectDockWidget::setInfo(vector<mzSample*>&samples) {
     _treeWidget->clear();
 
     QStringList header;
-    header << "Sample" << "Set" << "Scaling" << "Injection Order";
+    header << "Sample"
+           << "Set"
+           << "Scaling"
+           << "Injection Order"
+           << "Sample Number";
     _treeWidget->setHeaderLabels( header );
     _treeWidget->header()->setStretchLastSection(true);
     _treeWidget->setHeaderHidden(false);
@@ -612,6 +616,10 @@ void ProjectDockWidget::setInfo(vector<mzSample*>&samples) {
             item->setText(3, QString::number(sample->getInjectionOrder()));
         else
             item->setText(3, QString("NA"));
+        if(sample->sampleNumber != -1)
+            item->setText(4, QString::number(sample->sampleNumber));
+        else
+            item->setText(4, QString("NA"));
 
         item->setFlags(Qt::ItemIsEditable|Qt::ItemIsSelectable|Qt::ItemIsDragEnabled|Qt::ItemIsUserCheckable|Qt::ItemIsEnabled);
         sample->isSelected  ? item->setCheckState(0,Qt::Checked) : item->setCheckState(0,Qt::Unchecked);


### PR DESCRIPTION
The following changes have been made:
1. Sample number when not available from sample metadata, will be shown as "NA" instead of -1.
2. A column has been added to samples widget which displays the "Sample Number".