### PR TITLE
[ref] Refactored the 'DeleteGroups' for reducing time for deletion in large peak tables

### DIFF
--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1947,7 +1947,7 @@ void EicWidget::selectGroupNearRt(float rt) {
 
 void EicWidget::setSelectedGroup(PeakGroup* group) {
 	//qDebug <<"EicWidget::setSelectedGroup(PeakGroup* group ) ";
-	if (_frozen || group == NULL)
+        if (_frozen)
 		return;
         if (_showBarPlot)
                 addBarPlot(group);

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -1230,6 +1230,8 @@ void TableDockWidget::deleteSelectedItems()
             delete(item);
     }
 
+    showAllGroups();
+
     mzUtils::stopTimer(timerMain, "Deletion ends");
     return;
 }

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -1119,8 +1119,6 @@ void TableDockWidget::deleteGroup(PeakGroup *groupX) {
 
 void TableDockWidget::deleteSelectedItems()
 {
-    auto timerMain = mzUtils::startTimer();
-
     // temporarily disconnect selection trigger
     disconnect(treeWidget,
                SIGNAL(itemSelectionChanged()),
@@ -1131,10 +1129,9 @@ void TableDockWidget::deleteSelectedItems()
     QList<QTreeWidgetItem*> selectedItems;
     QTreeWidgetItem* nextItem = nullptr;
     for (auto item : treeWidget->selectedItems()) {
-        if (item)
-            nextItem = treeWidget->itemBelow(item);
         if (item->parent() == nullptr) {
             selectedItems.prepend(item);
+            nextItem = treeWidget->itemBelow(item);
         } else {
             selectedItems.append(item);
         }
@@ -1229,10 +1226,21 @@ void TableDockWidget::deleteSelectedItems()
         if(item)
             delete(item);
     }
-
+    auto groupSelected = getSelectedGroup();
     showAllGroups();
 
-    mzUtils::stopTimer(timerMain, "Deletion ends");
+    QTreeWidgetItemIterator it(treeWidget);
+    while (*it) {
+        QTreeWidgetItem *item = (*it);
+        QVariant v = item->data(0, Qt::UserRole);
+        PeakGroup *currentGroup = v.value<PeakGroup *>();
+        if (currentGroup == groupSelected) {
+            treeWidget->setCurrentItem(item);
+            break;
+        }
+        it++;
+    }
+
     return;
 }
 

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -235,7 +235,7 @@ public Q_SLOTS:
 
   void showConsensusSpectra();
 
-  virtual void deleteGroups();
+  virtual void deleteSelectedItems();
   virtual void deleteGroup(PeakGroup *groupX);
 
   void sortBy(int);


### PR DESCRIPTION
'DeleteGroups' function of tabledockwidget class has been refactored to take less time as compared to original function especially in case where the peak table are larger. This time complexity is now reduced to less than half of the original time taken.