### PR TITLE
[fix] Fix crash when files with unsupported format are uploaded

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -547,7 +547,8 @@ using namespace mzUtils;
             SIGNAL(compoundsLoaded(QString, int)),
             this,
             SLOT(_postCompoundsDBLoadActions(QString,int)));
-
+    
+    connect(fileLoader, SIGNAL(unsupportedFileFormat(QStringList)), this, SLOT(unsupportedFormat(QStringList)));
     // EMDB singals and slots
     connect(fileLoader,
             SIGNAL(sqliteDBLoadStarted(QString)),
@@ -943,6 +944,31 @@ void MainWindow::threadSave(const QString filename, const bool saveRawData)
     autosaveWorker->deleteCurrentProject();
     _latestUserProjectName = filename;
     saveWorker->saveProject(filename, saveRawData);
+}
+
+void MainWindow::unsupportedFormat(QStringList unsupportedFileList) 
+{
+    QString fileList = "";
+
+    for (QString filePath : unsupportedFileList) {
+        auto filePathSplit = mzUtils::split(filePath.toStdString(), "/");
+        string fileName = filePathSplit[filePathSplit.size() - 1];
+        fileList += "<li>" + QString::fromStdString(fileName);
+    }
+
+    auto htmlText = QString("<p>El-MAVEN does not support the file format"
+                            " of the following files: </p>"
+                          "<ul>%1</ul>").arg(fileList);
+    htmlText += "<p>Some files are not uploaded.</p>";
+    auto reply = QMessageBox::critical(this, 
+                                        tr(""), 
+                                        htmlText);
+    
+    setWindowTitle(programName
+                    + " "
+                    + STR(EL_MAVEN_VERSION)
+                    + " ");
+    return;
 }
 
 void MainWindow::saveProject(bool explicitSave)

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -959,7 +959,7 @@ void MainWindow::unsupportedFormat(QStringList unsupportedFileList)
     auto htmlText = QString("<p>El-MAVEN does not support the file format"
                             " of the following files: </p>"
                           "<ul>%1</ul>").arg(fileList);
-    htmlText += "<p>Some files are not uploaded.</p>";
+    htmlText += "<p>Some files were not uploaded.</p>";
     auto reply = QMessageBox::critical(this, 
                                         tr(""), 
                                         htmlText);

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -448,6 +448,12 @@ public Q_SLOTS:
      */
     void updateTablePostAlignment();
 
+	/**
+	 * @brief Creates a message box that notifies the user about sample 
+	 * uploaded is not supported in El-MAVEN.
+	 */ 
+	void unsupportedFormat(QStringList unsupportedFileList);
+
     /**
      * @brief The peak-editor is a widget that will allow the user to edit the
      * RT bounds of individual peaks in a peak-group.

--- a/src/gui/mzroll/mzfileio.cpp
+++ b/src/gui/mzroll/mzfileio.cpp
@@ -457,6 +457,8 @@ void mzFileIO::fileImport(void) {
     QStringList projects;
     QStringList spectralhits;
     QStringList compoundsDatabases;
+    QStringList unsupportedFileList;
+    bool fileNotSupported = false;
 
     Q_FOREACH (QString filename, filelist) {
         try {
@@ -475,11 +477,18 @@ void mzFileIO::fileImport(void) {
             } else if (isCompoundDatabaseType(filename)) {
                 compoundsDatabases << filename;
             } else {
-                throw MavenException(ErrorMsg::UnsupportedFormat);
+                fileNotSupported = true;
+                unsupportedFileList << filename;
+                filelist.removeOne(filename);
             }
         } catch (MavenException& excp) {
             qDebug() << "Error: " << excp.what();
         }
+    }
+
+    if (fileNotSupported) {
+        Q_EMIT(unsupportedFileFormat(unsupportedFileList));
+        Q_EMIT (updateProgressBar( "Importing errors", 0, 0));
     }
 
     Q_FOREACH(QString filename, projects ) {

--- a/src/gui/mzroll/mzfileio.h
+++ b/src/gui/mzroll/mzfileio.h
@@ -306,6 +306,7 @@ Q_OBJECT
      void sqliteDBUnrecognizedVersion(QString);
      void settingsLoaded(map<string, variant>);
      void appSettingsUpdated();
+     void unsupportedFileFormat(QStringList);
 
     protected:
       /**


### PR DESCRIPTION
Files with unsupported file format leads to the crash. Now the user will be notified when unsupported file is opened. Ideally, El-MAVEN would open files with supported format and notify the user for unsupported files. 