### PR TITLE
[fix] Handle carriage-return character as newlines while reading csv file

### DIFF
--- a/src/gui/mzroll/database.cpp
+++ b/src/gui/mzroll/database.cpp
@@ -895,7 +895,7 @@ int Database::loadCompoundCSVFile(string filename)
             if (!name.empty())
                 id = name;
             invalidRows.push_back(id);
-        }   
+        }
     };
 
     while(!file.atEnd())


### PR DESCRIPTION
While reading csv files, the file which contains carriage return character as new lines must be read successfully. Earlier ElMaven, did not read such files and show failure error. This has now been successfully handled.