### PR TITLE
[Fix] Incorrect SRM chromatograms for close pairs

### DIFF
--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -1282,6 +1282,7 @@ bool EIC::makeEICSlice(mzSample *sample, float mzmin, float mzmax, float rtmin, 
         {
             double sumMz = 0.0;
             double sumIntensity = 0.0;
+            vector<float> mzValues;
             for (unsigned int scanIdx = lb; scanIdx < scan->nobs(); scanIdx++)
             {
                 if (scan->mz[scanIdx] < mzmin)
@@ -1292,10 +1293,16 @@ bool EIC::makeEICSlice(mzSample *sample, float mzmin, float mzmax, float rtmin, 
                 double intensity = static_cast<double>(scan->intensity[scanIdx]);
                 sumIntensity += intensity;
                 sumMz += static_cast<double>(scan->mz[scanIdx]) * intensity;
+                mzValues.push_back(scan->mz[scanIdx]);
             }
             if (sumIntensity != 0.0) {
                 eicMz = static_cast<float>(sumMz / sumIntensity);
                 eicIntensity = static_cast<float>(sumIntensity);
+            } else {
+                eicMz = accumulate(begin(mzValues),
+                                   end(mzValues),
+                                   0.0) / mzValues.size();
+                eicIntensity = 0.0f;
             }
             break;
         }

--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -1248,7 +1248,7 @@ bool EIC::makeEICSlice(mzSample *sample, float mzmin, float mzmax, float rtmin, 
             break;
 
         eicMz = 0;
-        eicIntensity = 0;
+        eicIntensity = -0.01f;
 
         //binary search
         mzItr = lower_bound(scan->mz.begin(), scan->mz.end(), mzmin);
@@ -1325,6 +1325,11 @@ bool EIC::makeEICSlice(mzSample *sample, float mzmin, float mzmax, float rtmin, 
             break;
         }
         }
+
+        // Have to do this since we started with a default negative value,
+        // which itself makes sure that zero observations are not ignored.
+        if (eicIntensity < 0.0f)
+            eicIntensity = 0.0f;
 
         this->scannum.push_back(scanNum);
         this->rt.push_back(scan->rt);

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1200,7 +1200,7 @@ EIC* mzSample::getEIC(float precursorMz,
         // compatibility with both the formats.
 
         float eicMz = 0;
-        float eicIntensity = 0;
+        float eicIntensity = -0.01;
         string eicFilterline = "";
 
         switch ((EIC::EicType)eicType) {
@@ -1273,6 +1273,11 @@ EIC* mzSample::getEIC(float precursorMz,
             e = newEic();
             filterlineEicMap[eicFilterline] = e;
         }
+
+        // Have to do this since we started with a default negative value,
+        // which itself makes sure that zero observations are not ignored.
+        if (eicIntensity < 0.0f)
+            eicIntensity = 0.0f;
 
         // if rt is already present save the higher intensity for that rt
         // this can happen when there are multiple product m/z for the same
@@ -1398,7 +1403,7 @@ EIC* mzSample::getEIC(string srm, int eicType)
         for (unsigned int i = 0; i < srmscans.size(); i++) {
             Scan* scan = scans[srmscans[i]];
             float eicMz = 0;
-            float eicIntensity = 0;
+            float eicIntensity = -0.01f;
 
             switch ((EIC::EicType)eicType) {
             case EIC::MAX: {
@@ -1445,6 +1450,11 @@ EIC* mzSample::getEIC(string srm, int eicType)
                 break;
             }
             }
+
+            // Have to do this since we started with a default negative value,
+            // which itself makes sure that zero observations are not ignored.
+            if (eicIntensity < 0.0f)
+                eicIntensity = 0.0f;
 
             e->scannum.push_back(scan->scannum);
             e->rt.push_back(scan->rt);

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1265,10 +1265,6 @@ EIC* mzSample::getEIC(float precursorMz,
             e = newEic();
             filterlineEicMap[eicFilterline] = e;
         }
-        precursorDeltas.push_back(abs(scan->precursorMz - precursorMz));
-        filterlinePrecursorDeltas[eicFilterline] = precursorDeltas;
-        productDeltas.push_back(abs(eicMz - productMz));
-        filterlineProductDeltas[eicFilterline] = productDeltas;
 
         // if rt is already present save the higher intensity for that rt
         // this can happen when there are multiple product m/z for the same
@@ -1296,6 +1292,11 @@ EIC* mzSample::getEIC(float precursorMz,
             e->rtAtMaxIntensity = scan->rt;
             e->mzAtMaxIntensity = eicMz;
         }
+
+        precursorDeltas.push_back(abs(scan->precursorMz - precursorMz));
+        filterlinePrecursorDeltas[eicFilterline] = precursorDeltas;
+        productDeltas.push_back(abs(eicMz - productMz));
+        filterlineProductDeltas[eicFilterline] = productDeltas;
     }
 
     // lambda: make some adjustments to the generated EIC before returning
@@ -1329,10 +1330,12 @@ EIC* mzSample::getEIC(float precursorMz,
     for (auto& elem : filterlineEicMap) {
         string filterline = elem.first;
         EIC* eicAlt = elem.second;
+        if (eicAlt->size() == 0 || eicAlt->maxIntensity == 0.0f)
+            continue;
+
         auto precursorDeltas = filterlinePrecursorDeltas.at(filterline);
         auto productDeltas = filterlineProductDeltas.at(filterline);
-        if (eicAlt->size() > 0
-            && precursorDeltas.size() > 0
+        if (precursorDeltas.size() > 0
             && productDeltas.size() > 0) {
             auto meanPrecursorDelta = accumulate(begin(precursorDeltas),
                                                  end(precursorDeltas),

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -1223,6 +1223,7 @@ EIC* mzSample::getEIC(float precursorMz,
         case EIC::SUM: {
             double sumMz = 0.0;
             double sumIntensity = 0.0;
+            vector<float> mzValues;
             for (unsigned int k = 0; k < scan->nobs(); k++) {
                 if (productMz != 0.0f && abs(scan->mz[k] - productMz) > amuQ3)
                     continue;
@@ -1230,10 +1231,17 @@ EIC* mzSample::getEIC(float precursorMz,
                 double intensity = static_cast<double>(scan->intensity[k]);
                 sumIntensity += intensity;
                 sumMz += static_cast<double>(scan->mz[k]) * intensity;
+                mzValues.push_back(scan->mz[k]);
             }
             if (sumIntensity != 0.0) {
                 eicMz = static_cast<float>(sumMz / sumIntensity);
                 eicIntensity = static_cast<float>(sumIntensity);
+                eicFilterline = scan->filterLine;
+            } else {
+                eicMz = accumulate(begin(mzValues),
+                                   end(mzValues),
+                                   0.0) / mzValues.size();
+                eicIntensity = 0.0f;
                 eicFilterline = scan->filterLine;
             }
             break;
@@ -1408,14 +1416,21 @@ EIC* mzSample::getEIC(string srm, int eicType)
             case EIC::SUM: {
                 double sumMz = 0.0;
                 double sumIntensity = 0.0;
+                vector<float> mzValues;
                 for (unsigned int k = 0; k < scan->nobs(); k++) {
                     double intensity = static_cast<double>(scan->intensity[k]);
                     sumIntensity += intensity;
                     sumMz += static_cast<double>(scan->mz[k]) * intensity;
+                    mzValues.push_back(scan->mz[k]);
                 }
                 if (sumIntensity != 0.0) {
                     eicMz = static_cast<float>(sumMz / sumIntensity);
                     eicIntensity = static_cast<float>(sumIntensity);
+                } else {
+                    eicMz = accumulate(begin(mzValues),
+                                       end(mzValues),
+                                       0.0) / mzValues.size();
+                    eicIntensity = 0.0f;
                 }
                 break;
             }


### PR DESCRIPTION
When two SRM chromatgrams contain almost the exact same values for precursor/product m/z pair (i.e., too close to be distinguished using the existing Q1/Q3 accuracy), then the chromatogram returned for either pair would always be the one whose first RT observation was earlier. This was because, the filterline of the first scan found to match the queried precursor/product pair was imposed on all subsequent observations for the chromatogram (of that query). This has been fixed by constructing chromatograms for all pairs in the given range and then selecting the best among them.