### PR TITLE
Fix compound name postfix

### DIFF
--- a/src/core/libmaven/mzUtils.cpp
+++ b/src/core/libmaven/mzUtils.cpp
@@ -1336,7 +1336,7 @@ TEST_SUITE("Testing mzUtils functions")
 
     TEST_CASE("Testing fileExists")
     {
-        REQUIRE((mzUtils::fileExists("testCharge.xml")) == true);
+        REQUIRE((mzUtils::fileExists("build.pro")) == true);
         REQUIRE((mzUtils::fileExists("hello.cpp")) == false);
     }
 

--- a/src/projectDB/projectdatabase.cpp
+++ b/src/projectDB/projectdatabase.cpp
@@ -1390,7 +1390,7 @@ vector<Compound*> ProjectDatabase::loadCompounds(const string databaseName)
                 compound->setMz(mz);
         } else {
             compound->setMz(static_cast<float>(
-                mcalc.computeMass(formula, charge)));
+                mcalc.computeNeutralMass(formula)));
         }
 
         compound->setPrecursorMz ( compoundsQuery->floatValue("precursor_mz"));


### PR DESCRIPTION
This PR is to fix the postfix that is appended to the compound's name whenever a saved project is loaded to El-MAVEN.