### PR TITLE
Fix grouping and reduce RAM usage 

### DIFF
--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -468,7 +468,7 @@ void EIC::reduceToRtRange(float minRt, float maxRt)
             delete[] oldSpline;
         }
         rtmin = max(minRt, rtmin);
-		rtmax = min(maxRt, rtmax);
+	rtmax = min(maxRt, rtmax);
     }
 }
 

--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -753,7 +753,7 @@ void EIC::getPeakDetails(Peak &peak)
     int n = 1;
     peak.peakAreaTop = intensity[peak.pos];
     peak.peakAreaTopCorrected = intensity[peak.pos] - baseline[peak.pos];
-    if (peak.pos - 1 < N)
+    if (peak.pos > 0)
     {
         peak.peakAreaTop += intensity[peak.pos - 1];
         peak.peakAreaTopCorrected += intensity[peak.pos - 1] - baseline[peak.pos - 1];

--- a/src/core/libmaven/EIC.cpp
+++ b/src/core/libmaven/EIC.cpp
@@ -467,6 +467,8 @@ void EIC::reduceToRtRange(float minRt, float maxRt)
             copy(oldSpline + start, oldSpline + stop, spline);
             delete[] oldSpline;
         }
+        rtmin = max(minRt, rtmin);
+		rtmax = min(maxRt, rtmax);
     }
 }
 

--- a/src/core/libmaven/mzSample.cpp
+++ b/src/core/libmaven/mzSample.cpp
@@ -944,6 +944,8 @@ void mzSample::populateMzAndIntensity(const vector<float>& mzint, Scan* _scan)
 
     _scan->mz.resize(count);
     _scan->intensity.resize(count);
+    _scan->mz.shrink_to_fit();
+    _scan->intensity.shrink_to_fit();
 }
 
 void mzSample::populateFilterline(const string& filterLine, Scan* _scan)


### PR DESCRIPTION
Copied from an email received from @AndrewRosko:
I have indeed found a small bug (2 missing lines) in the EIC pulling code that causes incorrect grouping of peaks, especially when searching by retention time as well as m/z. 

The only other change I have made so far is another 2-line change in the mzSample file loader that trims some zeros off the Scan arrays, to cut the RAM usage by ~50%. On our system, despite still loading the entirety of the intensity data into memory, this makes a big difference in file load time. 