### PR TITLE
[Ftr] Visualize integrated area #782

### DIFF
--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -992,7 +992,12 @@ void EicWidget::unSetPeakTableGroup(PeakGroup* group)
     }
 }
 
-void EicWidget::replot(PeakGroup* group) {
+void EicWidget::replot(PeakGroup* group)
+{
+    if (_areaIntegration) {
+        toggleAreaIntegration(false);
+        return;
+    }
 
 	if (eicParameters->eics.size() == 0)
 		return;

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -651,6 +651,10 @@ void EicWidget::addEICLines(bool showSpline,
         }
 
         setLineAttributes(lineSpline, eic, 0.7f, zValue);
+
+        // we do not want baseline to be computed on area integration's redraws
+        if(_showBaseline && !_areaIntegration)
+            addBaseLine(eic, zValue);
     }
 }
 
@@ -852,9 +856,8 @@ void EicWidget::addMergedEIC() {
 
 }
 
-void EicWidget::addBaseLine(EIC* eic) {
-    QSettings* settings = this->getMainWindow()->getSettings();
-
+void EicWidget::addBaseLine(EIC* eic, double zValue)
+{
     if (!eic->baseline) {
         auto parameters = getMainWindow()->mavenParameters;
         eic->setBaselineDropTopX(parameters->baseline_dropTopX);
@@ -890,23 +893,12 @@ void EicWidget::addBaseLine(EIC* eic) {
 
     QColor color = QColor::fromRgbF( eic->color[0], eic->color[1], eic->color[2], 1 );
     line->setColor(color);
-	line->setZValue(5);
+    line->setZValue(zValue);
 
     QPen pen(color, 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
 
     line->setPen(pen);
 }
-
-void EicWidget::addBaseLine() {
-	qDebug() << " EicWidget::addBaseLine()";
-
-	for (unsigned int i = 0; i < eicParameters->eics.size(); i++) {
-		EIC* eic = eicParameters->eics[i];
-        addBaseLine(eic);
-    }
-}
-
-
 
 void EicWidget::showPeakArea(Peak* peak) {
 	//qDebug <<" EicWidget::showPeakArea(Peak* peak)";
@@ -1023,8 +1015,6 @@ void EicWidget::replot(PeakGroup* group) {
 
     if (_showCubicSpline)
         addCubicSpline();
-    if (_showBaseline)
-        addBaseLine();
     if (_showTicLine || _showBicLine)
         addTicLine();
     if (_showMergedEIC)

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1070,7 +1070,14 @@ void EicWidget::replot(PeakGroup* group)
 
 	setSelectedGroup(group);
 	setTitle();
-	addEICLines(_showSpline, _showEIC);
+
+    if (group != nullptr && !group->searchTableName.empty()) {
+        float rtMin = group->minRt;
+        float rtMax = group->maxRt;
+        addEICLines(_showSpline, _showEIC, true, rtMin, rtMax);
+    } else {
+        addEICLines(_showSpline, _showEIC);
+    }
 	showAllPeaks();
 
 	if (group && group->getCompound() != NULL && group->getCompound()->expectedRt > 0)

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1722,6 +1722,7 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
 
     emit groupSet(group);
     replot(group);
+    _clearEicPoints();
 	addPeakPositions(group);
 }
 

--- a/src/gui/mzroll/eicwidget.h
+++ b/src/gui/mzroll/eicwidget.h
@@ -253,6 +253,7 @@ private:
     bool _ignoreTolerance;
 
     bool _ignoreMouseReleaseEvent;
+    QGraphicsLineItem* _selectionLine;
     vector<EicLine*> _drawnLines;
     vector<EicPoint*> _drawnPoints;
 
@@ -278,6 +279,9 @@ private:
 
 	//function to add and remove notes
 	void getNotes(float mzmin, float mzmax);
+
+    void _drawSelectionLine(float rtMin, float rtMax);
+    void _eraseSelectionLine();
 
     void _clearEicLines();
     void _clearEicPoints();

--- a/src/gui/mzroll/eicwidget.h
+++ b/src/gui/mzroll/eicwidget.h
@@ -60,8 +60,7 @@ public Q_SLOTS:
                      float rtMax = -1.0f);
 
     void addCubicSpline(); //TODO: Sahil Added while merging eicWidget
-	void addBaseLine();
-    void addBaseLine(EIC*);
+    void addBaseLine(EIC* eic, double zValue = 0.0);
 	void addTicLine();
 	void addMergedEIC();
 	void setFocusLine(float rt);

--- a/src/gui/mzroll/eicwidget.h
+++ b/src/gui/mzroll/eicwidget.h
@@ -7,6 +7,8 @@
 
 class EIC;
 class EICLogic;
+class EicLine;
+class EicPoint;
 class Note;
 class BoxPlot;
 class BarPlot;
@@ -51,14 +53,18 @@ public Q_SLOTS:
 	void setCompound(Compound* c);
         void setSelectedGroup(PeakGroup* group);
         PeakGroup* getSelectedGroup();
-	void addEICLines(bool showSpline, bool showEIC);
+    void addEICLines(bool showSpline,
+                     bool showEic,
+                     bool overlayingIntegratedArea = false,
+                     float rtMin = -1.0f,
+                     float rtMax = -1.0f);
+
     void addCubicSpline(); //TODO: Sahil Added while merging eicWidget
 	void addBaseLine();
     void addBaseLine(EIC*);
 	void addTicLine();
 	void addMergedEIC();
 	void setFocusLine(float rt);
-	void drawSelectionLine(float rtmin, float rtmax);
 	void addFocusLine(PeakGroup*);
 	void addBarPlot(PeakGroup*);
 	void addBoxPlot(PeakGroup*);
@@ -124,10 +130,13 @@ public Q_SLOTS:
 	void startSpectralAveraging() {
 		toggleSpectraAveraging(true);
 	}
-	void toggleAreaIntegration(bool f) {
-		_areaIntegration = f;
-		f ? setCursor(Qt::SizeHorCursor) : setCursor(Qt::ArrowCursor);
-	}
+
+    /**
+     * @brief Hides peak-bubbles and fades the EIC such that any integrated is
+     * clearly visible as highlighted.
+     */
+    void toggleAreaIntegration(bool toggleOn);
+
 	void toggleSpectraAveraging(bool f) {
 		_spectraAveraging = f;
 		f ? setCursor(Qt::SizeHorCursor) : setCursor(Qt::ArrowCursor);
@@ -174,7 +183,8 @@ protected:
 	}
 	void contextMenuEvent(QContextMenuEvent * event);
 	void keyPressEvent(QKeyEvent *e);
-	void timerEvent(QTimerEvent * event);
+    void keyReleaseEvent(QKeyEvent *e);
+    void timerEvent(QTimerEvent * event);
 
 	void setupColors();
 	void setTitle();
@@ -243,10 +253,13 @@ private:
      */
     bool _ignoreTolerance;
 
+    bool _ignoreMouseReleaseEvent;
+    vector<EicLine*> _drawnLines;
+    vector<EicPoint*> _drawnPoints;
+
 	//gui related
 	QWidget *parent;
 	QGraphicsLineItem* _focusLine;
-	QGraphicsLineItem* _selectionLine;
 
 	void showPeak(float freq, float amplitude);
 	void groupPeaks();
@@ -267,6 +280,9 @@ private:
 	//function to add and remove notes
 	void getNotes(float mzmin, float mzmax);
 
+    void _clearEicLines();
+    void _clearEicPoints();
+    void _clearBarPlot();
 };
 
 #endif

--- a/src/gui/mzroll/eicwidget.h
+++ b/src/gui/mzroll/eicwidget.h
@@ -60,7 +60,7 @@ public Q_SLOTS:
                      float rtMax = -1.0f);
 
     void addCubicSpline(); //TODO: Sahil Added while merging eicWidget
-    void addBaseLine(EIC* eic, double zValue = 0.0);
+    EicLine* addBaseLine(EIC* eic, double zValue = 0.0);
 	void addTicLine();
 	void addMergedEIC();
 	void setFocusLine(float rt);

--- a/src/gui/mzroll/line.cpp
+++ b/src/gui/mzroll/line.cpp
@@ -41,10 +41,12 @@ void EicLine::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget
     	painter->setPen(pen);
     }
 
-    if (_fillPath)
+    if (_fillPath) {
+        if (!_clipPath.isEmpty())
+            painter->setClipPath(_clipPath);
         painter->drawPolygon(_line);
     //Draw piece by piece line - Kiran
-    else {
+    } else {
         for(int i=0; i <_line.size()-2;i+=2) {
             painter->drawLine(_line[i],_line[i+1]);
         }
@@ -101,4 +103,4 @@ void EicLine::fixEnds() {
 
     //qDebug() << last << a << b << first;
     _endsFixed=true;
-} 
+}

--- a/src/gui/mzroll/line.cpp
+++ b/src/gui/mzroll/line.cpp
@@ -14,6 +14,13 @@ EicLine::EicLine(QGraphicsItem* parent, QGraphicsScene *scene):QGraphicsItem(par
     if(scene) scene->addItem(this);
 }
 
+void EicLine::removeFromScene()
+{
+    prepareGeometryChange();
+    if (scene() != nullptr)
+        scene()->removeItem(this);
+}
+
 QRectF EicLine::boundingRect() const
 {
 

--- a/src/gui/mzroll/line.h
+++ b/src/gui/mzroll/line.h
@@ -24,6 +24,9 @@ public:
     QPainterPath shape() const;
     void setClosePath(bool value ) {_closePath=value;}
     void removeFromScene();
+    void setClipPath(QPainterPath& path) { _clipPath = path; }
+    QPolygonF line() const { return _line; }
+    void setLine(const QPolygonF& line) { _line = line; }
 
 protected:
     QRectF boundingRect() const;
@@ -43,7 +46,7 @@ private:
     bool _endsFixed;
     bool _closePath;
     bool _fillPath;
-
+    QPainterPath _clipPath;
 };
 
 #endif

--- a/src/gui/mzroll/line.h
+++ b/src/gui/mzroll/line.h
@@ -12,7 +12,7 @@ public:
     EicLine(QGraphicsItem* parent, QGraphicsScene *scene);
     void addPoint(float x, float y)  { _line << QPointF(x,y); }
     void addPoint(QPointF p)  { _line << p; }
-    void setColor(QColor &c)  { _color = c; }
+    void setColor(const QColor &c)  { _color = c; }
     void setPen(QPen &p)  { _pen = p; }
     void setBrush(QBrush &b)  { _brush = b; }
     void fixEnds();
@@ -23,6 +23,7 @@ public:
     void setFillPath(bool value) { _fillPath=value; }
     QPainterPath shape() const;
     void setClosePath(bool value ) {_closePath=value;}
+    void removeFromScene();
 
 protected:
     QRectF boundingRect() const;

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1395,6 +1395,7 @@ PeakGroup* MainWindow::bookmarkPeakGroup(PeakGroup* group)
 		bookmarkedGroup = bookmarkedPeaks->addPeakGroup(group);
         bookmarkedPeaks->showAllGroups();
 		bookmarkedPeaks->updateTable();
+        bookmarkedPeaks->selectPeakGroup(bookmarkedGroup);
     }
     return bookmarkedGroup;
 }

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -63,6 +63,13 @@ EicPoint::EicPoint(float x, float y, Peak* peak, MainWindow* mw)
 
 EicPoint::~EicPoint() {}
 
+void EicPoint::removeFromScene()
+{
+    prepareGeometryChange();
+    if (scene() != nullptr)
+        scene()->removeItem(this);
+}
+
 QRectF EicPoint::boundingRect() const
 {
     return(QRectF(_x-_cSize/2,_y-_cSize/2,_cSize,_cSize));

--- a/src/gui/mzroll/point.h
+++ b/src/gui/mzroll/point.h
@@ -29,7 +29,7 @@ public:
     void setPointShape(POINTSHAPE shape) { pointShape=shape; }
     void forceFillColor(bool flag) { _forceFill = flag; }
     void setSize(float size) { _cSize=size; }
-
+    void removeFromScene();
 
 protected:
     QRectF boundingRect() const;

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -934,6 +934,24 @@ vector<EIC *> TableDockWidget::getEICs(float rtmin,
   return (eics);
 }
 
+bool TableDockWidget::selectPeakGroup(PeakGroup *group)
+{
+  if (group == nullptr)
+    return false;
+
+  QTreeWidgetItemIterator it(treeWidget);
+  while (*it) {
+    QTreeWidgetItem *item = (*it);
+    QVariant v = item->data(0, Qt::UserRole);
+    PeakGroup *currentGroup = v.value<PeakGroup *>();
+    if (currentGroup == group) {
+        treeWidget->setCurrentItem(item);
+      return true;
+    }
+  }
+  return false;
+}
+
 void TableDockWidget::showSelectedGroup() {
 
   QTreeWidgetItem *item = treeWidget->currentItem();

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -246,6 +246,15 @@ public Q_SLOTS:
   void writeMascotGeneric(QString fileName);
   vector<EIC *> getEICs(float rtmin, float rtmax, PeakGroup &grp);
 
+  /**
+   * @brief Selects the item in the tree which stores the given peak-group.
+   * @param A pointer to a `PeakGroup` object that will be used to compare
+   * against stored peak-groups.
+   * @return Boolean value denoting whether the peak-group was found and
+   * selected or not.
+   */
+  bool selectPeakGroup(PeakGroup *group);
+
 protected:
   MainWindow *_mainwindow;
   tableViewType viewType;


### PR DESCRIPTION
Being able to (at least) visualize the area being integrated, either manually or automatically, has been missing from the software. This PR attempts to take a shot at solving this problem.

Pressing _Shift_ key will enter "area integration mode" (the same will happen using integration button on EIC toolbar), in which chromatogram is faded and upon mouse dragging becomes prominent highlighting the area that will be considered for integration of the peaks. Maybe the visuals can be improved, but it seems good enough to me for now.

Some other notes:
1. Releasing _Shift_ before mouse button exits integration mode without registering any selected peak area. This is intentional.
2. The area for all peak-groups in peak tables will be visible in the EIC in a similar to how it looks while being manually integrated.
3. Unfortunately, editing the bounds of an existing peak-group is still not possible (#476), yet. This involves not only adding some interactivity to the EIC widget, but also inspecting all the assumptions that have been made until now about the immutability of peak-group bounds, once created. That seemed a bit out-of-scope for this PR.