### PR TITLE
Fix VIB issues

### DIFF
--- a/src/gui/mzroll/forms/peakeditor.ui
+++ b/src/gui/mzroll/forms/peakeditor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>760</width>
+    <width>776</width>
     <height>580</height>
    </rect>
   </property>
@@ -65,7 +65,7 @@
                  </sizepolicy>
                 </property>
                 <property name="text">
-                 <string>Drop top [X] percent intensities</string>
+                 <string>Allow top [x] percent intensities as part of the real signal</string>
                 </property>
                </widget>
               </item>

--- a/src/gui/mzroll/gallerywidget.cpp
+++ b/src/gui/mzroll/gallerywidget.cpp
@@ -652,14 +652,15 @@ void GalleryWidget::mouseMoveEvent(QMouseEvent* event)
     auto mousePos = event->pos();
 
     if (_markerBeingDragged == nullptr) {
+        QGraphicsView::mouseMoveEvent(event);
         if (_rightMarker != nullptr
             && _markerNear(mousePos) == _rightMarker) {
-            setCursor(Qt::SizeHorCursor);
+            viewport()->setCursor(Qt::SizeHorCursor);
         } else if (_leftMarker != nullptr
                    && _markerNear(mousePos) == _leftMarker) {
-            setCursor(Qt::SizeHorCursor);
+            viewport()->setCursor(Qt::SizeHorCursor);
         } else {
-            setCursor(Qt::ArrowCursor);
+            viewport()->setCursor(Qt::ArrowCursor);
         }
         return;
     }

--- a/src/gui/mzroll/gallerywidget.h
+++ b/src/gui/mzroll/gallerywidget.h
@@ -1,6 +1,8 @@
 #ifndef GALLERYWIDGET_H
 #define GALLERYWIDGET_H
 
+#include <QGraphicsProxyWidget>
+
 #include "stable.h"
 
 class EIC;
@@ -45,6 +47,10 @@ private:
     map<EIC*, pair<float, float>> _peakBounds;
     QGraphicsLineItem* _leftMarker;
     QGraphicsLineItem* _rightMarker;
+    QGraphicsProxyWidget* _leftProxyEdit;
+    QGraphicsProxyWidget* _rightProxyEdit;
+    QLineEdit* _leftEdit;
+    QLineEdit* _rightEdit;
     QGraphicsLineItem* _markerBeingDragged;
     bool _scaleForHighestPeak;
 
@@ -53,15 +59,23 @@ private:
     float _rtBuffer;
 
     void _drawBoundaryMarkers();
+    void _drawBoundaryEditables(float rt1,
+                                float x1,
+                                float rt2,
+                                float x2,
+                                bool allPeaksEmpty);
     QGraphicsLineItem* _markerNear(QPointF pos);
     void _refillVisiblePlots(float x1, float x2);
     void _scaleVisibleYAxis();
     void _fillPlotData();
     bool _visibleItemsHavePeakData();
+    float _closestRealRt(float approximateRt, EIC* eic);
+    float _convertXCoordinateToRt(float x, EIC* eic);
 
 private slots:
     void _createNewPeak();
     void _deleteCurrentPeak();
+    void _setRtRegionForVisiblePeaks(float minRt, float maxRt);
 
 protected:
     bool recursionCheck;

--- a/src/gui/mzroll/peakeditor.cpp
+++ b/src/gui/mzroll/peakeditor.cpp
@@ -201,7 +201,6 @@ void PeakEditor::_setRtRangeAndValues()
 void PeakEditor::_setSyncRtCheckbox()
 {
     if ((_group->childIsotopeCount() == 0 && !_group->isIsotope())
-        || (_group->parent != nullptr && _group->parent->isGhost())
         || _group->isAdduct()) {
         ui->syncRtCheckBox->setChecked(false);
         ui->syncRtCheckBox->setEnabled(false);
@@ -213,7 +212,7 @@ void PeakEditor::_setSyncRtCheckbox()
     MavenParameters* parameters = _group->parameters().get();
     if (parameters->linkIsotopeRtRange
         && (_group->childIsotopeCount() > 0
-            || _group->tagString == "C12 PARENT")) {
+            || _group->tagString == C12_PARENT_LABEL)) {
         ui->syncRtCheckBox->setChecked(true);
     } else {
         ui->syncRtCheckBox->setChecked(false);
@@ -328,11 +327,13 @@ void PeakEditor::_applyEdits()
             return;
         }
 
-        auto eics = getEicsForGroup(parentGroup);
-        editGroup(parentGroup, eics, (parentGroup != _group.get()));
-        delete_all(eics);
+        if (!parentGroup->isGhost()) {
+            auto eics = getEicsForGroup(parentGroup);
+            editGroup(parentGroup, eics, (parentGroup != _group.get()));
+            delete_all(eics);
+        }
         for (auto child : parentGroup->childIsotopes()) {
-            eics = getEicsForGroup(child.get());
+            auto eics = getEicsForGroup(child.get());
             editGroup(child.get(), eics, (child != _group));
             delete_all(eics);
         }

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -1109,6 +1109,111 @@ void TableDockWidget::exportSpectralLib()
     }
 }
 
+void TableDockWidget::markDuplicatesAsBad() {
+    QStringList selectionItems;
+    selectionItems
+        << "Parent compounds only"
+        << "Parent compounds and their isotopes"
+        << "Parent compounds and their adducts"
+        << "All compounds";
+
+    bool ok;
+    QString item =
+        QInputDialog::getItem(this,
+                              "Mark duplicates as bad",
+                              "This operation will automatically mark "
+                              "duplicates of all compounds as \"bad\"\n"
+                              "peak-groups. The original for each "
+                              "compound is decided from rows with the\n"
+                              "same name but with the highest rank among "
+                              "them. The rest of them are regarded\n"
+                              "as duplicates.\n\n"
+                              "If isotopes or adducts are also considered "
+                              "then they will be compared with\n"
+                              "their siblings only (i.e., along with the "
+                              "name they must share the same parent).",
+                              selectionItems,
+                              0,
+                              false,
+                              &ok);
+
+    // lambda: given a map of vectors and a peak-group, adds the peak-group to
+    // the vector mapped against its name
+    auto indexGroup = [](map<string, vector<shared_ptr<PeakGroup>>>& duplicates,
+                         const shared_ptr<PeakGroup>& group) {
+        auto name = group->getName();
+        if (duplicates.count(name) == 0) {
+            duplicates[name] = {};
+        }
+        duplicates[name].push_back(group);
+    };
+
+    // lambda: given a map of vector of peak-groups, within each vector, mark
+    // all but the best peak-group as a "bad" one
+    auto markAllButTheBest =
+        [](map<string, vector<shared_ptr<PeakGroup>>>& duplicates) {
+            for (auto& elem : duplicates) {
+                auto& groups = elem.second;
+                if (groups.size() <= 1)
+                    continue;
+
+                sort(begin(groups),
+                     end(groups),
+                     [](shared_ptr<PeakGroup>& a, shared_ptr<PeakGroup>& b) {
+                         return a->groupRank < b->groupRank;
+                     });
+                for (size_t i = 1; i < groups.size(); ++i) {
+                    auto& group = groups[i];
+                    group->setLabel('b');
+                }
+            }
+        };
+
+    if (ok && !item.isEmpty()) {
+        map<string, vector<shared_ptr<PeakGroup>>> duplicateParents;
+        if (item == selectionItems.at(0)) {
+            // only parent items
+            for (auto& group : _topLevelGroups)
+                indexGroup(duplicateParents, group);
+        } else if (item == selectionItems.at(1)) {
+            // parent items and their child isotopes
+            for (auto& group : _topLevelGroups) {
+                indexGroup(duplicateParents, group);
+
+                map<string, vector<shared_ptr<PeakGroup>>> duplicateChildren;
+                for (auto& child : group->childIsotopes())
+                    indexGroup(duplicateChildren, child);
+                markAllButTheBest(duplicateChildren);
+            }
+        } else if (item == selectionItems.at(2)) {
+            // parent items and their child adducts
+            for (auto& group : _topLevelGroups) {
+                indexGroup(duplicateParents, group);
+
+                map<string, vector<shared_ptr<PeakGroup>>> duplicateChildren;
+                for (auto& child : group->childAdducts())
+                    indexGroup(duplicateChildren, child);
+                markAllButTheBest(duplicateChildren);
+            }
+        } else if (item == selectionItems.at(3)) {
+            // parent items and their child isotopes as well adducts
+            for (auto& group : _topLevelGroups) {
+                indexGroup(duplicateParents, group);
+
+                map<string, vector<shared_ptr<PeakGroup>>> duplicateChildren;
+                for (auto& child : group->childIsotopes())
+                    indexGroup(duplicateChildren, child);
+                for (auto& child : group->childAdducts())
+                    indexGroup(duplicateChildren, child);
+                markAllButTheBest(duplicateChildren);
+            }
+        }
+
+        markAllButTheBest(duplicateParents);
+        updateTable();
+    }
+}
+
 vector<EIC *> TableDockWidget::getEICs(float rtmin,
                                        float rtmax,
                                        PeakGroup &grp) {
@@ -1785,8 +1890,14 @@ void TableDockWidget::contextMenuEvent(QContextMenuEvent *event) {
           this,
           &TableDockWidget::showIntegrationSettings);
 
-  QAction *z4 = menu.addAction("Delete all groups from this table");
-  connect(z4, SIGNAL(triggered()), SLOT(deleteAll()));
+  QAction *z4 = menu.addAction("Mark duplicates as bad");
+  connect(z4,
+          &QAction::triggered,
+          this,
+          &TableDockWidget::markDuplicatesAsBad);
+
+  QAction *z5 = menu.addAction("Delete all groups from this table");
+  connect(z5, SIGNAL(triggered()), SLOT(deleteAll()));
 
   if (treeWidget->selectedItems().empty()) {
     // disable actions not relevant when nothing is selected

--- a/src/gui/mzroll/tabledockwidget.cpp
+++ b/src/gui/mzroll/tabledockwidget.cpp
@@ -493,8 +493,6 @@ void TableDockWidget::addRow(RowData& indexData, QTreeWidgetItem* root)
 
   if (group == nullptr)
     return;
-  if (group->meanMz <= 0 && !group->isGhost())
-    return;
 
   NumericTreeWidgetItem *item = new NumericTreeWidgetItem(root, 0);
   if (root == nullptr) {

--- a/src/gui/mzroll/tabledockwidget.h
+++ b/src/gui/mzroll/tabledockwidget.h
@@ -236,6 +236,8 @@ public slots:
   void exportJson();
   void exportSpectralLib();
 
+  void markDuplicatesAsBad();
+
   void UploadPeakBatchToCloud();
   void showSelectedGroup();
   void setGroupLabel(char label);


### PR DESCRIPTION
The follow changes were made:
* Allow RT range sync for siblings-only meta-groups - isotopes under ghost parents were not being synced when instructed.
* Allow auto-marking of duplicates as bad - allows the user to review duplicates of a given compound before exporting.
* Allow zeroed peak groups to be added to table - helpful when loading an emDB that contains peak-groups with no peaks.
* Show and allow setting explicit RT bounds in peak-editor - two editables will now show the current lower and upper range.

Note: this branch may get some minor changes as per feedback. Not ready for review yet.