### PR TITLE
[fix] Fix crash caused by "/" in text search

### DIFF
--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -1119,9 +1119,20 @@ void EicWidget::setTitle() {
 		tagString = QString(eicParameters->_slice.srmId.c_str());
 	}
 
-	QString titleText = tr("<b>%1</b> m/z: %2-%3").arg(tagString,
-			QString::number(eicParameters->_slice.mzmin, 'f', 4),
-			QString::number(eicParameters->_slice.mzmax, 'f', 4));
+    QString m1 = QString::number(eicParameters->_slice.mzmin, 'f', 4);
+    QString m2 = QString::number(eicParameters->_slice.mzmax, 'f', 4);
+    if (eicParameters->_slice.compound != nullptr
+        && eicParameters->_slice.compound->productMz() > 0.0f) {
+        m1 = QString::number(eicParameters->_slice.compound->precursorMz(),
+                             'f',
+                             3);
+        m1 = "prec=" + m1;
+        m2 = QString::number(eicParameters->_slice.compound->productMz(),
+                             'f',
+                             3);
+        m2 = "prod=" + m2;
+    }
+    QString titleText = tr("<b>%1</b> m/z: %2 - %3").arg(tagString, m1, m2);
 
 	QGraphicsTextItem* title = scene()->addText(titleText, font);
 	title->setHtml(titleText);

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -363,10 +363,7 @@ public Q_SLOTS:
     void setPeakGroup(shared_ptr<PeakGroup> group);
 	void showDockWidgets();
 	void hideDockWidgets();
-	//void terminateTheads();
-	void doSearch(QString needle);
-	//void setupSampleColors();
-        // void showMassSlices();
+    void searchForQuery();
         void showSRMList();
         void addToHistory(const mzSlice& slice);
         void historyNext();


### PR DESCRIPTION
El-MAVEN caused crash when typed "/" or for any other search. This was due to no memory allocation for "masscutoff" in peptide fregmentation class.