### PR TITLE
Add '.xml' to the list of filetype of load settings dialog. 

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2994,14 +2994,16 @@ void MainWindow::loadSettings()
     };
 
     QFile file(fileName);
-    if(!(fileName.contains(".xml") || fileName.contains(".XML"))) {
+    if(fileName.size() 
+        && !(fileName.contains(".xml") 
+            || fileName.contains(".XML"))) {
         auto fileNameSplit = mzUtils::split(fileName.toStdString(), "/");
         string fileNameString = fileNameSplit[fileNameSplit.size() - 1];
         fileName = "<li>" + QString::fromStdString(fileNameString);
         auto htmlText = QString("<p>El-MAVEN settings does not support the file format"
                             " of the following file: </p>"
                           "<ul>%1</ul>").arg(fileName);
-        htmlText += "<p>Setting file is not uploaded.</p>";
+        htmlText += "<p>Setting file was not uploaded.</p>";
         warning(htmlText);
         return;
     }
@@ -3020,7 +3022,7 @@ void MainWindow::loadSettings()
 
     else {
         // display an error message
-        warning("Unable to load settings. File name not specified.");
+        warning("Unable to load settings. Specified file is not readable.");
     }
 }
 

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -2883,6 +2883,9 @@ QToolButton* MainWindow::addDockWidgetButton(QToolBar* bar,
 void MainWindow::saveSettings()
 {
     QString fileName = QFileDialog::getSaveFileName(Q_NULLPTR,"Save Settings",QString());
+    if(!(fileName.contains(".xml") || fileName.contains(".XML"))){
+        fileName += ".xml";
+    }
 
     if(!mavenParameters->saveSettings(fileName.toStdString().c_str())) {
         QMessageBox msgBox;


### PR DESCRIPTION
This PR is for following two tasks: 

1. Add '.xml' filetype while saving El-MAVEN settings.
2. Only '.xml' files would be loaded in settings dialog. Any other uploaded file would give the user warning of unsupported file format. 