### PR TITLE
[Fix] Add prompt to confirm MS/MS type #1347

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -862,8 +862,10 @@ vector<Scan*> PeakGroup::getFragmentationEvents()
         mzSample* sample = peak.getSample();
         if (sample == nullptr)
             continue;
-        if (sample->ms2ScanCount() == 0)
+        if (sample->ms2ScanCount() == 0
+            || sample->msMsType() != mzSample::MsMsType::DDA) {
             continue;
+        }
 
         mzSlice slice(minMz, maxMz, peak.rtmin, peak.rtmax);
         vector<Scan*> scans = sample->getFragmentationEvents(&slice);

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -25,6 +25,7 @@ mzSample::mzSample() : _setName(""), injectionOrder(0)
     _id = -1;
     _numMS1Scans = 0;
     _numMS2Scans = 0;
+    _msMsType = MsMsType::None;
     maxMz = maxRt = 0;
     minMz = minRt = 0;
     isBlank = false;

--- a/src/core/libmaven/mzSample.h
+++ b/src/core/libmaven/mzSample.h
@@ -180,8 +180,13 @@ class mzLink
 */
 class mzSample
 {
+public:
+    enum class MsMsType {
+        DDA,
+        PRM,
+        None
+    };
 
-  public:
     /**
     * @brief Constructor for class mzSample
     */
@@ -681,6 +686,9 @@ class mzSample
 
     vector<float> getIntensityDistribution(int mslevel);
 
+    inline void setMsMsType(MsMsType msMsType) { _msMsType = msMsType; }
+    inline MsMsType msMsType() const { return _msMsType; }
+
     deque<Scan *> scans;
     string sampleName;
     string fileName;
@@ -728,6 +736,7 @@ class mzSample
     int _id;
     unsigned int _numMS1Scans;
     unsigned int _numMS2Scans;
+    MsMsType _msMsType;
 
     void sampleNaming(const char *filename);
     void checkSampleBlank(const char *filename);

--- a/src/gui/mzroll/eicwidget.cpp
+++ b/src/gui/mzroll/eicwidget.cpp
@@ -2120,7 +2120,11 @@ void EicWidget::addMS2Events(float mzmin, float mzmax)
 
     int count = 0;
     for (auto const& sample : samples) {
-        if (sample->ms1ScanCount() == 0) continue;
+        if (sample->ms1ScanCount() == 0
+            || sample->msMsType() != mzSample::MsMsType::DDA) {
+            continue;
+        }
+
         for (auto const& scan : sample->scans) {
             if (scan->mslevel == 2 && scan->precursorMz >= mzmin
                 && scan->precursorMz <= mzmax) {

--- a/src/gui/mzroll/mainwindow.h
+++ b/src/gui/mzroll/mainwindow.h
@@ -494,6 +494,7 @@ private Q_SLOTS:
 
     void _postProjectLoadActions();
     void _handleUnrecognizedProjectVersion(QString projectFilename);
+    void _confirmMsMsType();
 
 private:
     Controller* _controller;

--- a/src/gui/mzroll/peakdetectiondialog.cpp
+++ b/src/gui/mzroll/peakdetectiondialog.cpp
@@ -448,8 +448,9 @@ void PeakDetectionDialog::toggleFragmentation()
     auto iter = find_if(begin(samples),
                         end(samples),
                         [](mzSample* s) {
-                           return ((s->ms1ScanCount() > 0)
-                                   && (s->ms2ScanCount() > 0));
+                           return (s->ms1ScanCount() > 0
+                                   && s->ms2ScanCount() > 0
+                                   && s->msMsType() == mzSample::MsMsType::DDA);
                         });
     bool foundDda = iter != end(samples);
 


### PR DESCRIPTION
When loading a sample having MS1 and MS2 scans El-MAVEN has no way of being able to tell whether these samples were from a DDA or a PRM experiment. From now on, an input dialog will ask the user to confirm the MS/MS data type, whenever they load such samples. For now, this prevents MS2 events logic from interfering with PRM data analysis. It could potentially help with other things in the future.

**Note to reviewer**: please ask me for sample files that you can use to test this branch.