### PR TITLE
[Fix] Update isotope and peak intensity with quantitation #571

### DIFF
--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -323,12 +323,16 @@ void IsotopeWidget::populateByParentGroup(vector<Isotope> masslist, double paren
 		if (!peak)
 			continue;
 
+        vector<mzSample*> samples = {_selectedSample};
+        auto quantity = child.getOrderedIntensityVector(samples,
+                                                        _mw->getUserQuantType()).at(0);
+
 		mzLink link;
 		link.mz1 = parentMass;
 		link.mz2 = child.expectedMz;
 		link.note = isotopeName;
-		link.value1 = child.expectedAbundance;
-		link.value2 = peak->peakIntensity;
+        link.value1 = child.expectedAbundance;
+        link.value2 = quantity;
 		isotopeParameters->links.push_back(link);
 	}
 }
@@ -565,8 +569,8 @@ void IsotopeWidget::showTable()
 	p->clear();
 	p->setColumnCount(6);
 	p->setHeaderLabels(QStringList() << "Isotope Name"
-									 << "m/z"
-									 << "Intensity"
+                                     << "m/z"
+                                     << _mw->quantType->currentText()
 									 << "%Labeling"
 									 << "%Expected"
 									 << "%Relative");

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -673,3 +673,8 @@ QString IsotopeWidget::groupTextEport(PeakGroup *group)
 	}
 	return info.join("\t");
 }
+
+void IsotopeWidget::refreshForCurrentPeak()
+{
+    computeIsotopes(isotopeParameters->_formula);
+}

--- a/src/gui/mzroll/isotopeswidget.h
+++ b/src/gui/mzroll/isotopeswidget.h
@@ -63,6 +63,13 @@ public Q_SLOTS:
 	**/
 	void updateSampleList();
 
+    /**
+     * @brief This slot is meant to be called when the isotopes list needs to be
+     * updated based on changes to some external state. It will simply
+     * repopulate the list for an already set peak.
+     */
+    void refreshForCurrentPeak();
+
 private Q_SLOTS:
 	void showInfo();
 	void showTable();

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3089,6 +3089,10 @@ void MainWindow::createToolBars() {
     connect(quantType,
             SIGNAL(currentIndexChanged(int)),
             SLOT(refreshIntensities()));
+    connect(quantType,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            isotopeWidget,
+            &IsotopeWidget::refreshForCurrentPeak);
     fileLoader->insertSettingForSave("mainWindowPeakQuantitation",
                                      variant(0));
 

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -86,9 +86,35 @@ void EicPoint::hoverEnterEvent (QGraphicsSceneHoverEvent*) {
         QString sampleNumber =
             sample->sampleNumber != -1 ? QString::number(sample->sampleNumber)
                                        : "NA";
-        sampleName = sample->sampleName;
+        sampleName = _peak->getSample()->sampleName;
+
+        auto quantType = _mw->getUserQuantType();
+        float quantity = _peak->peakIntensity;
+        switch (quantType) {
+            case PeakGroup::Area:
+                quantity = _peak->peakAreaCorrected;
+                break;
+            case PeakGroup::AreaTop:
+                quantity = _peak->peakAreaTopCorrected;
+                break;
+            case PeakGroup::AreaNotCorrected:
+                quantity = _peak->peakArea;
+                break;
+            case PeakGroup::AreaTopNotCorrected:
+                quantity = _peak->peakAreaTop;
+                break;
+            case PeakGroup::Quality:
+                quantity = _peak->quality;
+                break;
+            case PeakGroup::RetentionTime:
+                quantity = _peak->rt;
+            default:
+                break;
+        }
+
         setToolTip( "<b>  Sample: </b>"   + QString( sampleName.c_str() ) +
-                          "<br> <b>intensity: </b>" +   QString::number(_peak->peakIntensity) +
+                   QString("<br> <b>%1: </b>").arg(_mw->quantType->currentText())
+                   + QString::number(quantity) +
                             "<br> <b>area: </b>" + 		  QString::number(_peak->peakAreaCorrected) +
                             "<br> <b>Spline Area: </b>" + 		  QString::number(_peak->peakSplineArea) +
                             "<br> <b>rt: </b>" +   QString::number(_peak->rt, 'f', 2 ) +


### PR DESCRIPTION
This PR contains fixes for the inconsistencies pointed out in #571. Depending on the quantitation type set by the user:
* update the abundance values shown in isotope widget,
* update the quantity shown in the tool-tip that pops up when hovering on a peak.