### PR TITLE
Fix - untargeted memory leak

### DIFF
--- a/src/core/libmaven/massslicer.cpp
+++ b/src/core/libmaven/massslicer.cpp
@@ -428,12 +428,15 @@ void MassSlicer::_reduceSlices(MassCutoff* massCutoff)
     }
 
     // remove merged slices
-    slices.erase(remove_if(slices.begin(),
-                           slices.end(),
-                           [](mzSlice* slice) {
-                               return (slice->ionCount == -1.0f);
-                           }),
-                 slices.end());
+    vector<size_t> indexesToErase;
+    for (size_t i = 0; i < slices.size(); ++i) {
+        auto slice = slices[i];
+        if (slice->ionCount == -1.0f) {
+            delete slice;
+            indexesToErase.push_back(i);
+        }
+    }
+    mzUtils::eraseIndexes(slices, indexesToErase);
 }
 
 void MassSlicer::_mergeSlices(const MassCutoff* massCutoff,

--- a/src/core/libmaven/peakdetector.cpp
+++ b/src/core/libmaven/peakdetector.cpp
@@ -1082,6 +1082,7 @@ void PeakDetector::detectIsotopesForParent(PeakGroup& parentGroup,
                                                    _mavenParameters,
                                                    _mavenParameters->clsf,
                                                    true);
+            delete_all(eics);
             if (isotopeGroup->peakCount() == 0)
                 continue;
 

--- a/src/core/libmaven/peakdetector.cpp
+++ b/src/core/libmaven/peakdetector.cpp
@@ -571,7 +571,7 @@ void PeakDetector::processSlices(vector<mzSlice*>& slices,
             return;
 
         _mavenParameters->allgroups.insert(
-            _mavenParameters->allgroups.begin(),
+            _mavenParameters->allgroups.end(),
             make_move_iterator(peakgroups.begin()),
             make_move_iterator(peakgroups.end()));
     };

--- a/src/gui/mzroll/backgroundopsthread.cpp
+++ b/src/gui/mzroll/backgroundopsthread.cpp
@@ -346,6 +346,7 @@ void BackgroundOpsThread::updateGroups(QList<shared_ptr<PeakGroup>>& groups,
         }
         group->updateQuality();
         group->groupStatistics();
+        delete_all(eics);
     };
 
     for(auto group : groups) {

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -2367,8 +2367,9 @@ PeakTableDockWidget::~PeakTableDockWidget() {
   delete toolBar;
 }
 
-void PeakTableDockWidget::destroy() {
-
+void PeakTableDockWidget::destroy()
+{
+  TableDockWidget::deleteAll(false);
   cleanUp();
   deleteLater();
   _mainwindow->removePeaksTable(this);
@@ -2377,8 +2378,11 @@ void PeakTableDockWidget::destroy() {
 void PeakTableDockWidget::deleteAll()
 {
   auto allDeleted = TableDockWidget::deleteAll();
-  if (allDeleted)
-    destroy();
+  if (allDeleted) {
+    cleanUp();
+    deleteLater();
+    _mainwindow->removePeaksTable(this);
+  }
 }
 
 void PeakTableDockWidget::cleanUp()


### PR DESCRIPTION
Various small fixes (with decent saves) to memory consumption during untargeted (and somewhat DB search) detections.

@sunil20dhakad This should resolve most of your concerns. @sakshikukreja14 will share the `ftr_peak_ml` branch rebased on this, once we merge it.