### PR TITLE
[UI] Allow filtering unfragmented groups using independent filter

### DIFF
--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -454,10 +454,15 @@ void PeakDetector::identifyFeatures(const vector<Compound*>& identificationSet)
 
                 // since we are creating targeted groups, we should ensure they
                 // pass MS2 filtering criteria, if enabled
-                if (mavenParameters->matchFragmentationFlag
-                    && groupFiltering.filterByMS2(groupWithTarget)
-                    && mavenParameters->mustHaveFragmentation) {
-                    continue;
+                if (mavenParameters->matchFragmentationFlag) {
+                    bool hasFragments = groupWithTarget.ms2EventCount > 0;
+                    if (!hasFragments
+                        && mavenParameters->mustHaveFragmentation) {
+                        continue;
+                    } else if (hasFragments
+                               && groupFiltering.filterByMS2(groupWithTarget)) {
+                        continue;
+                    }
                 }
 
                 matchFound = true;

--- a/src/core/libmaven/PeakDetector.cpp
+++ b/src/core/libmaven/PeakDetector.cpp
@@ -455,7 +455,8 @@ void PeakDetector::identifyFeatures(const vector<Compound*>& identificationSet)
                 // since we are creating targeted groups, we should ensure they
                 // pass MS2 filtering criteria, if enabled
                 if (mavenParameters->matchFragmentationFlag
-                    && groupFiltering.filterByMS2(groupWithTarget)) {
+                    && groupFiltering.filterByMS2(groupWithTarget)
+                    && mavenParameters->mustHaveFragmentation) {
                     continue;
                 }
 

--- a/src/core/libmaven/datastructures/mzSlice.cpp
+++ b/src/core/libmaven/datastructures/mzSlice.cpp
@@ -61,7 +61,8 @@ bool mzSlice::calculateMzMinMax(MassCutoff *compoundMassCutoffWindow, int charge
 		return false;
 	}
 
-	return true;
+    mz = (mzmax + mzmin) / 2.0f;
+    return true;
 }
 
 void mzSlice::calculateRTMinMax(bool matchRtFlag, float compoundRTWindow)
@@ -84,6 +85,7 @@ void mzSlice::calculateRTMinMax(bool matchRtFlag, float compoundRTWindow)
 		//double
 		this->rtmax = 1e9;
 	}
+    rt = (rtmax + rtmin) / 2.0f;
 }
 
 void mzSlice::setSRMId()

--- a/src/core/libmaven/groupFiltering.cpp
+++ b/src/core/libmaven/groupFiltering.cpp
@@ -39,8 +39,13 @@ void GroupFiltering::filter(vector<PeakGroup> &peakgroups)
             continue;
         }
 
+        if (_mavenParameters->mustHaveFragmentation
+            && peakgroups[i].ms2EventCount == 0) {
+            peakgroups.erase(peakgroups.begin() + i);
+            continue;
+        }
+
         i++;
-        
     }
 
 }
@@ -98,12 +103,14 @@ bool GroupFiltering::filterByMS1(PeakGroup &peakgroup)
 
 bool GroupFiltering::filterByMS2(PeakGroup& peakgroup)
 {
+    if (peakgroup.ms2EventCount == 0)
+        return false;
+
     //TODO: remove MS2 stats calculation from filtering.
     //Already calculated during grouping
     peakgroup.computeFragPattern(_mavenParameters->fragmentTolerance);
     peakgroup.matchFragmentation(_mavenParameters->fragmentTolerance,
                                  _mavenParameters->scoringAlgo);
-    
     FragmentationMatchScore score = peakgroup.fragMatchScore;
 
     if (score.numMatches < _mavenParameters->minFragMatch)

--- a/src/core/libmaven/groupFiltering.cpp
+++ b/src/core/libmaven/groupFiltering.cpp
@@ -33,16 +33,15 @@ void GroupFiltering::filter(vector<PeakGroup> &peakgroups)
         // only filter for MS2 for groups having targets
         if (_mavenParameters->matchFragmentationFlag
             && peakgroups[i].getCompound() != nullptr
-            && !(peakgroups[i].isAdduct())
-            && filterByMS2(peakgroups[i])) {
-            peakgroups.erase(peakgroups.begin() + i);
-            continue;
-        }
-
-        if (_mavenParameters->mustHaveFragmentation
-            && peakgroups[i].ms2EventCount == 0) {
-            peakgroups.erase(peakgroups.begin() + i);
-            continue;
+            && !(peakgroups[i].isAdduct())) {
+            bool hasFragments = peakgroups[i].ms2EventCount > 0;
+            if (!hasFragments && _mavenParameters->mustHaveFragmentation) {
+                peakgroups.erase(peakgroups.begin() + i);
+                continue;
+            } else if (hasFragments && filterByMS2(peakgroups[i])) {
+                peakgroups.erase(peakgroups.begin() + i);
+                continue;
+            }
         }
 
         i++;
@@ -104,7 +103,7 @@ bool GroupFiltering::filterByMS1(PeakGroup &peakgroup)
 bool GroupFiltering::filterByMS2(PeakGroup& peakgroup)
 {
     if (peakgroup.ms2EventCount == 0)
-        return false;
+        return true;
 
     //TODO: remove MS2 stats calculation from filtering.
     //Already calculated during grouping

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -33,8 +33,9 @@ MavenParameters::MavenParameters(string settingsPath):lastUsedSettingsPath(setti
         minFragMatchScore = 0;
         minFragMatch = 3;
         scoringAlgo = "Hypergeometric Score";
-        
-        
+        matchFragmentationFlag = false;
+        mustHaveFragmentation = false;
+
         /*
         * Whenever we create an instance of this class, massCutoffType must be set for massCutoffMerge
         */
@@ -315,6 +316,9 @@ void  MavenParameters::setPeakDetectionSettings(const char* key, const char* val
 
     if(strcmp(key, "matchFragmentation") == 0 )
         matchFragmentationFlag = atof(value);
+
+    if(strcmp(key, "mustHaveFragmentation") == 0)
+        mustHaveFragmentation = atof(value);
 
     if(strcmp(key, "minGroupIntensity") == 0 )
         minGroupIntensity = atof(value);

--- a/src/core/libmaven/mavenparameters.h
+++ b/src/core/libmaven/mavenparameters.h
@@ -162,6 +162,7 @@ class MavenParameters
         float fragmentTolerance;
         float minFragMatch;
         string scoringAlgo;
+        bool mustHaveFragmentation;
 
         // to allow adduct matching
         bool searchAdducts;

--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -161,20 +161,10 @@ void BackgroundPeakUpdate::writeCSVRep(string setName)
             csvreports->addGroup(&group);
 
         if (mavenParameters->keepFoundGroups) {
-            if (_untargetedMustHaveMs2
-                && mavenParameters->allgroups[j].ms2EventCount == 0)
-                continue;
-
             Q_EMIT(newPeakGroup(&(mavenParameters->allgroups[j])));
             QCoreApplication::processEvents();
         }
     }
-
-    if (csvreports != NULL) {
-            delete (csvreports);
-            csvreports = NULL;
-    }
-    Q_EMIT(updateProgressBar("Done", 1, 1));
 }
 
 void BackgroundPeakUpdate::setPeakDetector(PeakDetector *pd)

--- a/src/gui/mzroll/background_peaks_update.h
+++ b/src/gui/mzroll/background_peaks_update.h
@@ -97,10 +97,6 @@ public:
     PeakDetector* peakDetector;
     MavenParameters* mavenParameters;
 
-    inline void setUntargetedMustHaveMs2(bool pred) {
-        _untargetedMustHaveMs2 = pred;
-    }
-
     /**
      * @brief updateGroups Updates the attributes of peakgroups according to new
      * mainwindow parameters.
@@ -111,6 +107,7 @@ public:
     static void updateGroups(QList<PeakGroup> &groups,
                              vector<mzSample*> samples,
                              MavenParameters* mavenParameters);
+
 Q_SIGNALS:
 
 	/**
@@ -149,7 +146,6 @@ protected:
 	void run(void);
 	
 private:
-    bool _untargetedMustHaveMs2;
 	string runFunction;
 	MainWindow *mainwindow;
 

--- a/src/gui/mzroll/forms/peakdetectiondialog.ui
+++ b/src/gui/mzroll/forms/peakdetectiondialog.ui
@@ -99,10 +99,22 @@
           <property name="spacing">
            <number>4</number>
           </property>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_scoringAlgo">
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="scoringAlgo">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="cursor">
+             <cursorShape>BlankCursor</cursorShape>
+            </property>
             <property name="text">
-             <string>Scoring Algorithm</string>
+             <string>Hypergeometric Score</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -110,6 +122,30 @@
            <widget class="QLabel" name="label_fragmentTolerance">
             <property name="text">
              <string>Fragment Mass Tolerance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_matchAtLeastX">
+            <property name="text">
+             <string>Match at least X peaks</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_scoringAlgo">
+            <property name="text">
+             <string>Scoring Algorithm</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="minFragMatch">
+            <property name="decimals">
+             <number>0</number>
+            </property>
+            <property name="value">
+             <double>3.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -123,23 +159,6 @@
             </property>
             <property name="value">
              <double>20.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_matchAtLeastX">
-            <property name="text">
-             <string>Match at least X peaks</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="minFragMatch">
-            <property name="decimals">
-             <number>0</number>
-            </property>
-            <property name="value">
-             <double>3.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -162,26 +181,14 @@
              <double>1000.000000000000000</double>
             </property>
             <property name="singleStep">
-             <double>5.000000000000000</double>
+             <double>0.500000000000000</double>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QLineEdit" name="scoringAlgo">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="cursor">
-             <cursorShape>BlankCursor</cursorShape>
-            </property>
+          <item row="6" column="0">
+           <widget class="QCheckBox" name="mustHaveMs2">
             <property name="text">
-             <string>Hypergeometric Score</string>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
+             <string>Exclude unfragmented groups</string>
             </property>
            </widget>
           </item>
@@ -194,6 +201,7 @@
          <zorder>fragmentTolerance</zorder>
          <zorder>label_fragmentTolerance</zorder>
          <zorder>label_scoringAlgo</zorder>
+         <zorder>mustHaveMs2</zorder>
         </widget>
        </item>
        <item row="0" column="0" colspan="2">
@@ -241,107 +249,15 @@
           <property name="spacing">
            <number>4</number>
           </property>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_17">
-            <property name="text">
-             <string>Limit m/z Range</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="4">
-           <widget class="QDoubleSpinBox" name="rtMax">
-            <property name="maximum">
-             <double>999999999.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="identificationRtWindow">
-            <property name="suffix">
-             <string> min</string>
-            </property>
-            <property name="singleStep">
-             <double>0.500000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="4">
-           <widget class="QDoubleSpinBox" name="maxIntensity">
+          <item row="3" column="3">
+           <widget class="QDoubleSpinBox" name="minIntensity">
             <property name="maximum">
              <double>9999999999.989999771118164</double>
             </property>
             <property name="value">
-             <double>9999999999.000000000000000</double>
+             <double>50000.000000000000000</double>
             </property>
            </widget>
-          </item>
-          <item row="0" column="4">
-           <widget class="QDoubleSpinBox" name="mzMax">
-            <property name="maximum">
-             <double>999999999.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Mass Domain Resolution</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="label_18">
-            <property name="text">
-             <string>Limit Time Range</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QCheckBox" name="mustHaveMs2">
-            <property name="text">
-             <string>Exclude unfragmented groups</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QDoubleSpinBox" name="rtMin">
-            <property name="maximum">
-             <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QDoubleSpinBox" name="mzMin">
-            <property name="maximum">
-             <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Time Domain Resolution</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QLabel" name="label_19">
-            <property name="text">
-             <string>Limit Intensity Range</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QComboBox" name="identificationDatabase"/>
           </item>
           <item row="1" column="1">
            <widget class="QDoubleSpinBox" name="rtStep">
@@ -371,32 +287,67 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="ppmStep">
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Limit Time Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="identificationRtWindow">
             <property name="suffix">
-             <string> ppm</string>
-            </property>
-            <property name="decimals">
-             <number>3</number>
-            </property>
-            <property name="maximum">
-             <double>1000000000.000000000000000</double>
+             <string> min</string>
             </property>
             <property name="singleStep">
              <double>0.500000000000000</double>
             </property>
             <property name="value">
-             <double>20.000000000000000</double>
+             <double>1.000000000000000</double>
             </property>
            </widget>
           </item>
-          <item row="3" column="3">
-           <widget class="QDoubleSpinBox" name="minIntensity">
+          <item row="3" column="1">
+           <widget class="QComboBox" name="identificationDatabase"/>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Identify using database</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <widget class="QDoubleSpinBox" name="rtMax">
+            <property name="maximum">
+             <double>999999999.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>999999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Time Domain Resolution</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QDoubleSpinBox" name="mzMin">
+            <property name="maximum">
+             <double>999999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="4">
+           <widget class="QDoubleSpinBox" name="maxIntensity">
             <property name="maximum">
              <double>9999999999.989999771118164</double>
             </property>
             <property name="value">
-             <double>50000.000000000000000</double>
+             <double>9999999999.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -407,10 +358,17 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_4">
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_17">
             <property name="text">
-             <string>Identify using database</string>
+             <string>Limit m/z Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Mass Domain Resolution</string>
             </property>
            </widget>
           </item>
@@ -418,19 +376,6 @@
            <widget class="QLabel" name="label_20">
             <property name="text">
              <string>Limit Charged Species</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="3">
-           <widget class="QSpinBox" name="chargeMin">
-            <property name="minimum">
-             <number>0</number>
-            </property>
-            <property name="maximum">
-             <number>999999999</number>
-            </property>
-            <property name="value">
-             <number>0</number>
             </property>
            </widget>
           </item>
@@ -444,6 +389,62 @@
             </property>
             <property name="value">
              <number>0</number>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="3">
+           <widget class="QSpinBox" name="chargeMin">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>1000000</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+            <property name="value">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="label_19">
+            <property name="text">
+             <string>Limit Intensity Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QDoubleSpinBox" name="mzMax">
+            <property name="maximum">
+             <double>999999999.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>999999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QDoubleSpinBox" name="rtMin">
+            <property name="maximum">
+             <double>999999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="ppmStep">
+            <property name="minimum">
+             <double>0.500000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1000000.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.500000000000000</double>
+            </property>
+            <property name="value">
+             <double>20.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -483,24 +484,7 @@
           <property name="spacing">
            <number>4</number>
           </property>
-          <item row="3" column="0">
-           <widget class="QCheckBox" name="matchRt">
-            <property name="text">
-             <string>Match Retention Time (+/-)</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QCheckBox" name="searchAdducts">
-            <property name="text">
-             <string>Detect adducts within</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
+          <item row="3" column="2">
            <widget class="QSpinBox" name="eicMaxGroups">
             <property name="suffix">
              <string> best</string>
@@ -523,34 +507,12 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="2">
-           <widget class="QDoubleSpinBox" name="adductPercentCorrelation">
-            <property name="prefix">
-             <string>with </string>
-            </property>
-            <property name="suffix">
-             <string notr="true"> % correlation</string>
-            </property>
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="minimum">
-             <double>0.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>100.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>5.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>90.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="label_16">
             <property name="text">
+             <string>Match Retention Time (+/-)</string>
+            </property>
+            <property name="checked" stdset="0">
              <string>Limit Number of Reported Groups per Compound</string>
             </property>
            </widget>
@@ -578,7 +540,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="2">
+          <item row="2" column="2">
            <widget class="QDoubleSpinBox" name="compoundRTWindow">
             <property name="prefix">
              <string/>
@@ -597,10 +559,24 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
-           <widget class="QComboBox" name="compoundDatabase"/>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="matchRt">
+            <property name="text">
+             <string>Match Retention Time (+/-)</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
           </item>
-          <item row="5" column="1">
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="searchAdducts">
+            <property name="text">
+             <string>Detect adducts within</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
            <widget class="QDoubleSpinBox" name="adductSearchWindow">
             <property name="suffix">
              <string> seconds from parent ion</string>
@@ -615,6 +591,34 @@
              <double>0.100000000000000</double>
             </property>
            </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QDoubleSpinBox" name="adductPercentCorrelation">
+            <property name="prefix">
+             <string>with </string>
+            </property>
+            <property name="suffix">
+             <string notr="true"> % correlation</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>5.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>90.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QComboBox" name="compoundDatabase"/>
           </item>
          </layout>
         </widget>
@@ -1146,9 +1150,7 @@
  <tabstops>
   <tabstop>tabwidget</tabstop>
   <tabstop>featureOptions</tabstop>
-  <tabstop>ppmStep</tabstop>
   <tabstop>mzMin</tabstop>
-  <tabstop>mzMax</tabstop>
   <tabstop>rtStep</tabstop>
   <tabstop>rtMin</tabstop>
   <tabstop>rtMax</tabstop>

--- a/src/gui/mzroll/peakdetectiondialog.h
+++ b/src/gui/mzroll/peakdetectiondialog.h
@@ -37,6 +37,14 @@ class PeakDetectionDialog : public QDialog, public Ui_PeakDetectionDialog
                  void initPeakDetectionDialogWindow(FeatureDetectionType type);
 
                  /**
+                  * @brief Disables or enables certain UI elements, based on
+                  * whether peak detection is currently in progress.
+                  * @param detectionMode A boolean to signify whether peak
+                  * detection is taking place or not.
+                  */
+                 void setDetectionMode(bool detectionModeOn);
+
+                 /**
                   * @brief Repopulate the relevant databases in dropdowns.
                   */
                  void refreshCompoundDatabases();
@@ -48,7 +56,6 @@ class PeakDetectionDialog : public QDialog, public Ui_PeakDetectionDialog
 				 void showBaselineQuantileStatus(int);
 				 void showBlankQuantileStatus(int);
                  void setMassCutoffType(QString type);
-                virtual void closeEvent(QCloseEvent* event) override;
                                 void triggerSettingsUpdate();
                 void onReset();
 
@@ -61,12 +68,17 @@ class PeakDetectionDialog : public QDialog, public Ui_PeakDetectionDialog
         public:
                 QString massCutoffType;
 
+        protected:
+                virtual void closeEvent(QCloseEvent* event) override;
+                virtual void keyPressEvent(QKeyEvent* event) override;
+
         private:
 				QSettings *settings;
 				MainWindow *mainwindow;
                 BackgroundPeakUpdate* peakupdater;
 				FeatureDetectionType _featureDetectionType;
                 PeakDetectionSettings* peakSettings;
+                bool _inDetectionMode;
 
                 // void displayAppropriatePeakDetectionDialog(FeatureDetectionType type); //TODO: Sahil - Kiran, removed while merging mainwindow
                 void inputInitialValuesPeakDetectionDialog();


### PR DESCRIPTION
This PR is for the following two changes:
1. Move non-MS2 exclusion check to fragmentation options: this will allow us to perform peak-detection with fragmentation matching that only works as a whether-to-score-or-not flag. If elimination of unfragmented groups is desired, the "Exclude unfragmented groups" option will be available under "Match Fragmentation" options, independent of the mode of detection.
2. Prohibit closing dialog when detection in progress: this will make sure that no-interaction is possible while peak-detection is ongoing, which otherwise leads to confusion.
3. Fix - fragmentation events disappearing from EIC widget when tolerance switch is toggled on.