### PR TITLE
Fix: misplaced string header causes failure during compilation issue #1415

### DIFF
--- a/3rdparty/ErrorHandling/errorcodes.cpp
+++ b/3rdparty/ErrorHandling/errorcodes.cpp
@@ -1,5 +1,5 @@
 #include "errorcodes.h"
-#include <string>
+
 
 const ErrorMsg* ErrorMsg::errMsg = nullptr;
 

--- a/3rdparty/ErrorHandling/errorcodes.h
+++ b/3rdparty/ErrorHandling/errorcodes.h
@@ -1,6 +1,7 @@
 #ifndef ERRORCODES_H
 #define ERRORCODES_H
 
+#include <string>
 #include <map>
 
 //singleton


### PR DESCRIPTION
This commit is a simple fix on issue #1415 

As mentioned in issue #1415, the misplaced string header causes a fatal error during compilation.

To Fix this error, the string header needs to be included in the errorcodes.h instead of errorcodes.cpp

Issue #1415
