### PR TITLE
[Fix] Re-enable running concurrent sessions #1215

### DIFF
--- a/src/cli/peakdetector/main.cpp
+++ b/src/cli/peakdetector/main.cpp
@@ -33,7 +33,8 @@ int main(int argc, char *argv[]) {
 	// Polly CLI part over..
 
     QString parentFolder = "ElMaven";
-    QString logFile = "peakdetector_cli.log";
+    QString logFile = QString::fromStdString(Logger::constant_time()
+                                             + "_peakdetector_cli.log");
     QString fpath = QStandardPaths::writableLocation(
                         QStandardPaths::GenericConfigLocation)
                     + QDir::separator()

--- a/src/common/downloadmanager.cpp
+++ b/src/common/downloadmanager.cpp
@@ -13,7 +13,8 @@ DownloadManager::DownloadManager():
     err(false)
 {
     QString parentFolder = "ElMaven";
-    QString logFile = "download_manager.log";
+    QString logFile = QString::fromStdString(Logger::constant_time()
+                                             + "_download_manager.log");
     QString fpath = QStandardPaths::writableLocation(
                         QStandardPaths::GenericConfigLocation)
                     + QDir::separator()

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <fstream>
 #include <iostream>
+#include <iomanip>
 #include <sstream>
 
 class LogBuffer;
@@ -58,6 +59,23 @@ public:
      * @return A reference to a `std::ostream` object.
      */
     std::ostream& error();
+
+    /**
+     * @brief Obtain a unique calendar time, stamped from the first time this
+     * function is called.
+     * @return A shorthand ISO 8601 formatted time string, representing a UTC
+     * time-point.
+     */
+    static std::string constant_time()
+    {
+        static auto now = std::chrono::system_clock::now();
+        auto constant_time = std::chrono::system_clock::to_time_t(now);
+        auto tm = *std::gmtime(&constant_time);
+
+        std::stringstream sstream;
+        sstream << std::put_time(&tm, "%Y%m%dT%H%M%SZ");
+        return sstream.str();
+    }
 
 private:
     /**

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -10,7 +10,8 @@ PollyIntegration::PollyIntegration(DownloadManager* dlManager):
     _fPtr(nullptr)
 {
     QString parentFolder = "ElMaven";
-    QString logFile = "polly_integration.log";
+    QString logFile = QString::fromStdString(Logger::constant_time()
+                                             + "_polly_integration.log");
     QString fpath = QStandardPaths::writableLocation(
                         QStandardPaths::GenericConfigLocation)
                     + QDir::separator()

--- a/tests/MavenTests/testCLI.cpp
+++ b/tests/MavenTests/testCLI.cpp
@@ -13,7 +13,8 @@
 TestCLI::TestCLI()
 {
     QString parentFolder = "ElMaven";
-    QString logFile = "peakdetector_cli.log";
+    QString logFile = QString::fromStdString(Logger::constant_time()
+                                             + "_peakdetector_cli.log");
     QString fpath = QStandardPaths::writableLocation(
                         QStandardPaths::GenericConfigLocation)
                     + QDir::separator()


### PR DESCRIPTION
The log files, that were introduced for some utilities in the last release, were putting a restriction of being editable by only one process (most prominently on Windows), which lead to a second parallel session of El-MAVEN to throw a write exception as soon as it started. To prevent this event, log files will now write to a separate timestamped log, that share the same prefix for files from a single session but are different for files of a different El-MAVEN/peakdetector session.

Note: this fix also relies on the fact that, as soon as an executable begins they create at least one log that is created using the static timestamp - which is true for both El-MAVEN (which creates a DownloadManager log) and peakdetector (which creates a log for itself) - while starting up.