### PR TITLE
[CI] Prevent alpha/beta tags from creating an update event

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -240,7 +240,9 @@ after_build:
               exit 1
           }
 
-          if ( Test-Path env:APPVEYOR_REPO_TAG_NAME ) {
+          if ( (Test-Path env:APPVEYOR_REPO_TAG_NAME) -and
+               !($env:APPVEYOR_REPO_TAG_NAME -like "*alpha*") -and
+               !($env:APPVEYOR_REPO_TAG_NAME -like "*beta*") ) {
               # create update repository for this release
               echo "Creating an update repository for $ELMAVEN_BRANCH ..."
               $env:ELMAVEN_UPDATES = "repository"
@@ -304,7 +306,7 @@ deploy:
       set_public: true
       artifact: "Updates"
       on:
-          APPVEYOR_REPO_TAG: true        # deploy to release updates on tag push only
+          APPVEYOR_REPO_TAG: true      # deploy updates for release builds only
 
 
 on_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -232,9 +232,11 @@ after_success:
         exit 1
       fi
 
-      if [ "$TRAVIS_TAG" != "" ]; then
+      export IS_RELEASE_TAG=false
+      if [ "$TRAVIS_TAG" != "" ] && [[ "$TRAVIS_TAG" != *"alpha"* ]] && [[ "$TRAVIS_TAG" != *"beta"* ]]; then
         # create update repository for this release
         echo "Creating an update repository for $ELMAVEN_BRANCH ..."
+        IS_RELEASE_TAG=true
         export ELMAVEN_UPDATES="repository"
         cd $PARENT_DIR
         mkdir "$PARENT_DIR/$ELMAVEN_UPDATES"
@@ -328,4 +330,4 @@ deploy:
     local_dir: $ELMAVEN_UPDATES
     on:
       tags: true
-      condition: $TRAVIS_OS_NAME = "osx"
+      condition: $IS_RELEASE_TAG = true


### PR DESCRIPTION
As it was, the deployment scripts would have pushed alpha and beta tagged builds to the update repository which would result in users being prompted to update to alpha/beta unstable builds. This patch ensures that only stable releases are available as updates for all users.