### PR TITLE
[Fix] UPenn issues

### DIFF
--- a/src/gui/mzroll/forms/peakeditor.ui
+++ b/src/gui/mzroll/forms/peakeditor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>776</width>
+    <width>821</width>
     <height>580</height>
    </rect>
   </property>
@@ -18,7 +18,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,0,0">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1,0">
      <item>
       <widget class="QTreeWidget" name="sampleList">
        <property name="headerHidden">
@@ -33,6 +33,16 @@
      </item>
      <item>
       <layout class="QVBoxLayout" name="graphicsLayout"/>
+     </item>
+     <item>
+      <widget class="QSlider" name="yZoomSlider">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Moving this slider up will reduce the upper-limit of Y-axis in the plot. By default, this is set to contain the highest peaks in the visible chromatogram.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/gui/mzroll/forms/peakeditor.ui
+++ b/src/gui/mzroll/forms/peakeditor.ui
@@ -21,9 +21,15 @@
     <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1,0">
      <item>
       <widget class="QTreeWidget" name="sampleList">
+       <property name="textElideMode">
+        <enum>Qt::ElideNone</enum>
+       </property>
        <property name="headerHidden">
         <bool>true</bool>
        </property>
+       <attribute name="headerStretchLastSection">
+        <bool>false</bool>
+       </attribute>
        <column>
         <property name="text">
          <string notr="true">1</string>

--- a/src/gui/mzroll/gallerywidget.cpp
+++ b/src/gui/mzroll/gallerywidget.cpp
@@ -26,6 +26,8 @@ GalleryWidget::GalleryWidget(QWidget* parent)
     _maxRt = 0.0f;
     _rtBuffer = 0.5f;
 
+    _yZoomScale = 1.0f;
+
     _boxW = 300;
     _boxH = 200;
     _axesOffset = 18;
@@ -79,6 +81,13 @@ void GalleryWidget::setRtBounds(float minRt, float maxRt)
 {
     _minRt = minRt;
     _maxRt = maxRt;
+    _fillPlotData();
+    replot();
+}
+
+void GalleryWidget::setYZoomScale(float yZoomScale)
+{
+    _yZoomScale = yZoomScale;
     _fillPlotData();
     replot();
 }
@@ -451,6 +460,8 @@ void GalleryWidget::_scaleVisibleYAxis()
             maxIntensity = max(maxIntensity, plotIntensities.second);
         }
     }
+
+    maxIntensity = _yZoomScale * maxIntensity;
 
     for (int index : _indexesOfVisibleItems) {
         auto plot = _plotItems.at(index);

--- a/src/gui/mzroll/gallerywidget.h
+++ b/src/gui/mzroll/gallerywidget.h
@@ -23,6 +23,7 @@ public:
     pair<float, float> rtBounds();
     void setRtBounds(float minRt, float maxRt);
     float rtBuffer() { return _rtBuffer; }
+    void setYZoomScale(float yZoomScale);
 
 signals:
     void peakRegionSet(mzSample*, float, float);
@@ -57,6 +58,8 @@ private:
     float _minRt;
     float _maxRt;
     float _rtBuffer;
+
+    float _yZoomScale;
 
     void _drawBoundaryMarkers();
     void _drawBoundaryEditables(float rt1,

--- a/src/gui/mzroll/peakeditor.cpp
+++ b/src/gui/mzroll/peakeditor.cpp
@@ -21,6 +21,7 @@ PeakEditor::PeakEditor(MainWindow *parent,
 {
     ui->setupUi(this);
     ui->sampleList->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    ui->sampleList->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     _gallery = new GalleryWidget(this);
     ui->graphicsLayout->addWidget(_gallery);
 

--- a/src/gui/mzroll/peakeditor.cpp
+++ b/src/gui/mzroll/peakeditor.cpp
@@ -110,6 +110,13 @@ PeakEditor::PeakEditor(MainWindow *parent,
             &QCheckBox::toggled,
             _gallery,
             &GalleryWidget::setScaleForHighestPeak);
+    connect(ui->yZoomSlider,
+            &QSlider::valueChanged,
+            [this](int value) {
+                // The `value` is a number range [0, 99]
+                float fractionalZoom = static_cast<float>(value) / 100.0f;
+                _gallery->setYZoomScale(1.0 - fractionalZoom);
+            });
 }
 
 PeakEditor::~PeakEditor()


### PR DESCRIPTION
Two changes included:
* Allow scaling peak-editor plot along Y-axis (using a vertical slider beside the plot).
* Sample-list in peak-editor not scrolling horizontally, if the names of the samples are too long.