### PR TITLE
[Fix] Consistent isotope distribution for integrated groups #1225

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -77,6 +77,8 @@ PeakGroup::PeakGroup()  {
     _type = GroupType::None;
     _sliceSet = false;
 
+    _tableName = "";
+
     changePValue=0;
     changeFoldRatio=0;
     //children.reserve(0);

--- a/src/gui/mzroll/isotopeswidget.cpp
+++ b/src/gui/mzroll/isotopeswidget.cpp
@@ -305,12 +305,18 @@ void IsotopeWidget::computeIsotopes(string f)
 void IsotopeWidget::populateByParentGroup(vector<Isotope> masslist, double parentMass)
 {
 	PeakGroup *parentGroup = isotopeParameters->_group;
-	if (!(parentGroup && parentGroup->isIsotope() == false))
+    if (parentGroup == nullptr || parentGroup->isIsotope())
 		return;
 	if (!isotopeParameters->_scan)
 		return;
 
-	map<string, PeakGroup> isotopes = isotopeDetector->getIsotopes(parentGroup, masslist);
+    map<string, PeakGroup> isotopes;
+    if (!parentGroup->children.empty() && !parentGroup->tableName().empty()) {
+        for (auto& child : parentGroup->children)
+            isotopes[child.tagString] = child;
+    } else {
+        isotopes = isotopeDetector->getIsotopes(parentGroup, masslist);
+    }
 
 	map<string, PeakGroup>::iterator itrIsotope;
 	unsigned int index = 1;


### PR DESCRIPTION
Peak-groups that have already been integrated and added to a table are meant to be frozen in terms of their contents and properties. However, isotope widget always pulls isotopes at current global settings, which the user could have changed after doing detection or manual integration. Selected a group then, would show a different set of isotopes being populated in isotope widget than the ones shown in peak table (under the parent peak-group). This has been fixed and the isotope widget will now show the same set of isotopologues that are actually present in a parent group.