### PR TITLE
[fix] Fix segment fault in deletion of group from bookmark table

### DIFF
--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -1166,8 +1166,12 @@ void TableDockWidget::deleteSelectedItems()
         if (item->parent() == nullptr) {
             selectedItems.prepend(item);
             nextItem = treeWidget->itemBelow(item);
+            while(nextItem && nextItem->parent() != nullptr) {
+                nextItem = treeWidget->itemBelow(nextItem);
+            }
         } else {
             selectedItems.append(item);
+            nextItem = treeWidget->itemBelow(item);
         }
     }
     if (selectedItems.isEmpty())


### PR DESCRIPTION
Peakgroup when expanded with their isotopes and deleted after isotopes were explored lead to segment fault.