### PR TITLE
[fix] Fixed the issue of no default isotope option in "Isotope Dialog"

### DIFF
--- a/src/gui/mzroll/isotopedialog.cpp
+++ b/src/gui/mzroll/isotopedialog.cpp
@@ -68,8 +68,12 @@ IsotopeDialog::IsotopeDialog(MainWindow* parent) : QDialog(parent) {
                         && !N15Labeled_BPE->isChecked()
                         && !S34Labeled_BPE->isChecked())
                         C13Labeled_BPE->setChecked(true);
-                } else
+                } else {
                     C13Labeled_BPE->setChecked(false);
+                    D2Labeled_BPE->setChecked(false);
+                    N15Labeled_BPE->setChecked(false);
+                    S34Labeled_BPE->setChecked(false);
+                }
             });
 
     auto checkIsotopeDetectionValid = [this](const bool checked) {

--- a/src/gui/mzroll/isotopedialog.cpp
+++ b/src/gui/mzroll/isotopedialog.cpp
@@ -62,6 +62,14 @@ IsotopeDialog::IsotopeDialog(MainWindow* parent) : QDialog(parent) {
                     ->hitEvent("Peak Detection",
                                "Isotope Detection Switched",
                                state);
+                if (checked) {
+                    if (!D2Labeled_BPE->isChecked()
+                        && !C13Labeled_BPE->isChecked()
+                        && !N15Labeled_BPE->isChecked()
+                        && !S34Labeled_BPE->isChecked())
+                        C13Labeled_BPE->setChecked(true);
+                } else
+                    C13Labeled_BPE->setChecked(false);
             });
 
     auto checkIsotopeDetectionValid = [this](const bool checked) {


### PR DESCRIPTION
In isotope dialog, there was no default isotope checked. This could be an issue while providing default parameters as no isotope would be detected.
This has been fixed ans isotope "C13" has been made default option.