### PR TITLE
[fix] Fix the issue where peak bubbles are floating when alignment is performed after peak detection

### DIFF
--- a/src/gui/mzroll/background_peaks_update.cpp
+++ b/src/gui/mzroll/background_peaks_update.cpp
@@ -25,6 +25,7 @@
 #include "obiwarp.h"
 #include "PeakDetector.h"
 #include "samplertwidget.h"
+#include "EIC.h"
 
 BackgroundPeakUpdate::BackgroundPeakUpdate(QWidget*) {
         mainwindow = NULL;
@@ -437,4 +438,28 @@ bool BackgroundPeakUpdate::covertToMzXML(QString filename, QString outfile) {
         };
         QFile testOut(outfile);
         return testOut.exists();
+}
+
+void BackgroundPeakUpdate::updateGroups(QList<PeakGroup> &groups,
+                                        vector<mzSample *> samples,
+                                        MavenParameters* mavenParameters)
+{
+    for(PeakGroup& group : groups)
+    {
+        auto slice = group.getSlice();
+
+        auto eics  = PeakDetector::pullEICs(&slice,
+                                           samples,
+                                           mavenParameters);
+        for(auto eic : eics)
+        {
+            for(Peak& peak :  group.peaks)
+            {
+                if (eic->getSample() == peak.getSample()){
+                    eic->getPeakDetails(peak);
+                }
+            }
+        }
+        group.groupStatistics();
+    }
 }

--- a/src/gui/mzroll/background_peaks_update.h
+++ b/src/gui/mzroll/background_peaks_update.h
@@ -101,6 +101,16 @@ public:
         _untargetedMustHaveMs2 = pred;
     }
 
+    /**
+     * @brief updateGroups Updates the attributes of peakgroups according to new
+     * mainwindow parameters.
+     * @param groups    Updation of attributes of peakgroups.
+     * @param samples   Current visible samples in the state of alignment or not
+     * @param mavenParameters current mainwindow mavenparameters.
+     */
+    static void updateGroups(QList<PeakGroup> &groups,
+                             vector<mzSample*> samples,
+                             MavenParameters* mavenParameters);
 Q_SIGNALS:
 
 	/**

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1702,16 +1702,6 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
     emit groupSet(group);
     replot(group);
     _clearEicPoints();
-    // Done to update group in case of alignment performed
-    // after peak detection.
-    for (size_t i = 0; i < group->peaks.size(); i++) {
-        auto peak = group->peaks[i];
-        for (auto eic : eicParameters->eics) {
-            if (eic->sample == peak.getSample()) {
-                group->peaks[i].rt = eic->rt[peak.pos];
-            }
-        }
-    }
 	addPeakPositions(group);
 }
 

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1702,6 +1702,16 @@ void EicWidget::setPeakGroup(PeakGroup* group) {
     emit groupSet(group);
     replot(group);
     _clearEicPoints();
+    // Done to update group in case of alignment performed
+    // after peak detection.
+    for (size_t i = 0; i < group->peaks.size(); i++) {
+        auto peak = group->peaks[i];
+        for (auto eic : eicParameters->eics) {
+            if (eic->sample == peak.getSample()) {
+                group->peaks[i].rt = eic->rt[peak.pos];
+            }
+        }
+    }
 	addPeakPositions(group);
 }
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -750,15 +750,13 @@ MainWindow::~MainWindow()
 }
 
 
-void MainWindow::updateTablePostAlignment(bool update)
+void MainWindow::updateTablePostAlignment()
 {
-    if (update) {
-        auto tableList = getPeakTableList();
-        if(tableList.size() == 0)
-            return;
-        for(auto table : tableList) {
-            table->updateTableAfterAlignment();
-        }
+    auto tableList = getPeakTableList();
+    if(tableList.size() == 0)
+        return;
+    for(auto table : tableList) {
+        table->updateTableAfterAlignment();
     }
 }
 
@@ -2435,7 +2433,7 @@ BackgroundPeakUpdate* MainWindow::newWorkerThread(QString funcName) {
 	connect(workerThread, SIGNAL(updateProgressBar(QString,int,int)),
 			alignmentDialog, SLOT(setProgressBar(QString, int,int)));
 	connect(workerThread, SIGNAL(samplesAligned(bool)), alignmentDialog, SLOT(samplesAligned(bool)));
-        connect(workerThread, SIGNAL(samplesAligned(bool)), this, SLOT(updateTablePostAlignment(bool)));
+        connect(workerThread, SIGNAL(samplesAligned(bool)), this, SLOT(updateTablePostAlignment()));
 	workerThread->setRunFunction(funcName);
 	//threads.push_back(workerThread);
 	return workerThread;

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -749,6 +749,19 @@ MainWindow::~MainWindow()
     delete _usageTracker;
 }
 
+
+void MainWindow::updateTablePostAlignment(bool update)
+{
+    if (update) {
+        auto tableList = getPeakTableList();
+        if(tableList.size() == 0)
+            return;
+        for(auto table : tableList) {
+            table->updateTableAfterAlignment();
+        }
+    }
+}
+
 void MainWindow::promptUpdate(QString version)
 {
     qDebug() << "New release"
@@ -2422,6 +2435,7 @@ BackgroundPeakUpdate* MainWindow::newWorkerThread(QString funcName) {
 	connect(workerThread, SIGNAL(updateProgressBar(QString,int,int)),
 			alignmentDialog, SLOT(setProgressBar(QString, int,int)));
 	connect(workerThread, SIGNAL(samplesAligned(bool)), alignmentDialog, SLOT(samplesAligned(bool)));
+        connect(workerThread, SIGNAL(samplesAligned(bool)), this, SLOT(updateTablePostAlignment(bool)));
 	workerThread->setRunFunction(funcName);
 	//threads.push_back(workerThread);
 	return workerThread;

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -436,7 +436,9 @@ using namespace mzUtils;
 	alignmentDialog->setMainWindow(this);
 	connect(alignmentDialog->alignButton, SIGNAL(clicked()), SLOT(Align()));
 	connect(alignmentDialog->UndoAlignment, SIGNAL(clicked()),
-			SLOT(UndoAlignment()));
+                       SLOT(UndoAlignment()));
+        connect(alignmentDialog->UndoAlignment, SIGNAL(clicked()),
+                SLOT(updateTablePostAlignment()));
 
 	//rconsole dialog
 	//rconsoleDialog	 =  new RConsoleDialog(this);

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -439,9 +439,12 @@ public Q_SLOTS:
     void promptUpdate(QString version);
 
     /**
-     * @brief updateTablePostAlignment Updating peak tables after alignment.
+     * @brief updateTablePostAlignment Update the attributes of peaks for every
+     * group present in all current peak-tables. This method should be called
+     * after operations such as alignment, where the scan's RT changes from its
+     * original value.
      */
-    void updateTablePostAlignment(bool update);
+    void updateTablePostAlignment();
 
 private Q_SLOTS:
 	void createMenus();

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -438,6 +438,11 @@ public Q_SLOTS:
      */
     void promptUpdate(QString version);
 
+    /**
+     * @brief updateTablePostAlignment Updating peak tables after alignment.
+     */
+    void updateTablePostAlignment(bool update);
+
 private Q_SLOTS:
 	void createMenus();
 	void createToolBars();

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -36,6 +36,7 @@
 #include "svmPredictor.h"
 #include "tabledockwidget.h";
 #include "PeakDetector.h"
+#include "background_peaks_update.h"
 
 QMap<int, QString> TableDockWidget::_idTitleMap;
 
@@ -140,24 +141,9 @@ void TableDockWidget::sortBy(int col) {
 
 void TableDockWidget::updateTableAfterAlignment()
 {
-    for(size_t i = 0; i < allgroups.size(); i++)
-    {
-        auto slice = allgroups[i].getSlice();
-        auto samples = _mainwindow->getVisibleSamples();
-        auto eics  = peakDetector->pullEICs(&slice,
-                                           samples,
-                                           _mainwindow->mavenParameters);
-        for(auto eic : eics)
-        {
-            for(size_t j = 0; j < allgroups[i].peaks.size(); j++)
-            {
-                if (eic->getSample() == allgroups[i].peaks[j].getSample()){
-                    eic->getPeakDetails(allgroups[i].peaks[j]);
-                }
-            }
-        }
-        allgroups[i].groupStatistics();
-    }
+    BackgroundPeakUpdate::updateGroups(allgroups,
+                                       _mainwindow->getVisibleSamples(),
+                                       _mainwindow->mavenParameters);
     showAllGroups();
 }
 

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -64,7 +64,6 @@ TableDockWidget::TableDockWidget(MainWindow *mw) {
   _targetedGroups = 0;
   pal = palette();
   setAutoFillBackground(true);
-  peakDetector = new PeakDetector(_mainwindow->mavenParameters);
   pal.setColor(QPalette::Background, QColor(170, 170, 170, 100));
   setPalette(pal);
 

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -15,6 +15,7 @@ class JSONReports;
 class PeakGroup;
 class EIC;
 class QHistogramSlider;
+class PeakDetector;
 
 using namespace std;
 
@@ -29,6 +30,7 @@ public:
   JSONReports *jsonReports;
   int numberOfGroupsMarked = 0;
   QString writableTempS3Dir;
+  PeakDetector* peakDetector;
   /**
    * @brief vallgroups will be used by libmaven/jsonReports.cpp
    * @detail For json export. Since libmaven is written only standard
@@ -145,6 +147,12 @@ public:
       setTitleForId(-1);
       setTitleForId(0);
   }
+
+  /**
+   * @brief updateTableAfterAlignment Updates table if table existed before
+   * samples were assigned.
+   */
+  void updateTableAfterAlignment();
 
 public Q_SLOTS:
   void updateCompoundWidget();

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -30,7 +30,6 @@ public:
   JSONReports *jsonReports;
   int numberOfGroupsMarked = 0;
   QString writableTempS3Dir;
-  PeakDetector* peakDetector;
   /**
    * @brief vallgroups will be used by libmaven/jsonReports.cpp
    * @detail For json export. Since libmaven is written only standard


### PR DESCRIPTION
When alignment of sample is performed after detecting the peaks, the value of peak groups do not change accordingly. This leads to the peak bubble left floating in the area.
This has been fixed by updating RT value for peaks.