### PR TITLE
[fix] Removed the default state from 'Use Default Parameters' in option dialog #1251

### DIFF
--- a/src/gui/mzroll/isotopedialog.cpp
+++ b/src/gui/mzroll/isotopedialog.cpp
@@ -48,6 +48,9 @@ IsotopeDialog::IsotopeDialog(MainWindow* parent) : QDialog(parent) {
     _mw = parent;
     isotopeSettings = new IsotopeDialogSettings(this);
 
+    resetButton->setDefault(false);
+    resetButton->setAutoDefault(false);
+
     connect(resetButton, &QPushButton::clicked, this, &IsotopeDialog::onReset);
     connect(this, &IsotopeDialog::settingsChanged,
             isotopeSettings, &IsotopeDialogSettings::updateIsotopeDialogSettings);

--- a/src/gui/mzroll/settingsform.cpp
+++ b/src/gui/mzroll/settingsform.cpp
@@ -98,6 +98,9 @@ SettingsForm::SettingsForm(QSettings* s, MainWindow *w): QDialog(w) {
 
     optionSettings = new OptionsDialogSettings(this);
 
+    resetButton->setDefault(false);
+    resetButton->setAutoDefault(false);
+
     connect(tabWidget, SIGNAL(currentChanged(int)), SLOT(getFormValues()));
     connect(resetButton, &QPushButton::clicked, this, &SettingsForm::onReset);
 


### PR DESCRIPTION
In option dialog, if user changes any settings and presses enter, thinking changes will retain. Instead pressing enter resets the settings back to default. This is a bad user experience. This has been now fixed, where in pressing enter takes the effect of users setting and clicking button 'Use Default Parameters' resets setting to their default values.