### PR TITLE
[Fix] Chromatogram-level polarity not being read

### DIFF
--- a/src/core/libmaven/PeakGroup.cpp
+++ b/src/core/libmaven/PeakGroup.cpp
@@ -586,11 +586,8 @@ void PeakGroup::updateQuality() {
     weightedAvgPeakQuality = weightedSum / sumWeights;
 }
 
-// TODO: Remove this function as expected mz should be calculated while creating the group - Sahil
-double PeakGroup::getExpectedMz(int charge) {
-
-    float mz = 0;
-
+double PeakGroup::getExpectedMz(int charge)
+{
     if (isIsotope()
         && hasSlice()
         && hasCompoundLink()) {
@@ -598,8 +595,15 @@ double PeakGroup::getExpectedMz(int charge) {
     } else if (!isIsotope()
                && hasSlice()
                && hasCompoundLink()
+               && getCompound()->precursorMz() > 0
+               && getCompound()->productMz() > 0) {
+        return getCompound()->productMz();
+    } else if (!isIsotope()
+               && hasSlice()
+               && hasCompoundLink()
                && getCompound()->mz() > 0) {
         Compound* compound = getCompound();
+        float mz = 0.0;
 
         // for parent adducts, the global charge should be used and not that
         // of the associated adduct's
@@ -624,15 +628,9 @@ double PeakGroup::getExpectedMz(int charge) {
             mz = compound->mz();
         }
         return mz;
-    } else if (hasSlice()
-               && hasCompoundLink()
-               && getCompound()->mz() > 0
-               && getCompound()->productMz() > 0) {
-        mz = getCompound()->productMz();
-        return mz;
     }
 
-    return -1;
+    return -1.0;
 }
 
 void PeakGroup::groupStatistics() {

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -343,6 +343,14 @@ void mzSample::parseMzMLChromatogramList(const xml_node& chromatogramList)
 
         cleanFilterLine(chromatogramId);
 
+        int scanPolarity = -1;
+        map<string, string> chromatogramParams = mzML_cvParams(chromatogram);
+        if (chromatogramParams.count("positive scan")) {
+            scanPolarity = 1;
+        } else if (chromatogramParams.count("negative scan")) {
+            scanPolarity = -1;
+        }
+
         vector<float> timeVector;
         vector<float> intsVector;
 
@@ -368,7 +376,6 @@ void mzSample::parseMzMLChromatogramList(const xml_node& chromatogramList)
         if (activationParams.count("collision energy"))
             collisionEnergy = string2float(activationParams["collision energy"]);
 
-        int scanPolarity = -1;
         for (xml_node binaryDataArray = binaryDataArrayList.child("binaryDataArray");
              binaryDataArray;
              binaryDataArray =

--- a/src/core/libmaven/peakdetector.cpp
+++ b/src/core/libmaven/peakdetector.cpp
@@ -902,9 +902,11 @@ void PeakDetector::performMetaGrouping(bool applyGroupFilters,
                 continue;
 
             bool notAdduct = group.adduct() == nullptr;
-            bool parentAdductAndNotIsotope = (group.adduct()->isParent()
+            bool parentAdductAndNotIsotope = (group.adduct() != nullptr
+                                              && group.adduct()->isParent()
                                               && group.isotope().isNone());
-            bool parentAdductAndParentIsotope = (group.adduct()->isParent()
+            bool parentAdductAndParentIsotope = (group.adduct() != nullptr
+                                                 && group.adduct()->isParent()
                                                  && group.isotope().isParent());
             if (notAdduct
                 || parentAdductAndNotIsotope


### PR DESCRIPTION
Chromatograms in mzML files can have their polarity defined at the "chromatogram" level as well as the "binaryData" level. Only the latter was being read by our parser. This has been fixed.