### PR TITLE
[Fix] Incorrect m/z calculation for EI type

### DIFF
--- a/src/core/libmaven/datastructures/adduct.cpp
+++ b/src/core/libmaven/datastructures/adduct.cpp
@@ -97,6 +97,11 @@ float Adduct::computeParentMass(float mz)
 
 float Adduct::computeAdductMz(float parentMass)
 {
+    if (isParent() && MassCalculator::ionizationType == MassCalculator::EI) {
+        MassCalculator massCalc;
+        return massCalc.adjustMass(parentMass, _charge);
+    }
+
     return (parentMass * static_cast<float>(_nmol) + _mass)
            / static_cast<float>(abs(_charge));
 }

--- a/src/core/libmaven/mavenparameters.cpp
+++ b/src/core/libmaven/mavenparameters.cpp
@@ -524,10 +524,12 @@ void MavenParameters::setOptionsDialogSettings(const char* key, const char* valu
         setIonizationMode((Polarity)polarity);
     }
 
-    if (strcmp(key, "ionizationType") == 0 && stoi(value) == 1) {
-        MassCalculator::ionizationType = MassCalculator::EI;
-    } else {
-        MassCalculator::ionizationType = MassCalculator::ESI;
+    if (strcmp(key, "ionizationType") == 0) {
+        if (stoi(value) == 1) {
+            MassCalculator::ionizationType = MassCalculator::EI;
+        } else {
+            MassCalculator::ionizationType = MassCalculator::ESI;
+        }
     }
 
     if(strcmp(key, "q1Accuracy") == 0)

--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -3599,8 +3599,9 @@ void MainWindow::addToHistory(const mzSlice& slice) {
 bool MainWindow::addSample(mzSample* sample) {
 	if (sample && sample->scans.size() > 0) {
 		samples.push_back(sample);
-		mavenParameters->samples.push_back(sample);	
-        settingsForm->setSettingsIonizationMode("Auto-detect");
+        mavenParameters->samples.push_back(sample);
+        if (settingsForm->ionizationType->currentText() != "EI")
+            settingsForm->setSettingsIonizationMode("Auto-detect");
 		return true;
 	} else {
 		delete (sample);

--- a/src/gui/mzroll/settingsform.cpp
+++ b/src/gui/mzroll/settingsform.cpp
@@ -389,8 +389,11 @@ void SettingsForm::getFormValues()
     settings->setValue("aslsAsymmetry", asymmetrySlider->value());
 
     // change ionization type
-    if (ionizationType->currentText() == "EI")  MassCalculator::ionizationType = MassCalculator::EI;
-    else MassCalculator::ionizationType = MassCalculator::ESI;
+    if (ionizationType->currentText() == "EI") {
+        MassCalculator::ionizationType = MassCalculator::EI;
+    } else {
+        MassCalculator::ionizationType = MassCalculator::ESI;
+    }
 
     mzSample::setFilter_centroidScans( centroid_scan_flag->checkState() == Qt::Checked );
     mzSample::setFilter_minIntensity( scan_filter_min_intensity->value() );


### PR DESCRIPTION
The calculation of m/z differs only for EI ionization type. This
was not taken into account when calculating the m/z value from
parent adduct ions (which should still obey the EI/non-EI rules).

Additinally, the logic for setting ionization type in the
`MavenParameters` class was constantly assigning ESI even when
unintended.