### PR TITLE
[Ftr] Push directly to Polly project

### DIFF
--- a/src/gui/mzroll/forms/pollyelmaveninterface.ui
+++ b/src/gui/mzroll/forms/pollyelmaveninterface.ui
@@ -12,26 +12,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>590</height>
+    <width>424</width>
+    <height>560</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
   </property>
   <property name="minimumSize">
    <size>
-    <width>400</width>
-    <height>590</height>
+    <width>424</width>
+    <height>560</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>400</width>
-    <height>590</height>
+    <width>424</width>
+    <height>560</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -43,626 +37,681 @@
   <property name="modal">
    <bool>false</bool>
   </property>
-  <widget class="QWidget" name="horizontalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>300</x>
-     <y>10</y>
-     <width>91</width>
-     <height>32</height>
-    </rect>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <property name="leftMargin">
+    <number>6</number>
    </property>
-   <layout class="QHBoxLayout" name="horizontalLayout">
-    <item>
-     <widget class="QPushButton" name="logoutButton">
-      <property name="text">
-       <string>Log out</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
-  <widget class="QListWidget" name="workflowMenu">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>90</y>
-     <width>381</width>
-     <height>151</height>
-    </rect>
+   <property name="topMargin">
+    <number>6</number>
    </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
+   <property name="rightMargin">
+    <number>6</number>
    </property>
-   <property name="verticalScrollBarPolicy">
-    <enum>Qt::ScrollBarAlwaysOff</enum>
+   <property name="bottomMargin">
+    <number>6</number>
    </property>
-   <property name="horizontalScrollBarPolicy">
-    <enum>Qt::ScrollBarAlwaysOff</enum>
+   <property name="verticalSpacing">
+    <number>18</number>
    </property>
-   <property name="sizeAdjustPolicy">
-    <enum>QAbstractScrollArea::AdjustToContents</enum>
-   </property>
-   <property name="autoScroll">
-    <bool>false</bool>
-   </property>
-   <property name="alternatingRowColors">
-    <bool>false</bool>
-   </property>
-   <property name="selectionBehavior">
-    <enum>QAbstractItemView::SelectRows</enum>
-   </property>
-   <property name="iconSize">
-    <size>
-     <width>86</width>
-     <height>86</height>
-    </size>
-   </property>
-   <property name="textElideMode">
-    <enum>Qt::ElideNone</enum>
-   </property>
-   <property name="verticalScrollMode">
-    <enum>QAbstractItemView::ScrollPerItem</enum>
-   </property>
-   <property name="horizontalScrollMode">
-    <enum>QAbstractItemView::ScrollPerItem</enum>
-   </property>
-   <property name="movement">
-    <enum>QListView::Free</enum>
-   </property>
-   <property name="flow">
-    <enum>QListView::LeftToRight</enum>
-   </property>
-   <property name="isWrapping" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="resizeMode">
-    <enum>QListView::Fixed</enum>
-   </property>
-   <property name="layoutMode">
-    <enum>QListView::Batched</enum>
-   </property>
-   <property name="spacing">
-    <number>12</number>
-   </property>
-   <property name="viewMode">
-    <enum>QListView::IconMode</enum>
-   </property>
-   <property name="uniformItemSizes">
-    <bool>true</bool>
-   </property>
-   <property name="wordWrap">
-    <bool>false</bool>
-   </property>
-   <property name="currentRow">
-    <number>-1</number>
-   </property>
-   <item>
-    <property name="text">
-     <string>FirstView</string>
-    </property>
-    <property name="toolTip">
-     <string>FirstView: Preview El-MAVEN processed data and perform further analysis</string>
-    </property>
-    <property name="font">
-     <font>
-      <pointsize>12</pointsize>
-      <italic>true</italic>
-      <underline>false</underline>
-     </font>
-    </property>
-    <property name="textAlignment">
-     <set>AlignCenter</set>
-    </property>
-    <property name="icon">
-     <iconset resource="../mzroll.qrc">
-      <normaloff>:/images/firstView.png</normaloff>
-      <normalon>:/images/firstView.png</normalon>
-      <activeoff>:/images/firstView.png</activeoff>
-      <activeon>:/images/firstViewSelected.png</activeon>
-      <selectedoff>:/images/firstViewSelected.png</selectedoff>
-      <selectedon>:/images/firstViewSelected.png</selectedon>:/images/firstView.png</iconset>
-    </property>
-    <property name="flags">
-     <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
-    </property>
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="logoutButton">
+       <property name="text">
+        <string>Log out</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item>
-    <property name="text">
-     <string>PollyPhi</string>
-    </property>
-    <property name="toolTip">
-     <string>PollyPhi Relative: Process and derive insights from Relative flux workflow</string>
-    </property>
-    <property name="font">
-     <font>
-      <pointsize>12</pointsize>
-      <italic>true</italic>
-     </font>
-    </property>
-    <property name="textAlignment">
-     <set>AlignCenter</set>
-    </property>
-    <property name="icon">
-     <iconset resource="../mzroll.qrc">
-      <normaloff>:/images/flux.png</normaloff>
-      <normalon>:/images/flux.png</normalon>
-      <activeoff>:/images/flux.png</activeoff>
-      <activeon>:/images/fluxSelected.png</activeon>
-      <selectedoff>:/images/fluxSelected.png</selectedoff>
-      <selectedon>:/images/fluxSelected.png</selectedon>:/images/flux.png</iconset>
-    </property>
-    <property name="flags">
-     <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
-    </property>
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="usernameLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="styleSheet">
+        <string notr="true"/>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
-   <item>
-    <property name="text">
-     <string>QuantFit</string>
-    </property>
-    <property name="toolTip">
-     <string>Polly QuantFit: Calibrate and quantify your metabolites and labelled fragments of metabolites.</string>
-    </property>
-    <property name="font">
-     <font>
-      <pointsize>12</pointsize>
-      <italic>true</italic>
-     </font>
-    </property>
-    <property name="textAlignment">
-     <set>AlignCenter</set>
-    </property>
-    <property name="icon">
-     <iconset resource="../mzroll.qrc">
-      <normaloff>:/images/quant.png</normaloff>
-      <normalon>:/images/quant.png</normalon>
-      <activeoff>:/images/quant.png</activeoff>
-      <activeon>:/images/quantSelected.png</activeon>
-      <selectedoff>:/images/quantSelected.png</selectedoff>
-      <selectedon>:/images/quantSelected.png</selectedon>:/images/quant.png</iconset>
-    </property>
-    <property name="flags">
-     <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
-    </property>
-   </item>
-  </widget>
-  <widget class="QWidget" name="horizontalLayoutWidget_5">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>281</width>
-     <height>31</height>
-    </rect>
-   </property>
-   <layout class="QHBoxLayout" name="horizontalLayout_3">
-    <item>
-     <widget class="QLabel" name="usernameLabel">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="font">
-       <font>
-        <underline>true</underline>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true"/>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <spacer name="horizontalSpacer">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>40</width>
-        <height>20</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
-   </layout>
-  </widget>
-  <widget class="QLabel" name="label_2">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>50</y>
-     <width>381</width>
-     <height>31</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <weight>75</weight>
-     <bold>true</bold>
-    </font>
-   </property>
-   <property name="text">
-    <string>Select App</string>
-   </property>
-  </widget>
-  <widget class="QStackedWidget" name="stackedWidget">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>250</y>
-     <width>401</width>
-     <height>341</height>
-    </rect>
-   </property>
-   <property name="currentIndex">
-    <number>0</number>
-   </property>
-   <widget class="QWidget" name="pollyForm">
-    <widget class="QLabel" name="viewTitle">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>0</y>
-       <width>381</width>
-       <height>41</height>
-      </rect>
+   <item row="1" column="0" colspan="2">
+    <widget class="QTabWidget" name="sendModeTab">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Upload to Polly</string>
-     </property>
-    </widget>
-    <widget class="QWidget" name="horizontalLayoutWidget_2">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>40</y>
-       <width>381</width>
-       <height>41</height>
-      </rect>
-     </property>
-     <layout class="QHBoxLayout" name="tableOptions">
-      <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Select Table</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QComboBox" name="peakTableCombo">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>134</width>
-          <height>16777215</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-    <widget class="QWidget" name="horizontalLayoutWidget_4">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>290</y>
-       <width>381</width>
-       <height>41</height>
-      </rect>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5">
-      <item>
-       <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="gotoPollyButton">
-        <property name="text">
-         <string>Go to Polly</string>
-        </property>
-        <property name="default">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_5">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-    <widget class="QWidget" name="horizontalLayoutWidget_6">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>80</y>
-       <width>381</width>
-       <height>41</height>
-      </rect>
-     </property>
-     <layout class="QHBoxLayout" name="tableOptions_2">
-      <item>
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Select Groups</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_8">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QComboBox" name="groupSetCombo">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>134</width>
-          <height>16777215</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-    <widget class="QWidget" name="horizontalLayoutWidget_3">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>250</y>
-       <width>381</width>
-       <height>41</height>
-      </rect>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <item>
-       <widget class="QLabel" name="statusUpdate">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="uploadButton">
-        <property name="text">
-         <string>Upload</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-    <widget class="QGroupBox" name="projectOptions">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>130</y>
-       <width>381</width>
-       <height>111</height>
-      </rect>
-     </property>
-     <property name="title">
-      <string>Project on Polly</string>
-     </property>
-     <widget class="QWidget" name="gridLayoutWidget">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>29</y>
-        <width>361</width>
-        <height>71</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="1" column="0">
-        <widget class="QRadioButton" name="existingProjectRadio">
-         <property name="text">
-          <string>Select existing project</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLineEdit" name="newProjectEntry"/>
-       </item>
-       <item row="1" column="2">
-        <widget class="QComboBox" name="existingProjectCombo"/>
-       </item>
+     <widget class="QWidget" name="sendToAppTab">
+      <attribute name="title">
+       <string>Select Application</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="topMargin">
+        <number>6</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <property name="bottomMargin">
+        <number>6</number>
+       </property>
        <item row="0" column="0">
-        <widget class="QRadioButton" name="newProjectRadio">
-         <property name="text">
-          <string>Create new project</string>
+        <widget class="QListWidget" name="workflowMenu">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>156</height>
+          </size>
+         </property>
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContents</enum>
+         </property>
+         <property name="autoScroll">
+          <bool>false</bool>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>false</bool>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>84</width>
+           <height>84</height>
+          </size>
+         </property>
+         <property name="textElideMode">
+          <enum>Qt::ElideNone</enum>
+         </property>
+         <property name="verticalScrollMode">
+          <enum>QAbstractItemView::ScrollPerItem</enum>
+         </property>
+         <property name="horizontalScrollMode">
+          <enum>QAbstractItemView::ScrollPerItem</enum>
+         </property>
+         <property name="movement">
+          <enum>QListView::Free</enum>
+         </property>
+         <property name="flow">
+          <enum>QListView::LeftToRight</enum>
+         </property>
+         <property name="isWrapping" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="resizeMode">
+          <enum>QListView::Fixed</enum>
+         </property>
+         <property name="layoutMode">
+          <enum>QListView::Batched</enum>
+         </property>
+         <property name="spacing">
+          <number>17</number>
+         </property>
+         <property name="viewMode">
+          <enum>QListView::IconMode</enum>
+         </property>
+         <property name="uniformItemSizes">
+          <bool>true</bool>
+         </property>
+         <property name="wordWrap">
+          <bool>false</bool>
+         </property>
+         <property name="currentRow">
+          <number>-1</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>FirstView</string>
+          </property>
+          <property name="toolTip">
+           <string>FirstView: Preview El-MAVEN processed data and perform further analysis</string>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+            <italic>true</italic>
+            <underline>false</underline>
+           </font>
+          </property>
+          <property name="textAlignment">
+           <set>AlignCenter</set>
+          </property>
+          <property name="icon">
+           <iconset resource="../mzroll.qrc">
+            <normaloff>:/images/firstView.png</normaloff>
+            <normalon>:/images/firstView.png</normalon>
+            <activeoff>:/images/firstView.png</activeoff>
+            <activeon>:/images/firstViewSelected.png</activeon>
+            <selectedoff>:/images/firstViewSelected.png</selectedoff>
+            <selectedon>:/images/firstViewSelected.png</selectedon>:/images/firstView.png</iconset>
+          </property>
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>PollyPhi</string>
+          </property>
+          <property name="toolTip">
+           <string>PollyPhi Relative: Process and derive insights from Relative flux workflow</string>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="textAlignment">
+           <set>AlignCenter</set>
+          </property>
+          <property name="icon">
+           <iconset resource="../mzroll.qrc">
+            <normaloff>:/images/flux.png</normaloff>
+            <normalon>:/images/flux.png</normalon>
+            <activeoff>:/images/flux.png</activeoff>
+            <activeon>:/images/fluxSelected.png</activeon>
+            <selectedoff>:/images/fluxSelected.png</selectedoff>
+            <selectedon>:/images/fluxSelected.png</selectedon>:/images/flux.png</iconset>
+          </property>
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>QuantFit</string>
+          </property>
+          <property name="toolTip">
+           <string>Polly QuantFit: Calibrate and quantify your metabolites and labelled fragments of metabolites.</string>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="textAlignment">
+           <set>AlignCenter</set>
+          </property>
+          <property name="icon">
+           <iconset resource="../mzroll.qrc">
+            <normaloff>:/images/quant.png</normaloff>
+            <normalon>:/images/quant.png</normalon>
+            <activeoff>:/images/quant.png</activeoff>
+            <activeon>:/images/quantSelected.png</activeon>
+            <selectedoff>:/images/quantSelected.png</selectedoff>
+            <selectedon>:/images/quantSelected.png</selectedon>:/images/quant.png</iconset>
+          </property>
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+          </property>
+         </item>
         </widget>
        </item>
-       <item row="0" column="1">
-        <spacer name="horizontalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+       <item row="1" column="0">
+        <widget class="QStackedWidget" name="stackedWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
+         <property name="currentIndex">
+          <number>0</number>
          </property>
-        </spacer>
-       </item>
-       <item row="1" column="1">
-        <spacer name="horizontalSpacer_7">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
+         <widget class="QWidget" name="pollyForm">
+          <widget class="QLabel" name="viewTitle">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>391</width>
+             <height>41</height>
+            </rect>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Upload to Polly</string>
+           </property>
+          </widget>
+          <widget class="QWidget" name="horizontalLayoutWidget_2">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>50</y>
+             <width>391</width>
+             <height>32</height>
+            </rect>
+           </property>
+           <layout class="QHBoxLayout" name="tableOptions">
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Select Table</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QComboBox" name="peakTableCombo">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>134</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="horizontalLayoutWidget_4">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>270</y>
+             <width>391</width>
+             <height>32</height>
+            </rect>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="gotoPollyButton">
+              <property name="text">
+               <string>Go to Polly</string>
+              </property>
+              <property name="default">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="horizontalLayoutWidget_6">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>80</y>
+             <width>391</width>
+             <height>32</height>
+            </rect>
+           </property>
+           <layout class="QHBoxLayout" name="tableOptions_2">
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>Select Groups</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_8">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QComboBox" name="groupSetCombo">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>134</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="horizontalLayoutWidget_3">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>230</y>
+             <width>391</width>
+             <height>32</height>
+            </rect>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="statusUpdate">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="uploadButton">
+              <property name="text">
+               <string>Upload</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QGroupBox" name="projectOptions">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>120</y>
+             <width>391</width>
+             <height>101</height>
+            </rect>
+           </property>
+           <property name="title">
+            <string>Project on Polly</string>
+           </property>
+           <widget class="QWidget" name="gridLayoutWidget">
+            <property name="geometry">
+             <rect>
+              <x>10</x>
+              <y>29</y>
+              <width>371</width>
+              <height>63</height>
+             </rect>
+            </property>
+            <layout class="QGridLayout" name="gridLayout">
+             <item row="1" column="0">
+              <widget class="QRadioButton" name="existingProjectRadio">
+               <property name="text">
+                <string>Select existing project</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QLineEdit" name="newProjectEntry"/>
+             </item>
+             <item row="1" column="2">
+              <widget class="QComboBox" name="existingProjectCombo"/>
+             </item>
+             <item row="0" column="0">
+              <widget class="QRadioButton" name="newProjectRadio">
+               <property name="text">
+                <string>Create new project</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <spacer name="horizontalSpacer_6">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="1" column="1">
+              <spacer name="horizontalSpacer_7">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
+          </widget>
+         </widget>
+         <widget class="QWidget" name="advertBox">
+          <widget class="QLabel" name="viewTitleAdvert">
+           <property name="geometry">
+            <rect>
+             <x>10</x>
+             <y>0</y>
+             <width>381</width>
+             <height>41</height>
+            </rect>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Polly Application Name</string>
+           </property>
+          </widget>
+          <widget class="QWidget" name="verticalLayoutWidget">
+           <property name="geometry">
+            <rect>
+             <x>10</x>
+             <y>40</y>
+             <width>381</width>
+             <height>291</height>
+            </rect>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+             <widget class="QLabel" name="appAdvertLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_7">
+              <item>
+               <widget class="QLabel" name="tutorialLink">
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_9">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QPushButton" name="demoButton">
+                <property name="text">
+                 <string>Book a Demo</string>
+                </property>
+                <property name="default">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </widget>
        </item>
       </layout>
      </widget>
-    </widget>
-   </widget>
-   <widget class="QWidget" name="advertBox">
-    <widget class="QLabel" name="viewTitleAdvert">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>0</y>
-       <width>381</width>
-       <height>41</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Polly Application Name</string>
-     </property>
-    </widget>
-    <widget class="QWidget" name="verticalLayoutWidget">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>40</y>
-       <width>381</width>
-       <height>291</height>
-      </rect>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QLabel" name="appAdvertLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <widget class="QWidget" name="sendToProjectTab">
+      <attribute name="title">
+       <string>Send to Project Files</string>
+      </attribute>
+      <widget class="QWidget" name="horizontalLayoutWidget_5">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>170</y>
+         <width>391</width>
+         <height>32</height>
+        </rect>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
-         <widget class="QLabel" name="tutorialLink">
+         <widget class="QLabel" name="statusUpdateAlt">
           <property name="text">
            <string/>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_9">
+         <spacer name="horizontalSpacer_12">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -675,21 +724,153 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="demoButton">
+         <widget class="QPushButton" name="uploadButtonAlt">
           <property name="text">
-           <string>Book a Demo</string>
+           <string>Upload</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QLabel" name="label_2">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>389</width>
+         <height>41</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>An emDB and JSON file for all your tables in this session will be sent to the Polly project selected below.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+      <widget class="QWidget" name="horizontalLayoutWidget_7">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>440</y>
+         <width>391</width>
+         <height>32</height>
+        </rect>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <item>
+         <spacer name="horizontalSpacer_13">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="gotoPollyButtonAlt">
+          <property name="text">
+           <string>Go to Project</string>
           </property>
           <property name="default">
            <bool>true</bool>
           </property>
          </widget>
         </item>
+        <item>
+         <spacer name="horizontalSpacer_14">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
-      </item>
-     </layout>
+      </widget>
+      <widget class="QGroupBox" name="projectOptionsAlt">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>60</y>
+         <width>389</width>
+         <height>101</height>
+        </rect>
+       </property>
+       <property name="title">
+        <string>Project on Polly</string>
+       </property>
+       <widget class="QWidget" name="gridLayoutWidget_2">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>29</y>
+          <width>371</width>
+          <height>63</height>
+         </rect>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <item row="1" column="0">
+          <widget class="QRadioButton" name="existingProjectRadioAlt">
+           <property name="text">
+            <string>Select existing project</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLineEdit" name="newProjectEntryAlt"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QComboBox" name="existingProjectComboAlt"/>
+         </item>
+         <item row="0" column="0">
+          <widget class="QRadioButton" name="newProjectRadioAlt">
+           <property name="text">
+            <string>Create new project</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <spacer name="horizontalSpacer_10">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="1" column="1">
+          <spacer name="horizontalSpacer_11">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </widget>
     </widget>
-   </widget>
-  </widget>
+   </item>
+  </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <resources>

--- a/src/gui/mzroll/forms/pollyelmaveninterface.ui
+++ b/src/gui/mzroll/forms/pollyelmaveninterface.ui
@@ -13,19 +13,19 @@
     <x>0</x>
     <y>0</y>
     <width>424</width>
-    <height>560</height>
+    <height>566</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>424</width>
-    <height>560</height>
+    <height>566</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>424</width>
-    <height>560</height>
+    <height>566</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -124,173 +124,6 @@
        <property name="bottomMargin">
         <number>6</number>
        </property>
-       <item row="0" column="0">
-        <widget class="QListWidget" name="workflowMenu">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>156</height>
-          </size>
-         </property>
-         <property name="verticalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-         <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QAbstractScrollArea::AdjustToContents</enum>
-         </property>
-         <property name="autoScroll">
-          <bool>false</bool>
-         </property>
-         <property name="alternatingRowColors">
-          <bool>false</bool>
-         </property>
-         <property name="selectionBehavior">
-          <enum>QAbstractItemView::SelectRows</enum>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>84</width>
-           <height>84</height>
-          </size>
-         </property>
-         <property name="textElideMode">
-          <enum>Qt::ElideNone</enum>
-         </property>
-         <property name="verticalScrollMode">
-          <enum>QAbstractItemView::ScrollPerItem</enum>
-         </property>
-         <property name="horizontalScrollMode">
-          <enum>QAbstractItemView::ScrollPerItem</enum>
-         </property>
-         <property name="movement">
-          <enum>QListView::Free</enum>
-         </property>
-         <property name="flow">
-          <enum>QListView::LeftToRight</enum>
-         </property>
-         <property name="isWrapping" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="resizeMode">
-          <enum>QListView::Fixed</enum>
-         </property>
-         <property name="layoutMode">
-          <enum>QListView::Batched</enum>
-         </property>
-         <property name="spacing">
-          <number>17</number>
-         </property>
-         <property name="viewMode">
-          <enum>QListView::IconMode</enum>
-         </property>
-         <property name="uniformItemSizes">
-          <bool>true</bool>
-         </property>
-         <property name="wordWrap">
-          <bool>false</bool>
-         </property>
-         <property name="currentRow">
-          <number>-1</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>FirstView</string>
-          </property>
-          <property name="toolTip">
-           <string>FirstView: Preview El-MAVEN processed data and perform further analysis</string>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>12</pointsize>
-            <italic>true</italic>
-            <underline>false</underline>
-           </font>
-          </property>
-          <property name="textAlignment">
-           <set>AlignCenter</set>
-          </property>
-          <property name="icon">
-           <iconset resource="../mzroll.qrc">
-            <normaloff>:/images/firstView.png</normaloff>
-            <normalon>:/images/firstView.png</normalon>
-            <activeoff>:/images/firstView.png</activeoff>
-            <activeon>:/images/firstViewSelected.png</activeon>
-            <selectedoff>:/images/firstViewSelected.png</selectedoff>
-            <selectedon>:/images/firstViewSelected.png</selectedon>:/images/firstView.png</iconset>
-          </property>
-          <property name="flags">
-           <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>PollyPhi</string>
-          </property>
-          <property name="toolTip">
-           <string>PollyPhi Relative: Process and derive insights from Relative flux workflow</string>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>12</pointsize>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="textAlignment">
-           <set>AlignCenter</set>
-          </property>
-          <property name="icon">
-           <iconset resource="../mzroll.qrc">
-            <normaloff>:/images/flux.png</normaloff>
-            <normalon>:/images/flux.png</normalon>
-            <activeoff>:/images/flux.png</activeoff>
-            <activeon>:/images/fluxSelected.png</activeon>
-            <selectedoff>:/images/fluxSelected.png</selectedoff>
-            <selectedon>:/images/fluxSelected.png</selectedon>:/images/flux.png</iconset>
-          </property>
-          <property name="flags">
-           <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>QuantFit</string>
-          </property>
-          <property name="toolTip">
-           <string>Polly QuantFit: Calibrate and quantify your metabolites and labelled fragments of metabolites.</string>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>12</pointsize>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="textAlignment">
-           <set>AlignCenter</set>
-          </property>
-          <property name="icon">
-           <iconset resource="../mzroll.qrc">
-            <normaloff>:/images/quant.png</normaloff>
-            <normalon>:/images/quant.png</normalon>
-            <activeoff>:/images/quant.png</activeoff>
-            <activeon>:/images/quantSelected.png</activeon>
-            <selectedoff>:/images/quantSelected.png</selectedoff>
-            <selectedon>:/images/quantSelected.png</selectedon>:/images/quant.png</iconset>
-          </property>
-          <property name="flags">
-           <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
-          </property>
-         </item>
-        </widget>
-       </item>
        <item row="1" column="0">
         <widget class="QStackedWidget" name="stackedWidget">
          <property name="sizePolicy">
@@ -687,6 +520,173 @@
          </widget>
         </widget>
        </item>
+       <item row="0" column="0">
+        <widget class="QListWidget" name="workflowMenu">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>156</height>
+          </size>
+         </property>
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContents</enum>
+         </property>
+         <property name="autoScroll">
+          <bool>false</bool>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>false</bool>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>84</width>
+           <height>84</height>
+          </size>
+         </property>
+         <property name="textElideMode">
+          <enum>Qt::ElideNone</enum>
+         </property>
+         <property name="verticalScrollMode">
+          <enum>QAbstractItemView::ScrollPerItem</enum>
+         </property>
+         <property name="horizontalScrollMode">
+          <enum>QAbstractItemView::ScrollPerItem</enum>
+         </property>
+         <property name="movement">
+          <enum>QListView::Free</enum>
+         </property>
+         <property name="flow">
+          <enum>QListView::LeftToRight</enum>
+         </property>
+         <property name="isWrapping" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="resizeMode">
+          <enum>QListView::Fixed</enum>
+         </property>
+         <property name="layoutMode">
+          <enum>QListView::Batched</enum>
+         </property>
+         <property name="spacing">
+          <number>17</number>
+         </property>
+         <property name="viewMode">
+          <enum>QListView::IconMode</enum>
+         </property>
+         <property name="uniformItemSizes">
+          <bool>true</bool>
+         </property>
+         <property name="wordWrap">
+          <bool>false</bool>
+         </property>
+         <property name="currentRow">
+          <number>-1</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>FirstView</string>
+          </property>
+          <property name="toolTip">
+           <string>FirstView: Preview El-MAVEN processed data and perform further analysis</string>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+            <italic>true</italic>
+            <underline>false</underline>
+           </font>
+          </property>
+          <property name="textAlignment">
+           <set>AlignCenter</set>
+          </property>
+          <property name="icon">
+           <iconset resource="../mzroll.qrc">
+            <normaloff>:/images/firstView.png</normaloff>
+            <normalon>:/images/firstView.png</normalon>
+            <activeoff>:/images/firstView.png</activeoff>
+            <activeon>:/images/firstViewSelected.png</activeon>
+            <selectedoff>:/images/firstViewSelected.png</selectedoff>
+            <selectedon>:/images/firstViewSelected.png</selectedon>:/images/firstView.png</iconset>
+          </property>
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>PollyPhi</string>
+          </property>
+          <property name="toolTip">
+           <string>PollyPhi Relative: Process and derive insights from Relative flux workflow</string>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="textAlignment">
+           <set>AlignCenter</set>
+          </property>
+          <property name="icon">
+           <iconset resource="../mzroll.qrc">
+            <normaloff>:/images/flux.png</normaloff>
+            <normalon>:/images/flux.png</normalon>
+            <activeoff>:/images/flux.png</activeoff>
+            <activeon>:/images/fluxSelected.png</activeon>
+            <selectedoff>:/images/fluxSelected.png</selectedoff>
+            <selectedon>:/images/fluxSelected.png</selectedon>:/images/flux.png</iconset>
+          </property>
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>QuantFit</string>
+          </property>
+          <property name="toolTip">
+           <string>Polly QuantFit: Calibrate and quantify your metabolites and labelled fragments of metabolites.</string>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="textAlignment">
+           <set>AlignCenter</set>
+          </property>
+          <property name="icon">
+           <iconset resource="../mzroll.qrc">
+            <normaloff>:/images/quant.png</normaloff>
+            <normalon>:/images/quant.png</normalon>
+            <activeoff>:/images/quant.png</activeoff>
+            <activeon>:/images/quantSelected.png</activeon>
+            <selectedoff>:/images/quantSelected.png</selectedoff>
+            <selectedon>:/images/quantSelected.png</selectedon>:/images/quant.png</iconset>
+          </property>
+          <property name="flags">
+           <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+          </property>
+         </item>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="sendToProjectTab">
@@ -697,7 +697,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>170</y>
+         <y>240</y>
          <width>391</width>
          <height>32</height>
         </rect>
@@ -800,10 +800,16 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>60</y>
+         <y>130</y>
          <width>389</width>
          <height>101</height>
         </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
        <property name="title">
         <string>Project on Polly</string>
@@ -812,7 +818,7 @@
         <property name="geometry">
          <rect>
           <x>10</x>
-          <y>29</y>
+          <y>30</y>
           <width>371</width>
           <height>63</height>
          </rect>
@@ -867,6 +873,108 @@
         </layout>
        </widget>
       </widget>
+      <widget class="QWidget" name="horizontalLayoutWidget_8">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>60</y>
+         <width>391</width>
+         <height>32</height>
+        </rect>
+       </property>
+       <layout class="QHBoxLayout" name="tableOptions_3">
+        <item>
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Select Table</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_15">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QComboBox" name="peakTableComboAlt">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>134</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="horizontalLayoutWidget_9">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>90</y>
+         <width>391</width>
+         <height>32</height>
+        </rect>
+       </property>
+       <layout class="QHBoxLayout" name="tableOptions_4">
+        <item>
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Select Groups</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_16">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QComboBox" name="groupSetComboAlt">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>134</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <zorder>horizontalLayoutWidget_5</zorder>
+      <zorder>label_2</zorder>
+      <zorder>horizontalLayoutWidget_7</zorder>
+      <zorder>horizontalLayoutWidget_8</zorder>
+      <zorder>horizontalLayoutWidget_9</zorder>
+      <zorder>projectOptionsAlt</zorder>
      </widget>
     </widget>
    </item>

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -140,6 +140,14 @@ Q_OBJECT
         void updateGroup(PeakGroup* group, QString tableName);
 
         /**
+         * @brief Write current session data into a SQLite database meant to be
+         * uploaded to Polly.
+         * @param filename Name of the on-disk database file.
+         * @return `true` if write was successful, `false` otherwise.
+         */
+        bool writeSQLiteProjectForPolly(QString filename);
+
+        /**
          * @brief Write current session data into a SQLite database.
          * @details The data saved include samples' metadata, peak groups,
          * peaks, associated compounds and alignment data. Write operation

--- a/src/gui/mzroll/pollyelmaveninterface.cpp
+++ b/src/gui/mzroll/pollyelmaveninterface.cpp
@@ -1143,13 +1143,35 @@ PollyElmavenInterfaceDialog::_prepareSessionFiles(QString datetimestamp)
 
         QCoreApplication::processEvents();
 
-        QString csvFilename = datetimestamp + "_" + tableName + ".csv";
+        QString groupCsvFilename = datetimestamp
+                                   + "_"
+                                   + tableName
+                                   + "_groups"
+                                   + ".csv";
         peakTable->treeWidget->selectAll();
         peakTable->prepareDataForPolly(_writeableTempDir,
                                        "Groups Summary Matrix Format "
                                        "Comma Delimited (*.csv)",
-                                        csvFilename);
-        filenames.append(_writeableTempDir + QDir::separator() + csvFilename);
+                                        groupCsvFilename);
+        filenames.append(_writeableTempDir
+                         + QDir::separator()
+                         + groupCsvFilename);
+
+        QCoreApplication::processEvents();
+
+        QString peakCsvFilename = datetimestamp
+                                  + "_"
+                                  + tableName
+                                  + "_peaks"
+                                  + ".csv";
+        peakTable->treeWidget->selectAll();
+        peakTable->prepareDataForPolly(_writeableTempDir,
+                                       "Peaks Detailed Format "
+                                       "Comma Delimited (*.csv)",
+                                        peakCsvFilename);
+        filenames.append(_writeableTempDir
+                         + QDir::separator()
+                         + peakCsvFilename);
 
         QCoreApplication::processEvents();
     }

--- a/src/gui/mzroll/pollyelmaveninterface.h
+++ b/src/gui/mzroll/pollyelmaveninterface.h
@@ -114,6 +114,11 @@ class PollyElmavenInterfaceDialog : public QDialog,
 
 public:
 
+    enum class SendMode {
+        PollyApp,
+        PollyProject
+    };
+
     /**
      * @brief Constructor for the dialog.
      * @param mw A pointer to the main window of the application, used to create
@@ -237,6 +242,12 @@ private:
     QMap<PollyApp, QUrl> _redirectionUrlMap;
 
     /**
+     * @brief A URL that will open the Polly project to which the last session
+     * data upload was made.
+     */
+    QUrl _projectRedirectionUrl;
+
+    /**
      * @brief Project ID to which all uploads will be happening.
      */
     QString _pollyProjectId;
@@ -270,6 +281,11 @@ private:
      * prepared for upload was valid or not.
      */
     bool _lastCohortFileWasValid;
+
+    /**
+     * @brief Stores which mode the dialog is currently set to be in.
+     */
+    SendMode _selectedMode;
 
     /**
      * @brief A worker thread that allows separating blocking operations from
@@ -307,6 +323,15 @@ private:
     QStringList _prepareFilesToUpload(QDir qdir, QString datetimestamp);
 
     /**
+     * @brief Creates an emDB session file and JSON files for all peak tables,
+     * to be uploaded to a Polly project.
+     * @param datetimestamp A string which will be prepended to file-names as a
+     * way of time-stamping them.
+     * @return A list of file-names that were created.
+     */
+    QStringList _prepareSessionFiles(QString datetimestamp);
+
+    /**
      * @brief Creates a redirection URL based on the current state of the
      * dialog.
      * @param datetimestamp A timestamp string that will be used to generate a
@@ -315,8 +340,15 @@ private:
      * to.
      * @return Redirection URL as a QString.
      */
-    QString _getRedirectionUrl(QString datetimestamp,
-                               QString uploadProjectIdThread);
+    QString _getAppRedirectionUrl(QString datetimestamp,
+                                  QString uploadProjectIdThread);
+
+    /**
+     * @brief Creates a redirection URL for the given Polly project ID.
+     * @param projectId The unique ID to which a URL is needed.
+     * @return A URL as a QString.
+     */
+    QString _getProjectRedirectionUrl(QString projectId);
 
     /**
      * @brief Get project ID for the currently selected or newly entered project
@@ -428,9 +460,15 @@ private Q_SLOTS:
 
     /**
      * @brief Open a URL in desktop environment's browser that takes the user to
-     * a Polly interface where they can proceed with the analysis.
+     * a Polly application's interface where they can proceed with the analysis.
      */
-    void _goToPolly();
+    void _goToPollyApp();
+
+    /**
+     * @brief Open a URL in desktop environment's browser that takes the user to
+     * the Polly project where they can proceed with their analysis.
+     */
+    void _goToPollyProject();
 
     /**
      * @brief Log-out of Polly for the currently logged in user.
@@ -455,6 +493,13 @@ private Q_SLOTS:
      * revised.
      */
     void _reviseGroupOptions(QString tableName);
+
+    /**
+     * @brief Switch for the currently selected mode of data upload. This will
+     * either be sending files for a specific Polly application or only to a
+     * Polly project.
+     */
+    void _changeMode();
 };
 
 #endif

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -44,7 +44,7 @@ PollyIntegration::PollyIntegration(DownloadManager* dlManager):
       nodeModulesPath = binDir + "node_modules" + QDir::separator();
     #endif
 
-    indexFileURL = "https://raw.githubusercontent.com/saifulbkhan/polly-cli/ftr_get_project_endpoint/prod/index.js";
+    indexFileURL = "https://raw.githubusercontent.com/ElucidataInc/polly-cli/master/prod/index.js";
     _dlManager->setRequest(indexFileURL, this);
 }
 

--- a/src/pollyCLI/pollyintegration.cpp
+++ b/src/pollyCLI/pollyintegration.cpp
@@ -44,7 +44,7 @@ PollyIntegration::PollyIntegration(DownloadManager* dlManager):
       nodeModulesPath = binDir + "node_modules" + QDir::separator();
     #endif
 
-    indexFileURL = "https://raw.githubusercontent.com/ElucidataInc/polly-cli/master/prod/index.js";
+    indexFileURL = "https://raw.githubusercontent.com/saifulbkhan/polly-cli/ftr_get_project_endpoint/prod/index.js";
     _dlManager->setRequest(indexFileURL, this);
 }
 
@@ -675,6 +675,18 @@ QByteArray PollyIntegration::redirectionUiEndpoint()
     result = resultList[resultList.size() - 2];
 
     return result;
+}
+
+QString PollyIntegration::getProjectUrl(QString projectId)
+{
+    QString command2 = "getProjectUrl";
+    QList<QByteArray> resultAndError = runQtProcess(command2,
+                                                    QStringList() << projectId);
+    if (_hasError(resultAndError))
+        return "";
+
+    QByteArray result = resultAndError.at(0);
+    return QString(result).trimmed();
 }
 
 QString PollyIntegration::getComponentEndpoint(QString componentId,

--- a/src/pollyCLI/pollyintegration.h
+++ b/src/pollyCLI/pollyintegration.h
@@ -117,6 +117,13 @@ public:
     QByteArray redirectionUiEndpoint();
 
     /**
+     * @brief Given a Polly project's ID, obtain its UI endpoint.
+     * @param projectId A string storing a unique project ID.
+     * @return A string storing the URL directing to Polly project.
+     */
+    QString getProjectUrl(QString projectId);
+
+    /**
      * @brief Obtain a redirection URL for a given component and run ID.
      * @param componentId The component ID for which URL will be fetched.
      * @param runId The run ID that will be replaced within the URL.


### PR DESCRIPTION
Users may want to use services on Polly, that they have licenses for, but is not part of the three existing integrations (FirstView, PollyPhi and QuantFit). Currently, they will have to export their files and upload to Polly as two separate steps. Instead we are adding a "Send to Project" feature, where they can simply upload their data to Polly without having a workflow associated to it.

- [x] To-do: Revert to using the master "index.js", once [this PR](https://github.com/ElucidataInc/polly-cli/pull/14) gets merged.