### PR TITLE
[Travis] Upgrade Xcode to v11.3 - macOS Mojave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       compiler: gcc-7
       group: deprecated-2017Q2
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode11.3
       language: cpp
 
 


### PR DESCRIPTION
Attempt to fix macOS CI/CD pipeline. Qt homebrew bottle now requires a minimum OS version - 10.14 (Mojave).