### PR TITLE
[UI] Show error message when MS2 samples are aligned

### DIFF
--- a/src/gui/mzroll/mainwindow.cpp
+++ b/src/gui/mzroll/mainwindow.cpp
@@ -1174,9 +1174,15 @@ void MainWindow::saveProject(bool explicitSave)
 
 void MainWindow::showAlignmentErrorDialog(QString errorMessage)
 {
-    QMessageBox alignmentError;
-    alignmentError.setText(errorMessage);
-    alignmentError.open();
+    QMessageBox *alignmentError = new QMessageBox(this);
+    
+    alignmentError->setText(errorMessage);
+    alignmentError->setIcon(QMessageBox::Icon::Warning);
+
+    auto yesButton = alignmentError->addButton(tr("Ok"),
+                                QMessageBox::AcceptRole);
+    alignmentError->exec();
+    QCoreApplication::processEvents();
 }
 
 QDockWidget* MainWindow::createDockWidget(QString title, QWidget* w) {


### PR DESCRIPTION
When a user tried to align MS2 sample, El-MAVEN crashed. To avoid El-MAVEN to crash, added an error message when MS2 samples are aligned.