### PR TITLE
Fixes related to storing correct RT bounds

### DIFF
--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -8,7 +8,6 @@
 #include "boxplot.h"
 #include "classifierNeuralNet.h"
 #include "datastructures/adduct.h"
-#include "datastructures/mzSlice.h"
 #include "eiclogic.h"
 #include "globals.h"
 #include "isotopeswidget.h"
@@ -201,11 +200,15 @@ void EicWidget::mouseDoubleClickEvent(QMouseEvent* event) {
 void EicWidget::integrateRegion(float rtMin, float rtMax)
 {
     const auto& visibleSamples = getMainWindow()->getVisibleSamples();
+    auto slice = eicParameters->_slice;
+    auto bounds = visibleSamplesBounds();
+    slice.rtmin = bounds.rtmin;
+    slice.rtmax = bounds.rtmax;
     auto integratedGroup = PeakDetector::integrateEicRegion(
         eicParameters->eics,
         rtMin,
         rtMax,
-        eicParameters->_slice,
+        slice,
         visibleSamples,
         getMainWindow()->mavenParameters,
         getMainWindow()->getClassifier(),

--- a/src/gui/mzroll/eicwidget.h
+++ b/src/gui/mzroll/eicwidget.h
@@ -6,6 +6,7 @@
 #include "stable.h"
 
 #include "datastructures/isotope.h"
+#include "datastructures/mzSlice.h"
 
 class EIC;
 class EICLogic;
@@ -37,6 +38,7 @@ public:
 	void addPeakPositions();
 	void setBarplotPosition(PeakGroup* group);
     void renderPdf(shared_ptr<PeakGroup> group, QPainter* painter);
+    mzSlice visibleSamplesBounds();
 
 public Q_SLOTS:
 	void setMzSlice(float mz1, float mz2 = 0.0);
@@ -255,7 +257,6 @@ private:
 	void cleanup();		//deallocate eics, fragments, peaks, peakgroups
 	void clearPlot();	//removes non permenent graphics objects
 	void findPlotBounds(); //find _minX, _maxX...etc
-	mzSlice visibleSamplesBounds();
 
 	float toX(float x);
 	float toY(float y);

--- a/src/gui/mzroll/point.cpp
+++ b/src/gui/mzroll/point.cpp
@@ -221,6 +221,11 @@ void EicPoint::mouseDoubleClickEvent(QGraphicsSceneMouseEvent*) {
     if (_group != nullptr) {
         _group = make_shared<PeakGroup>(*_group,
                                         PeakGroup::IntegrationType::Manual);
+        auto slice = _group->getSlice();
+        auto bounds = _mw->getEicWidget()->visibleSamplesBounds();
+        slice.rtmin = bounds.rtmin;
+        slice.rtmax = bounds.rtmax;
+        _group->setSlice(slice);
         _mw->isotopeWidget->setPeakGroupAndMore(_group, true);
     }
 


### PR DESCRIPTION
Two changes for consistency in what RT bounds for slices are stored in peak-groups (and therefore in emDBs as well).
1. For isotopes which are "linked" to their parent (unlabelled) peak-groups, the slice has been made to have the exact same RT bound.
2. For manually bookmarked peak-groups, the RT bounds will always be the entire RT range (inclusive over all currently selected samples).