### PR TITLE
[fix] Fixed the empty sample name in windows

### DIFF
--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -105,9 +105,6 @@ void mzSample::addScan(Scan* s)
 string mzSample::getFileName(const string& filename)
 {
     char sep = '/';
-#ifdef _WIN32
-    sep = '\\';
-#endif
 
     size_t i = filename.rfind(sep, filename.length());
 


### PR DESCRIPTION
In windows, the sampleNames which were being used by the entire software were the empty strings. This problem has been fixed to give the true names for the same.