### PR TITLE
[Fix] Zero division error for sum type EIC #1259

### DIFF
--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -1186,7 +1186,8 @@ bool EIC::makeEICSlice(mzSample *sample, float mzmin, float mzmax, float rtmin, 
         //associated m/z is the weighted average(with intensities as weights)
         case EIC::SUM:
         {
-            float n = 0;
+            double sumMz = 0.0;
+            double sumIntensity = 0.0;
             for (unsigned int scanIdx = lb; scanIdx < scan->nobs(); scanIdx++)
             {
                 if (scan->mz[scanIdx] < mzmin)
@@ -1194,11 +1195,14 @@ bool EIC::makeEICSlice(mzSample *sample, float mzmin, float mzmax, float rtmin, 
                 if (scan->mz[scanIdx] > mzmax)
                     break;
 
-                eicIntensity += scan->intensity[scanIdx];
-                eicMz += scan->mz[scanIdx] * scan->intensity[scanIdx];
-                n += scan->intensity[scanIdx];
+                double intensity = static_cast<double>(scan->intensity[scanIdx]);
+                sumIntensity += intensity;
+                sumMz += static_cast<double>(scan->mz[scanIdx]) * intensity;
             }
-            eicMz /= n;
+            if (sumIntensity != 0.0) {
+                eicMz = static_cast<float>(sumMz / sumIntensity);
+                eicIntensity = static_cast<float>(sumIntensity);
+            }
             break;
         }
 

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1158,16 +1158,20 @@ EIC* mzSample::getEIC(float precursorMz,
         // calculate the weighted average(with intensities as weights)
         // while finding the eicMz for the whole EIC.
         case EIC::SUM: {
-            float n = 0;
+            double sumMz = 0.0;
+            double sumIntensity = 0.0;
             for (unsigned int k = 0; k < scan->nobs(); k++) {
                 if (abs(productMz - scan->mz[k]) > amuQ3)
                     continue;
-                eicIntensity += scan->intensity[k];
-                eicMz += (scan->mz[k]) * (scan->intensity[k]);
-                n += scan->intensity[k];
-            }
 
-            eicMz /= n;
+                double intensity = static_cast<double>(scan->intensity[k]);
+                sumIntensity += intensity;
+                sumMz += static_cast<double>(scan->mz[k]) * intensity;
+            }
+            if (sumIntensity != 0.0) {
+                eicMz = static_cast<float>(sumMz / sumIntensity);
+                eicIntensity = static_cast<float>(sumIntensity);
+            }
             break;
         }
 
@@ -1272,14 +1276,17 @@ EIC* mzSample::getEIC(string srm, int eicType)
             // calculate the weighted average(with intensities as weights)
             // while finding the eicMz for the whole EIC.
             case EIC::SUM: {
-                float n = 0;
+                double sumMz = 0.0;
+                double sumIntensity = 0.0;
                 for (unsigned int k = 0; k < scan->nobs(); k++) {
-                    eicIntensity += scan->intensity[k];
-                    eicMz += (scan->mz[k]) * (scan->intensity[k]);
-                    n += scan->intensity[k];
+                    double intensity = static_cast<double>(scan->intensity[k]);
+                    sumIntensity += intensity;
+                    sumMz += static_cast<double>(scan->mz[k]) * intensity;
                 }
-
-                eicMz /= n;
+                if (sumIntensity != 0.0) {
+                    eicMz = static_cast<float>(sumMz / sumIntensity);
+                    eicIntensity = static_cast<float>(sumIntensity);
+                }
                 break;
             }
 


### PR DESCRIPTION
When users opt for summed intensity values over a slice's m/z range, for each scan, the m/z assigned per time observation is calculated by weighted-averaging of all m/z values in that range. The weights here are intensities and their sum can be zero for a given time point. However, no check for a zero sum was made which often led to the weighted m/z being evaluated to a "nan" (zero division error). All subsequent calculations using this m/z also resulted in "nan" values. This has been fixed by simply adding the required check.