### PR TITLE
[fix] Fixed checking match retention time window if corresponding option is checked

### DIFF
--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -909,15 +909,15 @@ int Database::loadCompoundCSVFile(string filename)
 
         if (tempLine.contains('\r')) {
             vector<string> carriageSeparated;
-            mzUtils::split(line, '\r', carriageSeparated);
+            carriageSeparated = mzUtils::split(line, "\r");
             for(int i = 0; i < carriageSeparated.size(); i++){
                 vector<string>fields;
-                mzUtils::splitNew(carriageSeparated[i], sep, fields);
+                fields = mzUtils::split(carriageSeparated[i], sep);
                 getCompounds(allHeaders, fields, i+1);
             }
         } else{
             vector<string>fields;
-            mzUtils::splitNew(line, sep, fields);
+            fields = mzUtils::split(line, sep);
             getCompounds(allHeaders, fields, lineCount);
         }
     }

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -203,7 +203,12 @@ PeakDetectionDialog::PeakDetectionDialog(MainWindow* parent) :
         featureOptions->setChecked(false);
         connect(featureOptions, SIGNAL(toggled(bool)), SLOT(featureOptionsClicked()));
 
-        compoundRTWindow->setEnabled(false); //TODO: Sahil - Kiran, Added while merging mainwindow
+        //TODO: Sahil - Kiran, Added while merging mainwindow
+        if (matchRt->isChecked()) {
+            compoundRTWindow->setEnabled(true);
+        } else {
+            compoundRTWindow->setEnabled(false);
+        }
 
         connect(classificationModelFilename,
                 SIGNAL(textChanged(QString)),

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -146,14 +146,14 @@ PeakDetectionDialog::PeakDetectionDialog(MainWindow* parent) :
                         identificationRtWindow->setEnabled(false);
                         identificationMatchRt->setEnabled(false);
                     } else {
-                        identificationRtWindow->setEnabled(true);
                         identificationMatchRt->setEnabled(true);
                     }
                 });
 
         connect(computeButton, SIGNAL(clicked(bool)), SLOT(findPeaks()));
         connect(cancelButton, SIGNAL(clicked(bool)), SLOT(cancel()));
-        connect(matchRt,SIGNAL(clicked(bool)),compoundRTWindow,SLOT(setEnabled(bool))); //TODO: Sahil - Kiran, Added while merging mainwindow
+        connect(matchRt,SIGNAL(clicked(bool)),compoundRTWindow,SLOT(setEnabled(bool)));
+        connect(identificationMatchRt,SIGNAL(clicked(bool)),identificationRtWindow,SLOT(setEnabled(bool)));
         connect(matchFragmentationOptions,
                 &QGroupBox::toggled,
                 [this](const bool checked)
@@ -203,11 +203,16 @@ PeakDetectionDialog::PeakDetectionDialog(MainWindow* parent) :
         featureOptions->setChecked(false);
         connect(featureOptions, SIGNAL(toggled(bool)), SLOT(featureOptionsClicked()));
 
-        //TODO: Sahil - Kiran, Added while merging mainwindow
         if (matchRt->isChecked()) {
             compoundRTWindow->setEnabled(true);
         } else {
             compoundRTWindow->setEnabled(false);
+        }
+
+        if (identificationMatchRt->isChecked()) {
+            identificationRtWindow->setEnabled(true);
+        } else {
+            identificationRtWindow->setEnabled(false);
         }
 
         connect(classificationModelFilename,

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -147,6 +147,8 @@ PeakDetectionDialog::PeakDetectionDialog(MainWindow* parent) :
                         identificationMatchRt->setEnabled(false);
                     } else {
                         identificationMatchRt->setEnabled(true);
+                        if (identificationMatchRt->isChecked())
+                            identificationRtWindow->setEnabled(true);
                     }
                 });
 


### PR DESCRIPTION
Earlier, match retention time window remained unchecked even if its corresponding option was checked. This was due to setting its check state to false in constructor of Peak detection dialog, irrespective of the state of its option.