### PR TITLE
[Fix] Dedicated method for expected m/z in diff calculation

### DIFF
--- a/src/core/libmaven/csvreports.cpp
+++ b/src/core/libmaven/csvreports.cpp
@@ -302,28 +302,21 @@ void CSVReports::_writeGroupInfo(PeakGroup* group)
     string formula = "";
     float expectedRtDiff = 0;
     float ppmDist = 0;
-    if (group->getCompound() != NULL) {
-        compoundName = _sanitizeString(group->getCompound()->name().c_str()).toStdString();
-        compoundID   = _sanitizeString(group->getCompound()->id().c_str()).toStdString();
-        formula = _sanitizeString(group->getCompound()->formula().c_str()).toStdString();
-        if (!group->getCompound()->formula().empty()) {
-            int charge = getMavenParameters()->getCharge(group->getCompound());
-            if (group->parent != NULL) {
-                ppmDist = mzUtils::massCutoffDist(
-                    (double)group->getExpectedMz(charge),
-                    (double)group->meanMz,
-                    getMavenParameters()->massCutoffMerge);
-            } else {
-                ppmDist = mzUtils::massCutoffDist((double) group->getCompound()->adjustedMass(charge),
-                                                  (double) group->meanMz,
-                                                  getMavenParameters()->massCutoffMerge);
-            }
-        }
-        else {
-            ppmDist = mzUtils::massCutoffDist((double) group->getCompound()->mz(), (double) group->meanMz,getMavenParameters()->massCutoffMerge);
-        }
+    if (group->hasCompoundLink()) {
+        compoundName = _sanitizeString(
+                           group->getCompound()->name().c_str()).toStdString();
+        compoundID = _sanitizeString(
+                         group->getCompound()->id().c_str()).toStdString();
+        formula = _sanitizeString(
+                      group->getCompound()->formula().c_str()).toStdString();
+
+        int charge = getMavenParameters()->getCharge(group->getCompound());
+        double expectedMz = group->getExpectedMz(charge);
+        double observedMz = static_cast<double>(group->meanMz);
+        auto cutoff = getMavenParameters()->massCutoffMerge;
+        ppmDist = mzUtils::massCutoffDist(expectedMz, observedMz, cutoff);
+
         expectedRtDiff = group->expectedRtDiff();
-        // TODO: Added this while merging this file
     } else {
         // absence of a group compound means this group was created using
         // untargeted detection, we set compound name and ID to {mz}@{rt}


### PR DESCRIPTION
The `ppmDiff` exported for a particular lipidomics data is somehow very large (>1000 PPM) compared to the error allowed (50 PPM). This branch is only an attempt to fix the issue and is not guaranteed to do it - we will know more after testing. It should still be helpful to make the included changes on develop, regardless of whether it fixes the issue.