### PR TITLE
[fix] Fixed the crash on ElMaven stable release #1230

### DIFF
--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1546,7 +1546,8 @@ void EicWidget::setSensitiveToTolerance(bool sensitive)
         // method initiates a `cleanup` that erases all peakgroups in
         // `eicParameters` object; `eicParameters->selectedGroup()` might also
         // be deleted which leads to corruption
-        setPeakGroup(new PeakGroup(*eicParameters->selectedGroup()));
+        if ((*eicParameters).selectedGroup() != nullptr)
+            setPeakGroup(new PeakGroup(*eicParameters->selectedGroup()));
     }
 }
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -4003,6 +4003,10 @@ QWidget* MainWindowWidgetAction::createWidget(QWidget *parent) {
                                            "tolerance"));
         toleranceSyncSwitch->setCheckable(true);
         toleranceSyncSwitch->setChecked(false);
+        if (mw->getEicWidget()->getParameters()->selectedGroup() == nullptr){
+            toleranceSyncSwitch->setEnabled(false);
+        }
+
         connect(toleranceSyncSwitch, &QToolButton::toggled, this, [=](bool on) {
             if (on) {
                 QIcon locked(rsrcPath + "/toleranceSyncLock.png");


### PR DESCRIPTION
El-Maven Crashed when button to toggle tolerance sync switch clicked. This crash was due to a segment fault in the code. It has been fixed.