### PR TITLE
[Fix] Use spline intensity to adjust slices

### DIFF
--- a/src/core/libmaven/mzMassSlicer.cpp
+++ b/src/core/libmaven/mzMassSlicer.cpp
@@ -603,9 +603,12 @@ void MassSlices::adjustSlices()
         float highestIntensity = 0.0f;
         float mzAtHighestIntensity = 0.0f;
         for (auto eic : eics) {
-            if (eic->maxIntensity > highestIntensity) {
-                highestIntensity = eic->maxIntensity;
-                mzAtHighestIntensity = eic->mzAtMaxIntensity;
+            size_t size = eic->intensity.size();
+            for (int i = 0; i < size; ++i) {
+                if (eic->spline[i] > highestIntensity) {
+                    highestIntensity = eic->spline[i];
+                    mzAtHighestIntensity = eic->mz[i];
+                }
             }
         }
         float cutoff = mavenParameters->massCutoffMerge


### PR DESCRIPTION
After settling on a collection of slices (in untargeted mode), each slice is adjusted such that the highest intensity in its region is centered. This was being done using raw intensity values, where high-intensity noise data might lead to non-optimal adjustment. Therefore, spline values smoothed intensity) will be used instead, to do the same.