### PR TITLE
[Fix] Wrap sentry header include in OSX guards

### DIFF
--- a/src/common/mixpanel.cpp
+++ b/src/common/mixpanel.cpp
@@ -8,7 +8,11 @@
 #include <QNetworkReply>
 
 #include "mixpanel.h"
+#ifdef __OSX_AVAILABLE
+#ifndef DEBUG
 #include "sentry.h"
+#endif
+#endif
 
 Mixpanel::Mixpanel()
 {


### PR DESCRIPTION
This should fix compilation failure on Linux.