### PR TITLE
[Fix] Filter MRM data scans using productMz and CE #1273

### DIFF
--- a/src/core/libmaven/SRMList.cpp
+++ b/src/core/libmaven/SRMList.cpp
@@ -49,6 +49,7 @@ vector<mzSlice*> SRMList::getSrmSlices(double amuQ1, double amuQ3, int userPolar
             float precursorMz = scan->precursorMz;
             float productMz   = scan->productMz;
             float rt = scan->rt;
+            float collisionEnergy = scan->collisionEnergy;
             int   polarity= scan->getPolarity();
             if (polarity==0) filterLine[0] == '+' ? polarity=1 : polarity =-1;
             if (userPolarity) polarity=userPolarity;  //user specified ionization mode
@@ -62,9 +63,15 @@ vector<mzSlice*> SRMList::getSrmSlices(double amuQ1, double amuQ3, int userPolar
             }
 
             if (precursorMz != 0 && productMz != 0 ) {
-                compound = findSpeciesByPrecursor(precursorMz,productMz,rt,polarity,amuQ1,amuQ3);
+                compound = findSpeciesByPrecursor(precursorMz,
+                                                  productMz,
+                                                  rt,
+                                                  polarity,
+                                                  amuQ1,
+                                                  amuQ3,
+                                                  collisionEnergy);
             }
-            
+
             if (annotation[string(filterLine.toStdString())]) {
                 compound = annotation[filterLine.toStdString()];
             }
@@ -80,8 +87,14 @@ vector<mzSlice*> SRMList::getSrmSlices(double amuQ1, double amuQ3, int userPolar
     return slices;
 }
 
-Compound *SRMList::findSpeciesByPrecursor(float precursorMz, float productMz, float rt, int polarity,double amuQ1, double amuQ3) {
-    
+Compound* SRMList::findSpeciesByPrecursor(float precursorMz,
+                                          float productMz,
+                                          float rt,
+                                          int polarity,
+                                          double amuQ1,
+                                          double amuQ3,
+                                          float collisionEnergy)
+{
     Compound* x=NULL;
     float distMz=FLT_MAX;
     float distRt=FLT_MAX;
@@ -90,6 +103,10 @@ Compound *SRMList::findSpeciesByPrecursor(float precursorMz, float productMz, fl
             if (compoundsDB[i]->precursorMz() == 0 ) continue;
             //cerr << polarity << " " << compoundsDB[i]->charge << endl;
             if ((int) compoundsDB[i]->charge() != polarity && compoundsDB[i]->charge() != 0) continue;
+            if (collisionEnergy != 0.0f
+                && compoundsDB[i]->collisionEnergy() != 0.0f
+                && abs(compoundsDB[i]->collisionEnergy() - collisionEnergy) > 0.5)
+                continue;
             float a = abs(compoundsDB[i]->precursorMz() - precursorMz);
             if ( a > amuQ1 ) continue; // q1 tolerance
             float b = abs(compoundsDB[i]->productMz() - productMz);

--- a/src/core/libmaven/SRMList.h
+++ b/src/core/libmaven/SRMList.h
@@ -56,10 +56,17 @@ class SRMList{
      * @param polarity user polarity
      * @param amuQ1 Q1 mass tolerance
      * @param amuQ3 Q3 mass tolerance
+     * @param collisionEnergy Collision energy applied for the transition
      * @return Compound* Compound from compound database
      * @see Compound
      */
-    Compound* findSpeciesByPrecursor(float precursorMz, float productMz, float rt, int polarity,double amuQ1, double amuQ3);
+    Compound* findSpeciesByPrecursor(float precursorMz,
+                                     float productMz,
+                                     float rt,
+                                     int polarity,
+                                     double amuQ1,
+                                     double amuQ3,
+                                     float collisionEnergy);
 
     /**
      * @brief Get precursor m/z from filterline (srm-id)

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -337,7 +337,6 @@ void mzSample::parseMzMLChromatogramList(const xml_node& chromatogramList)
         string chromatogramId = chromatogram.attribute("id").value();
         int sampleNo = getSampleNoChromatogram(chromatogramId);
 
-        // why is this cleaning needed?
         cleanFilterLine(chromatogramId);
 
         vector<float> timeVector;

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1158,6 +1158,14 @@ EIC* mzSample::getEIC(float precursorMz,
                 if (scan->intensity[k] > eicIntensity) {
                     eicIntensity = scan->intensity[k];
                     eicMz = scan->mz[k];
+
+                    // We set the filterline to be the SRM ID of the first scan
+                    // that matches, so that all subsequent observations also
+                    // originate from the same SRM ID. Since, there could be
+                    // multiple SRM chromatograms that satisfy the m/z checks
+                    // above, but in the absence of CE, their observations may
+                    // not be differentiable.
+                    filterline = scan->filterLine;
                 }
             }
             break;
@@ -1176,6 +1184,7 @@ EIC* mzSample::getEIC(float precursorMz,
             if (sumIntensity != 0.0) {
                 eicMz = static_cast<float>(sumMz / sumIntensity);
                 eicIntensity = static_cast<float>(sumIntensity);
+                filterline = scan->filterLine;
             }
             break;
         }
@@ -1185,6 +1194,7 @@ EIC* mzSample::getEIC(float precursorMz,
                 if (scan->intensity[k] > eicIntensity) {
                     eicIntensity = scan->intensity[k];
                     eicMz = scan->mz[k];
+                    filterline = scan->filterLine;
                 }
             }
             break;

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1144,6 +1144,7 @@ EIC* mzSample::getEIC(float precursorMz,
         if (productMz != 0.0f && abs(scan->productMz - productMz) > amuQ3)
             continue;
         if (collisionEnergy != 0.0f
+            && scan->collisionEnergy != 0.0f
             && abs(scan->collisionEnergy - collisionEnergy) > 0.5) {
             continue;
         }

--- a/tests/MavenTests/testEIC.cpp
+++ b/tests/MavenTests/testEIC.cpp
@@ -45,21 +45,21 @@ void TestEIC::testgetEICms2() {
     
     EIC* e = NULL;
     e = mzsample->getEIC(195,0,70,0,"",0.5,0.5); //precursorMz,collisionEnergy,productMz,eicType,filterline,amuQ1,amuQ3
-    QVERIFY(e->rt.size() == 305);
-    QVERIFY(e->scannum[e->scannum.size()-1] == 3351);
-    QVERIFY(e->maxIntensity == 20200);
+    QCOMPARE(e->rt.size(), 305);
+    QCOMPARE(e->scannum[e->scannum.size()-1], 3354);
+    QCOMPARE(e->maxIntensity, 20200);
 
     EIC* e2 = NULL;
     e2 = mzsample_2->getEIC(195,0,69,1,"",0.5,0.5);
-    QVERIFY(e2->rt.size() == 305);
-    QVERIFY(e2->scannum[e2->scannum.size()-1] == 3041);
-    QVERIFY(e2->maxIntensity == 10600);
+    QCOMPARE(e2->rt.size(), 305);
+    QCOMPARE(e2->scannum[e2->scannum.size()-1], 3041);
+    QCOMPARE(e2->maxIntensity, 10600);
 
     EIC* e3 = NULL;
     e3 = mzsample_2->getEIC(195,0,69,1,"",2,2);
     QVERIFY(e3->rt.size() == 305);
-    QVERIFY(e3->scannum[e3->scannum.size()-1] == 3040);
-    QVERIFY(e3->maxIntensity == 49400);
+    QVERIFY(e3->scannum[e3->scannum.size()-1] == 3042);
+    QVERIFY(e3->maxIntensity == 2500);
 }
 
 void TestEIC::testcomputeSpline()


### PR DESCRIPTION
Data for MRM experiments is encoded as "chromatograms" within mzML files. These chromatograms are unique at least for a combination of precursor m/z, product m/z and collision energy. While creating "EIC" objects for these chromatograms, the scans beind iterated over were not correctly checking for product m/z and collision energy (the code was there but commented out). This has been fixed.

Additionally, SRM IDs can share the same string (once stripped of their key-value pairs) which led to two chromatograms being merged into one. This has also been fixed by adding collision energy data beside each string. This should be enough to maintain uniqueness amond SRM ID strings.