### PR TITLE
[fix] Fixed the order of reference samples in OBI-Warp in "Align" dialog #1249

### DIFF
--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -143,11 +143,18 @@ void AlignmentDialog::intialSetup()
     samplesBox->clear();
     samplesBox->addItem("Select Randomly",
 						QVariant(QVariant::fromValue(static_cast<void*>(nullptr))));
+    vector<mzSample*> selectedSample;
     for(auto sample: _mw->samples) {
         if(sample->isSelected)
-            samplesBox->addItem(sample->sampleName.c_str(),
-								QVariant(QVariant::fromValue(static_cast<void*>(sample))));
+            selectedSample.push_back(sample);
     }
+    sort(selectedSample.begin(), selectedSample.end(), mzSample::compSampleSort);
+    for(auto sample: selectedSample)
+    {
+        samplesBox->addItem(sample->sampleName.c_str(),
+                            QVariant(QVariant::fromValue(static_cast<void*>(sample))));
+    }
+
 }
 
 void AlignmentDialog::restorDefaultValues(bool checked)

--- a/src/gui/mzroll/alignmentdialog.cpp
+++ b/src/gui/mzroll/alignmentdialog.cpp
@@ -143,13 +143,9 @@ void AlignmentDialog::intialSetup()
     samplesBox->clear();
     samplesBox->addItem("Select Randomly",
 						QVariant(QVariant::fromValue(static_cast<void*>(nullptr))));
-    vector<mzSample*> selectedSample;
-    for(auto sample: _mw->samples) {
-        if(sample->isSelected)
-            selectedSample.push_back(sample);
-    }
-    sort(selectedSample.begin(), selectedSample.end(), mzSample::compSampleSort);
-    for(auto sample: selectedSample)
+    auto selectedSamples = _mw->getVisibleSamples();
+    sort(selectedSamples.begin(), selectedSamples.end(), mzSample::compSampleSort);
+    for(auto sample: selectedSamples)
     {
         samplesBox->addItem(sample->sampleName.c_str(),
                             QVariant(QVariant::fromValue(static_cast<void*>(sample))));


### PR DESCRIPTION
The list reference samples in 'Align' dialog for OBI-Warp appeared in random fashion. It has now been modified to appear in lexicographical order.