### PR TITLE
[Fix] Terminate crashserver on normal app exit #1295

### DIFF
--- a/crashhandler/crashserver/elmavcrashserver.cpp
+++ b/crashhandler/crashserver/elmavcrashserver.cpp
@@ -96,6 +96,15 @@ void OnChildProcessDumpRequested(void* aContext,
 
 }
 
+void onClientExit(void* context,
+                  const ClientInfo* client_info)
+{
+    Q_UNUSED(context);
+    Q_UNUSED(client_info);
+    handlerWait.wakeAll();
+    mutex.unlock();
+}
+
 int main(int argc, char** argv)
 {
     mutex.lock();
@@ -121,7 +130,7 @@ int main(int argc, char** argv)
                                                     NULL,
                                                     OnChildProcessDumpRequested,
                                                    NULL,
-                                                   NULL,
+                                                   onClientExit,
                                                    NULL,
                                                    NULL,
                                                    NULL,


### PR DESCRIPTION
The crashserver daemon has been hooked to only respond to crash dump requests until now. In case there is no crash event and El-MAVEN exits normally, the daemon continues to listen in a limbo state. The Breakpad library, however, does provide for listening to client exit events along with crash events. A handler for this has now been installed to take care of the same.