### PR TITLE
[Fix] Adduct detection

### DIFF
--- a/src/core/libmaven/peakdetector.cpp
+++ b/src/core/libmaven/peakdetector.cpp
@@ -559,7 +559,8 @@ void PeakDetector::processSlices(vector<mzSlice*>& slices,
 
         // we do not filter non-parent adducts or non-parent isotopologues
         bool isParentGroup = slice->adduct == nullptr
-                             || slice->isotope.isNone()
+                             || (slice->adduct->isParent()
+                                 && slice->isotope.isNone())
                              || (slice->adduct->isParent()
                                  && slice->isotope.isParent());
         if (isParentGroup && applyGroupFilters) {
@@ -624,7 +625,8 @@ void PeakDetector::processSlices(vector<mzSlice*>& slices,
 
         // we only filter parent peak-groups on group filtering parameters
         bool isParentGroup = slice->adduct == nullptr
-                             || slice->isotope.isNone()
+                             || (slice->adduct->isParent()
+                                 && slice->isotope.isNone())
                              || (slice->adduct->isParent()
                                  && slice->isotope.isParent());
         if (isParentGroup
@@ -889,11 +891,14 @@ void PeakDetector::performMetaGrouping(bool applyGroupFilters,
             if (compound == nullptr)
                 continue;
 
-            bool noAdduct = group.adduct() == nullptr;
-            bool noIsotope = group.isotope().isNone();
-            bool parentAdductAndIsotope = (group.adduct()->isParent()
-                                           && group.isotope().isParent());
-            if (noAdduct || noIsotope || parentAdductAndIsotope) {
+            bool notAdduct = group.adduct() == nullptr;
+            bool parentAdductAndNotIsotope = (group.adduct()->isParent()
+                                              && group.isotope().isNone());
+            bool parentAdductAndParentIsotope = (group.adduct()->isParent()
+                                                 && group.isotope().isParent());
+            if (notAdduct
+                || parentAdductAndNotIsotope
+                || parentAdductAndParentIsotope) {
                 if (parentCompounds.count(compound) == 0)
                     parentCompounds[compound] = {};
                 parentCompounds[compound].push_back(i);

--- a/src/core/libmaven/peakdetector.cpp
+++ b/src/core/libmaven/peakdetector.cpp
@@ -683,7 +683,7 @@ void _keepNBestRanked(unordered_map<Compound*, vector<size_t>>& compoundGroups,
         sort(begin(groupIndexes), end(groupIndexes), [&](size_t a, size_t b) {
             PeakGroup& group = container[a];
             PeakGroup& otherGroup = container[b];
-            return group.groupRank > otherGroup.groupRank;
+            return group.groupRank < otherGroup.groupRank;
         });
         for (size_t i = nBest; i < groupIndexes.size(); ++i)
             indexesToDelete.push_back(groupIndexes[i]);


### PR DESCRIPTION
1. Fix adduct search not working without isotope search turned on.
2. Fix rank-based filtering preserving the worst peaks instead of the best ones.