### PR TITLE
More beta fixes

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -713,9 +713,6 @@ void PeakGroup::groupStatistics() {
     if (nonZeroCount) {
         meanRt = rtSum/nonZeroCount;
         meanMz = mzSum/nonZeroCount;
-    } else {
-        meanRt = (_slice.rtmin + _slice.rtmax) / 2.0f;
-        meanMz = (_slice.mzmin + _slice.mzmax) / 2.0f;
     }
 
     groupOverlapMatrix();

--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -710,9 +710,12 @@ void PeakGroup::groupStatistics() {
     weightedAvgPeakQuality = weightedSum/sumWeights;
 
     if (sampleCount>0) sampleMean = sampleMean/sampleCount;
-    if ( nonZeroCount ) {
+    if (nonZeroCount) {
         meanRt = rtSum/nonZeroCount;
         meanMz = mzSum/nonZeroCount;
+    } else {
+        meanRt = (_slice.rtmin + _slice.rtmax) / 2.0f;
+        meanMz = (_slice.mzmin + _slice.mzmax) / 2.0f;
     }
 
     groupOverlapMatrix();

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -167,7 +167,8 @@ MavenParameters::MavenParameters(const MavenParameters& mp)
 
 MavenParameters::~MavenParameters()
 {
-    saveSettings(lastUsedSettingsPath.c_str());
+    if (!lastUsedSettingsPath.empty())
+        saveSettings(lastUsedSettingsPath.c_str());
 }
 
 MavenParameters& MavenParameters::operator=(const MavenParameters& mp)
@@ -290,7 +291,9 @@ void MavenParameters::copyFrom(const MavenParameters& mp)
     overlapWeight = mp.overlapWeight;
     useOverlap = mp.useOverlap;
 
-    lastUsedSettingsPath = mp.lastUsedSettingsPath;
+    // intentionally set this empty, so that it does not write to session
+    // setting when being destroyed
+    lastUsedSettingsPath = "";
     defaultSettingsData = mp.defaultSettingsData;
     mavenSettings = mp.mavenSettings;
 

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1670,9 +1670,12 @@ void EicWidget::setPeakGroup(shared_ptr<PeakGroup> group)
     if (_autoZoom && group->parent != NULL) {
         eicParameters->_slice.rtmin = group->parent->minRt - 2 * _zoomFactor;
         eicParameters->_slice.rtmax = group->parent->maxRt + 2 * _zoomFactor;
-    } else if (_autoZoom) {
+    } else if (_autoZoom && group->peakCount() > 0) {
         eicParameters->_slice.rtmin = group->minRt - 2 * _zoomFactor;
         eicParameters->_slice.rtmax = group->maxRt + 2 * _zoomFactor;
+    } else if (_autoZoom) {
+        eicParameters->_slice.rtmin = group->meanRt - 2.5f * _zoomFactor;
+        eicParameters->_slice.rtmax = group->meanRt + 2.5f * _zoomFactor;
     }
 
     //make sure that plot region is within visible samPle bounds;

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1667,15 +1667,13 @@ void EicWidget::setPeakGroup(shared_ptr<PeakGroup> group)
         setMzSlice(group->getSlice());
     }
 
-    if (_autoZoom && group->parent != NULL) {
-        eicParameters->_slice.rtmin = group->parent->minRt - 2 * _zoomFactor;
-        eicParameters->_slice.rtmax = group->parent->maxRt + 2 * _zoomFactor;
-    } else if (_autoZoom && group->peakCount() > 0) {
-        eicParameters->_slice.rtmin = group->minRt - 2 * _zoomFactor;
-        eicParameters->_slice.rtmax = group->maxRt + 2 * _zoomFactor;
+    auto parentGroup = group->parent == nullptr ? group.get() : group->parent;
+    if (_autoZoom && parentGroup->peakCount() > 0) {
+        eicParameters->_slice.rtmin = parentGroup->minRt - 2 * _zoomFactor;
+        eicParameters->_slice.rtmax = parentGroup->maxRt + 2 * _zoomFactor;
     } else if (_autoZoom) {
-        eicParameters->_slice.rtmin = group->meanRt - 2.5f * _zoomFactor;
-        eicParameters->_slice.rtmax = group->meanRt + 2.5f * _zoomFactor;
+        eicParameters->_slice.rtmin = parentGroup->meanRt - 2.5f * _zoomFactor;
+        eicParameters->_slice.rtmax = parentGroup->meanRt + 2.5f * _zoomFactor;
     }
 
     //make sure that plot region is within visible samPle bounds;

--- a/src/gui/mzroll/gallerywidget.cpp
+++ b/src/gui/mzroll/gallerywidget.cpp
@@ -134,6 +134,11 @@ void GalleryWidget::addEicPlots(PeakGroup* group)
         emit peakRegionSet(eic->sample, peakRtMin, peakRtMax);
     }
 
+    // possible when all peaks are zeroed
+    if (_minRt == numeric_limits<float>::max()
+        && _maxRt == numeric_limits<float>::min()) {
+        _minRt = _maxRt = group->meanRt;
+    }
     _minRt -= _rtBuffer;
     _maxRt += _rtBuffer;
 

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -206,18 +206,6 @@ PeakDetectionDialog::PeakDetectionDialog(MainWindow* parent) :
         featureOptions->setChecked(false);
         connect(featureOptions, SIGNAL(toggled(bool)), SLOT(featureOptionsClicked()));
 
-        if (matchRt->isChecked()) {
-            compoundRTWindow->setEnabled(true);
-        } else {
-            compoundRTWindow->setEnabled(false);
-        }
-
-        if (identificationMatchRt->isChecked()) {
-            identificationRtWindow->setEnabled(true);
-        } else {
-            identificationRtWindow->setEnabled(false);
-        }
-
         connect(classificationModelFilename,
                 SIGNAL(textChanged(QString)),
                 this,
@@ -460,6 +448,18 @@ void PeakDetectionDialog::inputInitialValuesPeakDetectionDialog() {
         toggleFragmentation();
 
         _setAdductWindowState();
+
+        if (matchRt->isChecked()) {
+            compoundRTWindow->setEnabled(true);
+        } else {
+            compoundRTWindow->setEnabled(false);
+        }
+
+        if (identificationMatchRt->isChecked()) {
+            identificationRtWindow->setEnabled(true);
+        } else {
+            identificationRtWindow->setEnabled(false);
+        }
 
         QDialog::exec();
     }

--- a/src/gui/mzroll/peakeditor.cpp
+++ b/src/gui/mzroll/peakeditor.cpp
@@ -174,8 +174,10 @@ void PeakEditor::_setRtRangeAndValues()
         }
     } else if (_group->isIsotope() && _group->parent != nullptr) {
         PeakGroup* parentGroup = _group->parent;
-        minRt = parentGroup->minRt - rtBuffer;
-        maxRt = parentGroup->maxRt + rtBuffer;
+        if (parentGroup->peakCount() > 0) {
+            minRt = parentGroup->minRt - rtBuffer;
+            maxRt = parentGroup->maxRt + rtBuffer;
+        }
         for (auto child : parentGroup->children) {
             if (child->peakCount() == 0)
                 continue;
@@ -335,6 +337,7 @@ void PeakEditor::_applyEdits()
             _editPeakRegionForSample(group, sample, eics, rtMin, rtMax);
         }
         group->groupStatistics();
+        qDebug() << group->getName().c_str() << group->meanMz << group->meanRt;
     };
 
     // lambda: obtain full range EICs for the given peak-group

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -1609,7 +1609,11 @@ void TableDockWidget::editSelectedPeakGroup()
   editor->exec();
 
   auto currentItem = treeWidget->currentItem();
-  updateItem(currentItem, true);
+  if (currentItem->parent() != nullptr) {
+    updateItem(currentItem->parent(), true);
+  } else {
+    updateItem(currentItem, true);
+  }
 
   auto groupToSave = group;
   if (group->isIsotope() && group->parent != nullptr) {

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -241,13 +241,13 @@ void TableDockWidget::updateItem(QTreeWidgetItem *item, bool updateChildren) {
 
   //score group quality
   groupClassifier* groupClsf = _mainwindow->getGroupClassifier();
-  if (groupClsf != NULL) {
+  if (group->peakCount() > 0 && groupClsf != NULL) {
       groupClsf->classify(group.get());
   }
 
   //get probability good/bad from svm
   svmPredictor* groupPred = _mainwindow->getSVMPredictor();
-  if (groupPred != NULL) {
+  if (group->peakCount() > 0 && groupPred != NULL) {
       groupPred->predict(group.get());
   }
 
@@ -397,8 +397,6 @@ void TableDockWidget::addRow(shared_ptr<PeakGroup> group,
 
   if (group == nullptr)
     return;
-  if (group->peakCount() == 0)
-    return;
   if (group->meanMz <= 0) {
     return;
   }
@@ -458,13 +456,13 @@ void TableDockWidget::addRow(shared_ptr<PeakGroup> group,
 
     //TODO: Move this to peak detector or peakgroup
     groupClassifier* groupClsf = _mainwindow->getGroupClassifier();
-    if (groupClsf != NULL) {
+    if (group->peakCount() > 0 && groupClsf != NULL) {
         groupClsf->classify(group.get());
     }
 
     //Get prediction labels from svm
     svmPredictor* groupPred = _mainwindow->getSVMPredictor();
-    if (groupPred != NULL) {
+    if (group->peakCount() > 0 && groupPred != NULL) {
         groupPred->predict(group.get());
     }
   } else if (viewType == peakView) {


### PR DESCRIPTION
The following things were patched:
- RT windows staying disabled with RT matching on (in "Peaks" dialog).
- Non-global `MavenParameters` object would write to the "lastRun.xml" settings file.
- Editor axes mangled when all peaks are zeroed
- Zeroed groups being auto-deleted on table refresh or session restore.